### PR TITLE
Update tests to use new planning workflow

### DIFF
--- a/tests/integration/test_enforced_json_coordinator_integration.py
+++ b/tests/integration/test_enforced_json_coordinator_integration.py
@@ -137,113 +137,41 @@ class TestEnforcedJsonCoordinatorIntegration:
             
             yield coordinator
 
-    def test_execute_pre_planning_phase_with_enforced_json(self, mock_coordinator):
-        """Test that coordinator correctly uses enforced JSON pre-planning when enabled."""
-        # Execute pre-planning with a test task
+    def test_pre_planning_with_enforced_json(self, mock_coordinator):
+        """Coordinator uses enforced JSON to perform pre-planning."""
         task_description = "Implement user authentication system"
-        result = mock_coordinator._execute_pre_planning_phase(task_description)
-        
-        # Verify results
-        assert result["success"] is True
-        assert result["status"] == "completed"
-        assert "uses_enforced_json" in result
-        assert result["uses_enforced_json"] is True
-        
-        # Verify the call to router_agent was made
-        mock_coordinator.router_agent.call_llm_by_role.assert_called_once()
-        
-        # Verify progress tracker was updated
-        mock_coordinator.progress_tracker.update_progress.assert_called()
-        
-        # Extract the first update_progress call arguments
-        first_call_args = mock_coordinator.progress_tracker.update_progress.call_args_list[0][0][0]
-        
-        # Verify pre-planning was started
-        assert first_call_args["phase"] == "pre_planning"
-        assert first_call_args["status"] == "started"
-        
-        # Extract the second update_progress call arguments
-        second_call_args = mock_coordinator.progress_tracker.update_progress.call_args_list[1][0][0]
-        
-        # Verify pre-planning was completed
-        assert second_call_args["phase"] == "pre_planning"
-        assert second_call_args["status"] == "completed"
-        assert second_call_args["json_formatted"] is True
-        assert second_call_args["enforced_json"] is True
+        with patch('agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json') as mock_call:
+            mock_call.return_value = (True, {"features": [], "complexity_score": 75})
 
-    @patch('agent_s3.pre_planner_json_enforced.integrate_with_coordinator')
-    def test_coordinator_fallback_to_standard_json(self, mock_integrate, mock_coordinator):
-        """Test that coordinator falls back to standard JSON when enforced JSON fails."""
-        # Make enforced JSON fail
-        mock_integrate.side_effect = Exception("Enforced JSON failed")
-        
-        # Setup standard JSON to succeed
-        with patch('agent_s3.pre_planner_json.integrate_with_pre_planning_manager') as mock_standard_json:
-            mock_standard_json.return_value = {
-                "status": "completed",
-                "success": True,
-                "complexity_score": 50.0,
-                "json_formatted": True
-            }
-            
-            # Enable standard JSON as fallback
-            mock_coordinator.config.config["use_json_pre_planning"] = True
-            
-            # Execute pre-planning
-            result = mock_coordinator._execute_pre_planning_phase("Test task")
-            
-            # Verify standard JSON was used as fallback
+            result = integrate_with_coordinator(mock_coordinator, task_description)
+
             assert result["success"] is True
-            assert result["status"] == "completed"
-            assert "uses_enforced_json" not in result
-            assert mock_standard_json.called
-            
-            # Verify progress tracker was updated with fallback info
-            second_call_args = mock_coordinator.progress_tracker.update_progress.call_args_list[1][0][0]
-            assert second_call_args["json_formatted"] is True
-            assert not second_call_args.get("enforced_json", False)
+            assert result["uses_enforced_json"] is True
+            mock_call.assert_called_once_with(mock_coordinator.router_agent, task_description)
 
-    @patch('agent_s3.pre_planner_json_enforced.integrate_with_coordinator')
+    @patch('agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json', side_effect=Exception("Enforced JSON failed"))
     @patch('agent_s3.pre_planner_json.integrate_with_pre_planning_manager')
-    def test_coordinator_fallback_to_standard_planning(self, mock_standard_json, mock_enforced_json, mock_coordinator):
-        """Test that coordinator falls back to standard planning when both JSON formats fail."""
-        # Make both JSON formats fail
-        mock_enforced_json.side_effect = Exception("Enforced JSON failed")
-        mock_standard_json.side_effect = Exception("Standard JSON failed")
-        
-        # Setup mocks for standard planning
-        mock_coordinator.pre_planner.collect_impacted_files.return_value = ["file1.py", "file2.py"]
-        mock_coordinator.pre_planner.estimate_complexity_from_request.return_value = {"risk": "medium"}
-        mock_coordinator.pre_planner.get_complexity_breakdown.return_value = {
-            "total_lines": 100, 
-            "total_branches": 20
-        }
-        mock_coordinator.pre_planner.identify_test_requirements.return_value = ["Test requirement 1"]
-        mock_coordinator.pre_planner.analyze_dependencies.return_value = {"internal": ["dep1"]}
-        
-        # Enable both JSON formats to test complete fallback
-        mock_coordinator.config.config["use_json_pre_planning"] = True
-        mock_coordinator.config.config["use_enforced_json_pre_planning"] = True
-        
-        # Execute pre-planning
-        result = mock_coordinator._execute_pre_planning_phase("Test task")
-        
-        # Verify standard planning was used
-        assert result["success"] is True
-        assert result["status"] == "completed"
-        assert "impacted_files" in result
-        assert "complexity_score" in result
-        assert "test_requirements" in result
-        assert "dependencies" in result
-        
-        # Verify both JSON methods were attempted
-        assert mock_enforced_json.called
-        assert mock_standard_json.called
-        
-        # Verify standard pre-planning methods were called
-        assert mock_coordinator.pre_planner.collect_impacted_files.called
-        assert mock_coordinator.pre_planner.estimate_complexity_from_request.called
-        assert mock_coordinator.pre_planner.get_complexity_breakdown.called
+    def test_coordinator_fallback_to_standard_json(self, mock_std_json, mock_call, mock_coordinator):
+        """If enforced JSON fails, ensure the error propagates."""
+        mock_coordinator.router_agent = MagicMock()
+
+        with pytest.raises(Exception):
+            integrate_with_coordinator(mock_coordinator, "Test task")
+
+        mock_call.assert_called_once_with(mock_coordinator.router_agent, "Test task")
+        mock_std_json.assert_not_called()
+
+    @patch('agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json', side_effect=Exception("Enforced JSON failed"))
+    @patch('agent_s3.pre_planner_json.integrate_with_pre_planning_manager')
+    def test_coordinator_fallback_to_standard_planning(self, mock_std_json, mock_call, mock_coordinator):
+        """Both JSON workflows failing should surface the exception."""
+        mock_coordinator.router_agent = MagicMock()
+
+        with pytest.raises(Exception):
+            integrate_with_coordinator(mock_coordinator, "Test task")
+
+        mock_call.assert_called_once_with(mock_coordinator.router_agent, "Test task")
+        mock_std_json.assert_not_called()
 
     @patch('agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json')
     def test_direct_integration_with_coordinator(self, mock_call, mock_coordinator):

--- a/tests/test_coordinator_json_preplanning.py
+++ b/tests/test_coordinator_json_preplanning.py
@@ -16,98 +16,45 @@ from agent_s3.pre_planner_json_enforced import integrate_with_coordinator
 class TestCoordinatorJsonPrePlanning:
     """Tests for the coordinator's pre-planning functionality with JSON enforcement."""
     
-    @patch('agent_s3.pre_planner_json_enforced.integrate_with_coordinator')
+    @patch('agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json')
     @patch('agent_s3.pre_planner_json.integrate_with_pre_planning_manager')
-    def test_execute_pre_planning_phase_prioritizes_enforced_json(self, mock_std_json, mock_enforced_json):
-        """Test that coordinator prioritizes enforced JSON when both are enabled."""
-        # Setup for the test
+    def test_pre_planning_prioritizes_enforced_json(self, mock_std_json, mock_call):
+        """Coordinator should use enforced JSON when available."""
         coordinator = MagicMock()
         coordinator.config = MagicMock()
         coordinator.config.config = {
             "use_enforced_json_pre_planning": True,
-            "use_json_pre_planning": True  # Both enabled
+            "use_json_pre_planning": True
         }
-        coordinator.scratchpad = MagicMock()
-        coordinator.progress_tracker = MagicMock()
         coordinator.pre_planner = MagicMock()
-        
-        # Mock the enforced JSON integration to return success
-        mock_enforced_json.return_value = {
-            "status": "completed",
-            "success": True,
-            "complexity_score": 50,
-            "uses_enforced_json": True
-        }
-        
-        # Original method to intercept to avoid testing everything
-        original_method = Coordinator._execute_pre_planning_phase
-        
-        try:
-            # Mock the pre-planning method to call our implementation
-            task_description = "Test task"
-            result = original_method(coordinator, task_description)
-            
-            # Verify that enforced JSON was called and standard JSON was not
-            mock_enforced_json.assert_called_once()
-            mock_std_json.assert_not_called()
-            
-            # Verify the result
-            assert result.get("status") == "completed"
-            assert result.get("success") is True
-            assert result.get("uses_enforced_json") is True
-            
-        except Exception as e:
-            # Restore original method and re-raise if there's an error
-            pytest.fail(f"Test failed: {str(e)}")
+        coordinator.router_agent = MagicMock()
+
+        mock_call.return_value = (True, {"features": [], "complexity_score": 50})
+
+        result = integrate_with_coordinator(coordinator, "Test task")
+
+        mock_call.assert_called_once_with(coordinator.router_agent, "Test task")
+        mock_std_json.assert_not_called()
+        assert result["uses_enforced_json"] is True
     
-    @patch('agent_s3.pre_planner_json_enforced.integrate_with_coordinator')
+    @patch('agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json', side_effect=Exception("Enforced JSON failed"))
     @patch('agent_s3.pre_planner_json.integrate_with_pre_planning_manager')
-    def test_fallback_to_standard_json_when_enforced_fails(self, mock_std_json, mock_enforced_json):
-        """Test that coordinator falls back to standard JSON when enforced JSON fails."""
-        # Setup for the test
+    def test_fallback_to_standard_json_when_enforced_fails(self, mock_std_json, mock_call):
+        """If enforced JSON fails, an exception is raised and standard JSON is not used."""
         coordinator = MagicMock()
         coordinator.config = MagicMock()
         coordinator.config.config = {
             "use_enforced_json_pre_planning": True,
-            "use_json_pre_planning": True  # Both enabled
+            "use_json_pre_planning": True
         }
-        coordinator.scratchpad = MagicMock()
-        coordinator.progress_tracker = MagicMock()
         coordinator.pre_planner = MagicMock()
-        
-        # Make enforced JSON fail
-        mock_enforced_json.side_effect = Exception("Enforced JSON failed")
-        
-        # Make standard JSON succeed
-        mock_std_json.return_value = {
-            "status": "completed",
-            "success": True,
-            "complexity_score": 50,
-            "json_formatted": True
-        }
-        
-        # Original method to patch
-        original_method = Coordinator._execute_pre_planning_phase
-        
-        try:
-            # Mock the pre-planning method to call our implementation
-            task_description = "Test task"
-            result = original_method(coordinator, task_description)
-            
-            # Verify that enforced JSON was attempted
-            mock_enforced_json.assert_called_once()
-            
-            # Verify that standard JSON was used as fallback
-            mock_std_json.assert_called_once()
-            
-            # Verify the result
-            assert result.get("status") == "completed"
-            assert result.get("success") is True
-            assert result.get("json_formatted") is True
-            
-        except Exception as e:
-            # Re-raise if there's an error
-            pytest.fail(f"Test failed: {str(e)}")
+        coordinator.router_agent = MagicMock()
+
+        with pytest.raises(Exception):
+            integrate_with_coordinator(coordinator, "Test task")
+
+        mock_call.assert_called_once_with(coordinator.router_agent, "Test task")
+        mock_std_json.assert_not_called()
     
     @patch('agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json')
     def test_direct_integration_function(self, mock_call):
@@ -232,67 +179,45 @@ class TestCoordinatorJsonPrePlanning:
         assert "approval_baseline" in result["test_requirements"]
         assert result["test_requirements"]["approval_baseline"] == ["Baseline test"]
 
-    def test_execute_pre_planning_phase_with_updated_complexity(self):
-        """Test that updated complexity scoring is reflected in JSON pre-planning."""
-        # Setup for the test
+    def test_pre_planning_with_updated_complexity(self):
+        """Test that complexity scoring from the JSON workflow is returned."""
         coordinator = MagicMock()
         coordinator.config = MagicMock()
         coordinator.config.config = {
             "use_enforced_json_pre_planning": True,
             "use_json_pre_planning": True
         }
-        coordinator.pre_planner.assess_complexity.return_value = {
-            "score": 60,
-            "is_complex": True
-        }
+        coordinator.router_agent = MagicMock()
+        coordinator.pre_planner.assess_complexity.return_value = {"score": 60, "is_complex": True}
 
-        # Mock enforced JSON integration
-        with patch('agent_s3.pre_planner_json_enforced.integrate_with_coordinator') as mock_enforced_json:
-            mock_enforced_json.return_value = {
-                "status": "completed",
-                "success": True,
-                "complexity_score": 60,
-                "uses_enforced_json": True
-            }
+        with patch('agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json') as mock_call:
+            mock_call.return_value = (True, {"complexity_score": 60, "features": []})
 
-            # Execute
-            result = coordinator._execute_pre_planning_phase("Test task")
+            result = integrate_with_coordinator(coordinator, "Test task")
 
-            # Verify
             assert result["success"] is True
             assert result["complexity_score"] == 60
-            mock_enforced_json.assert_called_once()
+            mock_call.assert_called_once_with(coordinator.router_agent, "Test task")
 
-    def test_execute_pre_planning_phase_with_caching(self):
-        """Test that caching is applied to pre-planning phase."""
-        # Setup for the test
+    def test_pre_planning_with_caching(self):
+        """Test repeated calls invoke the JSON workflow each time."""
         coordinator = MagicMock()
         coordinator.config = MagicMock()
         coordinator.config.config = {
             "use_enforced_json_pre_planning": True,
             "use_json_pre_planning": True
         }
-        coordinator.pre_planner.collect_impacted_files = MagicMock()
-        coordinator.pre_planner.collect_impacted_files.return_value = ["file1.py", "file2.py"]
+        coordinator.router_agent = MagicMock()
 
-        # Mock enforced JSON integration
-        with patch('agent_s3.pre_planner_json_enforced.integrate_with_coordinator') as mock_enforced_json:
-            mock_enforced_json.return_value = {
-                "status": "completed",
-                "success": True,
-                "complexity_score": 60,
-                "uses_enforced_json": True
-            }
+        with patch('agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json') as mock_call:
+            mock_call.return_value = (True, {"complexity_score": 60, "features": []})
 
-            # Execute twice to test caching
-            result1 = coordinator._execute_pre_planning_phase("Test task")
-            result2 = coordinator._execute_pre_planning_phase("Test task")
+            result1 = integrate_with_coordinator(coordinator, "Test task")
+            result2 = integrate_with_coordinator(coordinator, "Test task")
 
-            # Verify
             assert result1["success"] is True
             assert result2["success"] is True
-            coordinator.pre_planner.collect_impacted_files.assert_called_once()  # Cached result used
-            mock_enforced_json.assert_called_once()
+            assert mock_call.call_count == 2
 
 
 if __name__ == "__main__":

--- a/tests/test_coordinator_phases.py
+++ b/tests/test_coordinator_phases.py
@@ -14,6 +14,11 @@ from unittest.mock import MagicMock, patch
 from agent_s3.coordinator import Coordinator
 from agent_s3.config import Config
 from agent_s3.enhanced_scratchpad_manager import LogLevel
+from agent_s3.pre_planner_json_enforced import (
+    integrate_with_coordinator,
+    call_pre_planner_with_enforced_json,
+    JSONValidationError,
+)
 
 # Test fixtures
 
@@ -61,6 +66,7 @@ def coordinator(mock_config):
         coordinator.file_tool = MagicMock()
         coordinator.error_context_manager = MagicMock()
         coordinator.debugging_manager = MagicMock()
+        coordinator.router_agent = MagicMock()
         
         yield coordinator
 
@@ -154,199 +160,130 @@ def test_initialize_workspace_exception(coordinator):
         assert result["errors"][0]["type"] == "exception"
         coordinator.workspace_initializer.initialize_workspace.assert_called_once()
 
-# Test _execute_pre_planning_phase method
+# Pre-planning phase tests using the JSON workflow
 
-def test_pre_planning_phase_normal_flow(coordinator):
-    """Test normal flow of pre-planning phase."""
-    # Set up mocks
-    coordinator.pre_planner.collect_impacted_files.return_value = ["file1.py", "file2.py"]
-    coordinator.pre_planner.estimate_complexity.return_value = 150.0
-    coordinator.prompt_moderator.ask_binary_question.return_value = False  # Don't switch to design
-    
-    # Execute
-    result = coordinator._execute_pre_planning_phase("Add feature X")
-    
-    # Assert
+@patch("agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json")
+def test_pre_planning_phase_normal_flow(mock_call, coordinator):
+    """Test normal flow of pre-planning phase using the new workflow."""
+    json_data = {"features": [], "complexity_score": 150.0}
+    mock_call.return_value = (True, json_data)
+    coordinator.pre_planner.assess_complexity.return_value = {"score": 150.0, "is_complex": False}
+
+    result = integrate_with_coordinator(coordinator, "Add feature X")
+
     assert result["success"] is True
     assert result["status"] == "completed"
-    assert result["switch_workflow"] is False
-    assert len(result["impacted_files"]) == 2
     assert result["complexity_score"] == 150.0
-    coordinator.pre_planner.collect_impacted_files.assert_called_once()
-    coordinator.pre_planner.estimate_complexity.assert_called_once()
+    assert result["uses_enforced_json"] is True
+    assert "features" in result
+    mock_call.assert_called_once_with(coordinator.router_agent, "Add feature X")
 
-def test_pre_planning_phase_high_complexity(coordinator):
-    """Test pre-planning phase with high complexity leading to workflow switch."""
-    # Set up mocks
-    coordinator.pre_planner.collect_impacted_files.return_value = ["file1.py", "file2.py", "file3.py", "file4.py"]
-    coordinator.pre_planner.estimate_complexity.return_value = 400.0  # Above threshold
-    coordinator.prompt_moderator.ask_binary_question.return_value = True  # Switch to design
-    
-    # Execute
-    result = coordinator._execute_pre_planning_phase("Refactor module Y")
-    
-    # Assert
+@patch("agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json")
+def test_pre_planning_phase_high_complexity(mock_call, coordinator):
+    """Test pre-planning phase handling of high complexity tasks."""
+    json_data = {"features": [], "complexity_score": 400.0}
+    mock_call.return_value = (True, json_data)
+    coordinator.pre_planner.assess_complexity.return_value = {"score": 400.0, "is_complex": True}
+
+    result = integrate_with_coordinator(coordinator, "Refactor module Y")
+
     assert result["success"] is True
     assert result["status"] == "completed"
-    assert result["switch_workflow"] is True
-    assert result["workflow"] == "design"
-    assert len(result["impacted_files"]) == 4
+    assert result["is_complex"] is True
     assert result["complexity_score"] == 400.0
-    coordinator.pre_planner.collect_impacted_files.assert_called_once()
-    coordinator.pre_planner.estimate_complexity.assert_called_once()
-    coordinator.prompt_moderator.ask_binary_question.assert_called_once()
+    mock_call.assert_called_once_with(coordinator.router_agent, "Refactor module Y")
 
-def test_pre_planning_file_collection_error(coordinator):
-    """Test pre-planning phase with file collection error."""
-    # Set up mocks
-    coordinator.pre_planner.collect_impacted_files.side_effect = Exception("File collection error")
-    coordinator.pre_planner.estimate_complexity.return_value = 100.0  # Will use empty list
-    
-    # Execute
-    result = coordinator._execute_pre_planning_phase("Add feature Z")
-    
-    # Assert
-    assert result["success"] is True  # Still succeeds with fallback
-    assert result["status"] == "completed"
-    assert "file_collection_error" in result
-    assert result["impacted_files"] == []
-    coordinator.pre_planner.collect_impacted_files.assert_called_once()
-    coordinator.pre_planner.estimate_complexity.assert_called_once_with([])
+@patch("agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json")
+def test_pre_planning_file_collection_error(mock_call, coordinator):
+    """Test that JSON validation errors surface when pre-planning fails."""
+    mock_call.return_value = (False, {})
 
-def test_pre_planning_complexity_estimation_error(coordinator):
-    """Test pre-planning phase with complexity estimation error."""
-    # Set up mocks
-    coordinator.pre_planner.collect_impacted_files.return_value = ["file1.py", "file2.py"]
-    coordinator.pre_planner.estimate_complexity.side_effect = Exception("Complexity estimation error")
-    
-    # Execute
-    result = coordinator._execute_pre_planning_phase("Add feature W")
-    
-    # Assert
-    assert result["success"] is True  # Still succeeds with fallback
-    assert result["status"] == "completed"
-    assert "complexity_error" in result
-    assert result["complexity_estimated"] is False
-    assert result["complexity_score"] == 250  # Default value
-    coordinator.pre_planner.collect_impacted_files.assert_called_once()
-    coordinator.pre_planner.estimate_complexity.assert_called_once()
+    with pytest.raises(JSONValidationError):
+        integrate_with_coordinator(coordinator, "Add feature Z")
 
-def test_pre_planning_prompt_error(coordinator):
-    """Test pre-planning phase with prompt error."""
-    # Set up mocks
-    coordinator.pre_planner.collect_impacted_files.return_value = ["file1.py", "file2.py"]
-    coordinator.pre_planner.estimate_complexity.return_value = 400.0  # Above threshold
-    coordinator.prompt_moderator.ask_binary_question.side_effect = Exception("Prompt error")
-    
-    # Execute
-    result = coordinator._execute_pre_planning_phase("Add feature V")
-    
-    # Assert
-    assert result["success"] is True  # Still succeeds
-    assert result["status"] == "completed"
-    assert result["switch_workflow"] is False  # Default to not switching
-    assert "prompt_error" in result
-    coordinator.pre_planner.collect_impacted_files.assert_called_once()
-    coordinator.pre_planner.estimate_complexity.assert_called_once()
-    coordinator.prompt_moderator.ask_binary_question.assert_called_once()
+    mock_call.assert_called_once_with(coordinator.router_agent, "Add feature Z")
 
-def test_pre_planning_complete_failure(coordinator):
-    """Test pre-planning phase with complete failure."""
-    # Set up mocks for complete failure
-    coordinator.pre_planner.collect_impacted_files.side_effect = Exception("Critical error")
-    coordinator.pre_planner.estimate_complexity.side_effect = Exception("Should not be called")
-    
-    # Make sure the error propagates to the top level
-    with patch('traceback.format_exc', return_value="Mock traceback"):
-        # Execute
-        result = coordinator._execute_pre_planning_phase("Invalid query")
-        
-        # Assert
-        assert result["success"] is False
-        assert result["status"] == "error"
-        assert "error" in result
-        assert "error_context" in result
-        assert result["error_context"]["error_type"] == "Exception"
-        coordinator.pre_planner.collect_impacted_files.assert_called_once()
-        coordinator.pre_planner.estimate_complexity.assert_not_called()
-        coordinator.progress_tracker.update_progress.assert_any_call({
-            "phase": "pre_planning", 
-            "status": "error",
-            "error": result["error"]
-        })
+@patch("agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json")
+def test_pre_planning_complexity_estimation_error(mock_call, coordinator):
+    """Test handling when complexity assessment fails."""
+    json_data = {"features": []}
+    mock_call.return_value = (True, json_data)
+    coordinator.pre_planner.assess_complexity.side_effect = Exception("Complexity estimation error")
 
-def test_pre_planning_phase_updated_requirements(coordinator):
-    """Test pre-planning phase with updated test requirements."""
-    # Set up mocks
-    coordinator.pre_planner.collect_impacted_files.return_value = ["file1.py", "file2.py"]
-    coordinator.pre_planner.estimate_complexity.return_value = 200.0
-    coordinator.pre_planner.get_test_requirements.return_value = {
-        "unit": ["Test case 1"],
-        "integration": ["Integration test 1"],
-        "property_based": ["Property-based test 1"],
-        "acceptance": [
-            {
-                "given": "Condition",
-                "when": "Action",
-                "then": "Result"
-            }
-        ],
-        "approval_baseline": ["Baseline test"]
-    }
+    result = integrate_with_coordinator(coordinator, "Add feature W")
 
-    # Execute
-    result = coordinator._execute_pre_planning_phase("Add feature X")
-
-    # Assert
     assert result["success"] is True
     assert result["status"] == "completed"
+    assert result.get("complexity_score") is None
+    assert result["is_complex"] is False
+    mock_call.assert_called_once_with(coordinator.router_agent, "Add feature W")
+
+@patch("agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json", side_effect=Exception("Prompt error"))
+def test_pre_planning_prompt_error(mock_call, coordinator):
+    """Test handling when the LLM call fails."""
+
+    with pytest.raises(Exception):
+        integrate_with_coordinator(coordinator, "Add feature V")
+
+    mock_call.assert_called_once_with(coordinator.router_agent, "Add feature V")
+
+@patch(
+    "agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json",
+    side_effect=Exception("Critical error"),
+)
+def test_pre_planning_complete_failure(mock_call, coordinator):
+    """Test that a critical failure raises an exception."""
+
+    with pytest.raises(Exception):
+        integrate_with_coordinator(coordinator, "Invalid query")
+
+    mock_call.assert_called_once_with(coordinator.router_agent, "Invalid query")
+
+@patch("agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json")
+def test_pre_planning_phase_updated_requirements(mock_call, coordinator):
+    """Test that test requirements from JSON are returned."""
+    json_data = {
+        "features": [],
+        "test_requirements": {"approval_baseline": ["Baseline test"]},
+        "complexity_score": 200.0,
+    }
+    mock_call.return_value = (True, json_data)
+    coordinator.pre_planner.assess_complexity.return_value = {"score": 200.0, "is_complex": False}
+
+    result = integrate_with_coordinator(coordinator, "Add feature X")
+
+    assert result["success"] is True
     assert result["test_requirements"]["approval_baseline"] == ["Baseline test"]
-    coordinator.pre_planner.collect_impacted_files.assert_called_once()
-    coordinator.pre_planner.estimate_complexity.assert_called_once()
-    coordinator.pre_planner.get_test_requirements.assert_called_once()
+    mock_call.assert_called_once_with(coordinator.router_agent, "Add feature X")
 
-def test_pre_planning_phase_updated_complexity(coordinator):
-    """Test pre-planning phase with updated complexity scoring."""
-    # Set up mocks
-    coordinator.pre_planner.collect_impacted_files.return_value = ["file1.py", "file2.py", "file3.py"]
-    coordinator.pre_planner.assess_complexity.return_value = {
-        "score": 55,
-        "is_complex": True
-    }
-    coordinator.prompt_moderator.ask_binary_question.return_value = True  # Switch to design
+@patch("agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json")
+def test_pre_planning_phase_updated_complexity(mock_call, coordinator):
+    """Test that complexity scoring is returned from JSON workflow."""
+    json_data = {"features": [], "complexity_score": 55}
+    mock_call.return_value = (True, json_data)
+    coordinator.pre_planner.assess_complexity.return_value = {"score": 55, "is_complex": True}
 
-    # Execute
-    result = coordinator._execute_pre_planning_phase("Add feature X")
+    result = integrate_with_coordinator(coordinator, "Add feature X")
 
-    # Assert
     assert result["success"] is True
     assert result["status"] == "completed"
-    assert result["switch_workflow"] is True
-    assert result["workflow"] == "design"
+    assert result["is_complex"] is True
     assert result["complexity_score"] == 55
-    coordinator.pre_planner.collect_impacted_files.assert_called_once()
-    coordinator.pre_planner.assess_complexity.assert_called_once()
+    mock_call.assert_called_once_with(coordinator.router_agent, "Add feature X")
 
-def test_pre_planning_phase_with_caching(coordinator):
-    """Test pre-planning phase with caching applied."""
-    # Set up mocks
-    coordinator.pre_planner.collect_impacted_files.return_value = ["file1.py", "file2.py"]
-    coordinator.pre_planner.assess_complexity.return_value = {
-        "score": 55,
-        "is_complex": True
-    }
-    coordinator.prompt_moderator.ask_binary_question.return_value = True  # Switch to design
+@patch("agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json")
+def test_pre_planning_phase_with_caching(mock_call, coordinator):
+    """Test repeated calls invoke the JSON workflow each time."""
+    json_data = {"features": [], "complexity_score": 55}
+    mock_call.return_value = (True, json_data)
+    coordinator.pre_planner.assess_complexity.return_value = {"score": 55, "is_complex": True}
 
-    # Execute twice to test caching
-    result1 = coordinator._execute_pre_planning_phase("Add feature X")
-    result2 = coordinator._execute_pre_planning_phase("Add feature X")
+    result1 = integrate_with_coordinator(coordinator, "Add feature X")
+    result2 = integrate_with_coordinator(coordinator, "Add feature X")
 
-    # Assert
     assert result1["success"] is True
     assert result2["success"] is True
-    assert result1 == result2  # Cached result should be identical
-    coordinator.pre_planner.collect_impacted_files.assert_called_once()  # Cached result used
-    coordinator.pre_planner.assess_complexity.assert_called_once()
+    assert mock_call.call_count == 2
 
 # Test consolidated workflow through feature_group_processor
 

--- a/tests/test_feature_based_workflow.py
+++ b/tests/test_feature_based_workflow.py
@@ -41,7 +41,6 @@ class TestFeatureBasedWorkflow:
         }
         
         # Mock the methods used in the new consolidated workflow
-        coordinator._execute_pre_planning_phase = MagicMock()
         coordinator._validate_pre_planning_data = MagicMock(return_value=True)
         coordinator._regenerate_pre_planning_with_modifications = MagicMock()
         coordinator._present_pre_planning_results_to_user = MagicMock(return_value=("yes", None))


### PR DESCRIPTION
## Summary
- replace all usages of the removed `_execute_pre_planning_phase` with calls to `integrate_with_coordinator`
- remove obsolete mocks for the old method
- adjust test assertions for the new result structure

## Testing
- `pip install pytest` *(fails: Could not establish connection)*