### PR TITLE
Resolve merge conflict for pre_planning_workflow path option

### DIFF
--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -503,7 +503,12 @@ def validate_preplan_all(data) -> Tuple[bool, str]:
         errors.append(f"Planner compatibility check exception: {e}")
     return (len(errors) == 0), "\n".join(errors)
 
-def pre_planning_workflow(router_agent, initial_request: str, context: Dict[str, Any] = None) -> Tuple[bool, Dict[str, Any]]:
+def pre_planning_workflow(
+    router_agent,
+    initial_request: str,
+    context: Dict[str, Any] = None,
+    preplan_path: str = "preplan.json",
+) -> Tuple[bool, Dict[str, Any]]:
     """
     Canonical pre-planning workflow: user request, LLM (question or preplan JSON), user clarification loop, then extensive JSON validation.
     Now includes retry on JSON validation failure, appending error feedback to the prompt and always requesting the full JSON schema.
@@ -547,7 +552,6 @@ def pre_planning_workflow(router_agent, initial_request: str, context: Dict[str,
                 last_error_msg = all_errors
                 continue  # Retry LLM with combined error feedback
             # --- Write preplan.json for human review ---
-            preplan_path = "preplan.json"
             try:
                 with open(preplan_path, "w", encoding="utf-8") as f:
                     json.dump(data, f, indent=2, ensure_ascii=False)

--- a/tests/test_pre_planner_json_enforced.py
+++ b/tests/test_pre_planner_json_enforced.py
@@ -287,8 +287,8 @@ class TestPrePlannerJsonEnforced:
     @patch('agent_s3.pre_planner_json_enforced.get_json_system_prompt')
     @patch('agent_s3.pre_planner_json_enforced.get_json_user_prompt')
     @patch('agent_s3.pre_planner_json_enforced.get_openrouter_json_params')
-    def test_call_pre_planner_with_enforced_json_success(self, mock_params, mock_user_prompt, 
-                                                        mock_system_prompt, mock_process):
+    def test_call_pre_planner_with_enforced_json_success(self, mock_params, mock_user_prompt,
+                                                        mock_system_prompt, mock_process, tmp_path):
         """Test successful call to pre-planner with enforced JSON."""
         # Setup mocks
         mock_system_prompt.return_value = "System prompt"
@@ -304,7 +304,12 @@ class TestPrePlannerJsonEnforced:
         mock_agent.call_llm_by_role.return_value = "{}"
         
         # Call the function
-        success, data = pre_planning_workflow(mock_agent, "Test request")
+        preplan_file = tmp_path / "preplan.json"
+        success, data = pre_planning_workflow(
+            mock_agent,
+            "Test request",
+            preplan_path=str(preplan_file),
+        )
         
         # Verify results
         assert success is True
@@ -315,8 +320,8 @@ class TestPrePlannerJsonEnforced:
     @patch('agent_s3.pre_planner_json_enforced.get_json_system_prompt')
     @patch('agent_s3.pre_planner_json_enforced.get_json_user_prompt')
     @patch('agent_s3.pre_planner_json_enforced.get_openrouter_json_params')
-    def test_call_pre_planner_with_enforced_json_retry(self, mock_params, mock_user_prompt, 
-                                                       mock_system_prompt, mock_process):
+    def test_call_pre_planner_with_enforced_json_retry(self, mock_params, mock_user_prompt,
+                                                       mock_system_prompt, mock_process, tmp_path):
         """Test retry mechanism for pre-planner with enforced JSON."""
         # Setup mocks
         mock_system_prompt.return_value = "System prompt"
@@ -332,7 +337,12 @@ class TestPrePlannerJsonEnforced:
         mock_agent.call_llm_by_role.return_value = "{}"
         
         # Call the function
-        success, data = pre_planning_workflow(mock_agent, "Test request")
+        preplan_file = tmp_path / "preplan.json"
+        success, data = pre_planning_workflow(
+            mock_agent,
+            "Test request",
+            preplan_path=str(preplan_file),
+        )
         
         # Verify results
         assert success is True
@@ -344,9 +354,9 @@ class TestPrePlannerJsonEnforced:
     @patch('agent_s3.pre_planner_json_enforced.get_json_user_prompt')
     @patch('agent_s3.pre_planner_json_enforced.get_openrouter_json_params')
     @patch('agent_s3.pre_planner_json_enforced.create_fallback_json')
-    def test_call_pre_planner_with_enforced_json_fallback(self, mock_fallback, mock_params, 
-                                                          mock_user_prompt, mock_system_prompt, 
-                                                          mock_process):
+    def test_call_pre_planner_with_enforced_json_fallback(self, mock_fallback, mock_params,
+                                                          mock_user_prompt, mock_system_prompt,
+                                                          mock_process, tmp_path):
         """Test fallback mechanism for pre-planner with enforced JSON."""
         # Setup mocks
         mock_system_prompt.return_value = "System prompt"
@@ -365,7 +375,12 @@ class TestPrePlannerJsonEnforced:
         
         # Call the function and expect an exception
         with pytest.raises(JSONValidationError):
-            pre_planning_workflow(mock_agent, "Test request")
+            preplan_file = tmp_path / "preplan.json"
+            pre_planning_workflow(
+                mock_agent,
+                "Test request",
+                preplan_path=str(preplan_file),
+            )
         
         # Verify results
         assert mock_agent.call_llm_by_role.call_count == 2  # Both attempts fail


### PR DESCRIPTION
## Summary
- allow specifying the path for `preplan.json` in `pre_planning_workflow`
- update pre-planner tests to use a temporary file path when calling the workflow

## Testing
- `ruff check agent_s3/pre_planner_json_enforced.py tests/test_pre_planner_json_enforced.py --quiet` *(fails: F401, F541, E722 etc.)*
