### PR TITLE
Remove unused test imports

### DIFF
--- a/tests/test_coordinator_phases.py
+++ b/tests/test_coordinator_phases.py
@@ -6,8 +6,6 @@ within the Coordinator's task execution flow, with a focus on error handling,
 graceful degradation, and appropriate output formatting.
 """
 
-import os
-import json
 import pytest
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_feature_based_workflow.py
+++ b/tests/test_feature_based_workflow.py
@@ -6,8 +6,6 @@ Tests the new feature-based iterative approach to task execution.
 
 import pytest
 from unittest.mock import MagicMock, patch
-import json
-from datetime import datetime
 
 from agent_s3.coordinator import Coordinator
 from agent_s3.enhanced_scratchpad_manager import LogLevel


### PR DESCRIPTION
## Summary
- tidy unused imports from test files
- ensure preplanning and integration tests end with newline

## Testing
- `python -m py_compile tests/test_coordinator_json_preplanning.py tests/test_coordinator_phases.py tests/test_feature_based_workflow.py tests/integration/test_enforced_json_coordinator_integration.py`
