### PR TITLE
Remove obsolete TestCritic tests

### DIFF
--- a/tests/test_test_critic.py
+++ b/tests/test_test_critic.py
@@ -1,53 +1,74 @@
 """Unit tests for the TestCritic class."""
 
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 import pytest
 
-from agent_s3.tools.test_critic.core import TestCritic, TestType, TestVerdict
+import agent_s3.tools.test_critic.core as core
+from agent_s3.tools.test_critic.core import TestVerdict
+
 
 @pytest.fixture
 def sample_workspace(tmp_path):
     (tmp_path / "test_sample.py").write_text("def test_example(): assert True")
     return tmp_path
 
-# These tests won't work since TestCriticRunner class has been replaced with TestCritic
-# Commenting them out for now but keeping the class structure in case it needs to be reactivated
-# with updated implementation in the future
-"""
-class TestPytestAdapterIntegration:
-    def test_collect_errors(self, sample_workspace):
-        critic = TestCritic(sample_workspace)
-        result = critic.run_analysis()
-        assert "collect_errors" not in result['details'] or not result['details']['collect_errors']
-        
-    def test_smoke_run(self, sample_workspace):
-        critic = TestCritic(sample_workspace)
-        result = critic.run_analysis()
-        assert result['details']['smoke_passed'] is True
-        
-    def test_coverage_threshold(self, sample_workspace):
-        critic = TestCritic(sample_workspace)
-        result = critic.run_analysis()
-        assert result['details']['coverage_percent'] >= 80.0
-        
-    def test_mutation_threshold(self, sample_workspace):
-        critic = TestCritic(sample_workspace)
-        result = critic.run_analysis()
-        assert result['details']['mutation_score'] >= 70.0
 
-    def test_full_verdict(self, sample_workspace):
-        critic = TestCritic(sample_workspace)
-        result = critic.run_analysis()
-        assert result['verdict'] == 'pass'
-"""
+class DummyAdapter:
+    """Simple adapter returning predetermined results."""
 
-# We keep a marker but skip all tests rather than deleting them completely
-# This provides documentation that these tests were intentionally disabled
-@pytest.mark.skip("Tests for deprecated TestCriticRunner APIs - current TestCritic implementation differs")
-class TestTestCritic(unittest.TestCase):
-    """Tests for the TestCritic class with advanced APIs that have changed in the current implementation."""
-    pass
+    name = "dummy"
+
+    def collect_only(self, workspace):
+        return []
+
+    def smoke_run(self, workspace):
+        return True
+
+    def coverage(self, workspace):
+        return 85.0
+
+    def mutation(self, workspace):
+        return 75.0
+
+
+@pytest.fixture
+def critic(monkeypatch):
+    adapter = DummyAdapter()
+    monkeypatch.setattr(core, "select_adapter", lambda workspace, lang_hint=None: adapter)
+
+    class NoOpReporter:
+        def __init__(self, workspace):
+            self.workspace = workspace
+
+        def write(self, results):
+            pass
+
+    monkeypatch.setattr(core, "Reporter", NoOpReporter)
+    return core.TestCritic()
+
+
+class TestCriticRunAnalysis:
+    def test_collect_errors(self, critic, sample_workspace):
+        result = critic.run_analysis(sample_workspace)
+        assert result["details"]["collect_errors"] == []
+
+    def test_smoke_run(self, critic, sample_workspace):
+        result = critic.run_analysis(sample_workspace)
+        assert result["details"]["smoke_passed"] is True
+
+    def test_coverage_threshold(self, critic, sample_workspace):
+        result = critic.run_analysis(sample_workspace)
+        assert result["details"]["coverage_percent"] >= 80.0
+
+    def test_mutation_threshold(self, critic, sample_workspace):
+        result = critic.run_analysis(sample_workspace)
+        assert result["details"]["mutation_score"] >= 70.0
+
+    def test_full_verdict(self, critic, sample_workspace):
+        result = critic.run_analysis(sample_workspace)
+        assert result["verdict"] == TestVerdict.PASS
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- drop old TestPytestAdapterIntegration and TestTestCritic stubs
- add new unit tests for TestCritic using a dummy adapter

## Testing
- `ruff check agent_s3/ tests/test_test_critic.py`
- `mypy agent_s3/` *(fails: unterminated string literal)*
- `pytest tests/test_test_critic.py -q` *(fails: pytest not installed)*