### PR TITLE
Add unit tests for core utilities

### DIFF
--- a/tests/test_json_editor_bridge.py
+++ b/tests/test_json_editor_bridge.py
@@ -1,0 +1,60 @@
+import unittest
+import sys
+import types
+from pathlib import Path
+
+# Stub out agent_s3 package to avoid importing heavy dependencies via __init__.
+if 'agent_s3' not in sys.modules:
+    pkg = types.ModuleType('agent_s3')
+    pkg.__path__ = [str(Path(__file__).resolve().parents[1] / 'agent_s3')]
+    sys.modules['agent_s3'] = pkg
+
+# Stub communication package to avoid importing its __init__ which requires
+# optional dependencies like jsonschema.
+comm_pkg = types.ModuleType('agent_s3.communication')
+comm_pkg.__path__ = [str(Path(__file__).resolve().parents[1] / 'agent_s3' / 'communication')]
+sys.modules.setdefault('agent_s3.communication', comm_pkg)
+
+# Provide a minimal vscode_bridge module to satisfy imports inside json_editor_bridge
+vc_stub = types.ModuleType('agent_s3.communication.vscode_bridge')
+class VSCodeBridge:
+    pass
+vc_stub.VSCodeBridge = VSCodeBridge
+sys.modules['agent_s3.communication.vscode_bridge'] = vc_stub
+
+# Stub message_protocol to avoid jsonschema dependency
+mp_stub = types.ModuleType('agent_s3.communication.message_protocol')
+class Message: ...
+class MessageType: ...
+class MessageBus: ...
+class OutputCategory: ...
+mp_stub.Message = Message
+mp_stub.MessageType = MessageType
+mp_stub.MessageBus = MessageBus
+mp_stub.OutputCategory = OutputCategory
+sys.modules['agent_s3.communication.message_protocol'] = mp_stub
+
+from agent_s3.communication.json_editor_bridge import JSONPath
+
+
+class TestJSONPath(unittest.TestCase):
+    """Tests for JSONPath helper methods."""
+
+    def test_parse_path(self):
+        path = "feature_groups[0].features[1].name"
+        components = JSONPath.parse_path(path)
+        self.assertEqual(components, ["feature_groups", 0, "features", 1, "name"])
+
+    def test_get_and_set_value(self):
+        data = {}
+        JSONPath.set_value(data, "items[0].name", "foo")
+        self.assertEqual(data, {"items": [{"name": "foo"}]})
+        self.assertEqual(JSONPath.get_value(data, "items[0].name"), "foo")
+
+        JSONPath.set_value(data, "items[1]", {"name": "bar"})
+        self.assertEqual(JSONPath.get_value(data, "items[1].name"), "bar")
+        self.assertEqual(len(data["items"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_schema_validator.py
+++ b/tests/test_schema_validator.py
@@ -1,0 +1,90 @@
+import json
+import unittest
+import sys
+import types
+from pathlib import Path
+
+# Create lightweight agent_s3 package stub to avoid heavy optional dependencies.
+if 'agent_s3' not in sys.modules:
+    pkg = types.ModuleType('agent_s3')
+    pkg.__path__ = [str(Path(__file__).resolve().parents[1] / 'agent_s3')]
+    sys.modules['agent_s3'] = pkg
+
+from agent_s3.schema_validator import (
+    extract_json,
+    sanitize_response,
+    parse_with_fallback,
+    validate_llm_response,
+    JsonValidator,
+    TestCase,
+)
+
+
+class TestSchemaValidator(unittest.TestCase):
+    """Tests for schema validator helpers."""
+
+    def test_extract_json(self):
+        text = "prefix ```json\n{\"a\": 1}\n``` suffix"
+        self.assertEqual(extract_json(text), {"a": 1})
+
+        text = "before {\"b\": 2} after"
+        self.assertEqual(extract_json(text), {"b": 2})
+
+    def test_sanitize_response(self):
+        dirty = "<script>alert('x');</script> rm -rf /tmp && exec('hi')"
+        cleaned = sanitize_response(dirty)
+        self.assertNotIn("<script", cleaned)
+        self.assertNotIn("rm -rf", cleaned)
+        self.assertNotIn("exec(", cleaned)
+
+    def test_parse_with_fallback(self):
+        parser = json.loads
+        result = parse_with_fallback('{"x":1}', parser, {})
+        self.assertEqual(result, {"x": 1})
+
+        fallback = parse_with_fallback('bad', parser, {"f": True})
+        self.assertEqual(fallback, {"f": True})
+
+    def test_validate_llm_response_success(self):
+        payload = {
+            "description": "d",
+            "inputs": {"a": 1},
+            "expected_output": 2,
+            "expected_exception": None,
+            "assertions": ["a == 1"],
+        }
+        # Pydantic v1 compatibility: provide a model_validate method
+        if not hasattr(TestCase, "model_validate"):
+            TestCase.model_validate = classmethod(lambda cls, data: cls.parse_obj(data))
+
+        ok, res = validate_llm_response(json.dumps(payload), TestCase)
+        self.assertTrue(ok)
+        self.assertIsInstance(res, TestCase)
+
+    def test_json_validator_plan_validation(self):
+        validator = JsonValidator()
+        plan = {
+            "functional_plan": {
+                "overview": "o",
+                "steps": [],
+                "file_changes": [],
+                "functions": [],
+            },
+            "test_plan": {
+                "test_files": [],
+                "test_scenarios": [],
+                "test_cases": [],
+            },
+        }
+        valid, err = validator.validate_plan_json(plan)
+        self.assertTrue(valid)
+        self.assertIsNone(err)
+
+        bad_plan = {"functional_plan": {"overview": "o"}}
+        valid, err = validator.validate_plan_json(bad_plan)
+        self.assertFalse(valid)
+        self.assertIsInstance(err, str)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_signature_normalizer.py
+++ b/tests/test_signature_normalizer.py
@@ -1,0 +1,116 @@
+import os
+import unittest
+from copy import deepcopy
+import sys
+import types
+from pathlib import Path
+
+# Create a lightweight agent_s3 package to avoid heavy side effects from the
+# real __init__ which imports optional dependencies.
+if 'agent_s3' not in sys.modules:
+    pkg = types.ModuleType('agent_s3')
+    pkg.__path__ = [str(Path(__file__).resolve().parents[1] / 'agent_s3')]
+    sys.modules['agent_s3'] = pkg
+
+# Stub plan_validator to avoid optional dependencies like libcst.
+tools_pkg = types.ModuleType('agent_s3.tools')
+tools_pkg.__path__ = [str(Path(__file__).resolve().parents[1] / 'agent_s3' / 'tools')]
+sys.modules.setdefault('agent_s3.tools', tools_pkg)
+
+plan_validator_stub = types.ModuleType('agent_s3.tools.plan_validator')
+plan_validator_stub.validate_code_syntax = lambda *args, **kwargs: True
+sys.modules['agent_s3.tools.plan_validator'] = plan_validator_stub
+
+from agent_s3.signature_normalizer import SignatureNormalizer
+
+
+class TestSignatureNormalizer(unittest.TestCase):
+    """Tests for signature normalization utilities."""
+
+    def setUp(self):
+        self.normalizer = SignatureNormalizer(cwd=".")
+
+    def test_normalize_pre_plan_basic(self):
+        pre_plan = {
+            "feature_groups": [
+                {
+                    "group_name": "Group1",
+                    "features": [
+                        {
+                            "name": "LoginFeature",
+                            "description": "desc",
+                            "files_affected": [],
+                            "dependencies": {},
+                            "risk_assessment": {},
+                            "system_design": {
+                                "code_elements": [
+                                    {
+                                        "element_type": "class",
+                                        "name": "AuthManager",
+                                        "element_id": "",
+                                        "target_file": "src/AuthManager.py",
+                                        "signature": "class AuthManager",
+                                        "description": "",
+                                        "key_attributes_or_methods": [],
+                                    },
+                                    {
+                                        "element_type": "function",
+                                        "name": "helper_func",
+                                        "element_id": "",
+                                        "target_file": "",
+                                        "signature": "",
+                                        "description": "",
+                                        "key_attributes_or_methods": [],
+                                    },
+                                    {
+                                        "element_type": "function",
+                                        "name": "doThing",
+                                        "element_id": "",
+                                        "target_file": "src/do_thing.ts",
+                                        "signature": "function doThing()",
+                                        "description": "",
+                                        "key_attributes_or_methods": [],
+                                    },
+                                ]
+                            },
+                            "test_requirements": {
+                                "unit_tests": [
+                                    {"description": "t", "target_element": "AuthManager"}
+                                ],
+                                "integration_tests": []
+                            },
+                        }
+                    ],
+                }
+            ]
+        }
+
+        normalized = self.normalizer.normalize_pre_plan(deepcopy(pre_plan))
+        element = normalized["feature_groups"][0]["features"][0]["system_design"]["code_elements"][0]
+        self.assertEqual(element["element_id"], "loginfeature_authmanager_class")
+        self.assertEqual(element["target_file"], os.path.normpath("src/auth_manager.py"))
+        self.assertEqual(element["signature"], "class AuthManager():")
+
+        # second element checks default file and signature generation
+        second = normalized["feature_groups"][0]["features"][0]["system_design"]["code_elements"][1]
+        self.assertEqual(second["target_file"], os.path.normpath("src/helper_func.py"))
+        self.assertEqual(second["signature"], "def helper_func():")
+
+        # third element checks js/ts handling
+        third = normalized["feature_groups"][0]["features"][0]["system_design"]["code_elements"][2]
+        self.assertEqual(third["target_file"], os.path.normpath("src/doThing.ts"))
+        self.assertEqual(third["signature"], "function doThing();")
+
+        # test requirement updated with element id
+        unit_test = normalized["feature_groups"][0]["features"][0]["test_requirements"]["unit_tests"][0]
+        self.assertEqual(unit_test.get("target_element_id"), element["element_id"])
+
+    def test_element_id_uniqueness(self):
+        id1 = self.normalizer._normalize_element_id("duplicate", "Name", "function", "Feat", "Group")
+        id2 = self.normalizer._normalize_element_id("duplicate", "Name", "function", "Feat", "Group")
+        self.assertEqual(id1, "duplicate")
+        self.assertEqual(id2, "duplicate_1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add SignatureNormalizer tests for core normalization helpers
- verify JSONPath parsing and editing helpers
- test schema validator JSON extraction and validation logic
- stub heavy optional dependencies so tests run offline

## Testing
- `python -m unittest tests.test_signature_normalizer tests.test_json_editor_bridge tests.test_schema_validator -v`