### PR TITLE
Remove direct pytest execution blocks

### DIFF
--- a/tests/integration/test_enforced_json_coordinator_integration.py
+++ b/tests/integration/test_enforced_json_coordinator_integration.py
@@ -239,5 +239,3 @@ class TestEnforcedJsonCoordinatorIntegration:
         mock_call.assert_called_once_with(mock_coordinator.router_agent, task)
 
 
-if __name__ == "__main__":
-    pytest.main(["-xvs", "test_enforced_json_coordinator_integration.py"])

--- a/tests/test_advanced_workflows.py
+++ b/tests/test_advanced_workflows.py
@@ -502,6 +502,3 @@ class TestMultiStepDebugging:
         assert "session_manager.py" in result["changes"]
         assert "password_validator.py" in result["changes"]
 
-
-if __name__ == "__main__":
-    pytest.main(["-xvs", __file__])

--- a/tests/test_coordinator_json_preplanning.py
+++ b/tests/test_coordinator_json_preplanning.py
@@ -235,5 +235,3 @@ class TestCoordinatorJsonPrePlanning:
         assert mock_call.call_count == 2
 
 
-if __name__ == "__main__":
-    pytest.main(["-xvs", "test_coordinator_json_preplanning.py"])

--- a/tests/test_coordinator_plan_validation.py
+++ b/tests/test_coordinator_plan_validation.py
@@ -374,5 +374,3 @@ class TestCoordinatorPlanValidation:
                 coordinator.feature_group_processor.process_pre_planning_output.assert_not_called()
 
 
-if __name__ == "__main__":
-    pytest.main(["-xvs", "tests/test_coordinator_plan_validation.py"])

--- a/tests/test_feature_based_workflow.py
+++ b/tests/test_feature_based_workflow.py
@@ -561,5 +561,3 @@ class TestFeatureBasedWorkflow:
             )
 
 
-if __name__ == "__main__":
-    pytest.main(["-xvs", "test_feature_based_workflow.py"])

--- a/tests/test_plan_validator.py
+++ b/tests/test_plan_validator.py
@@ -330,5 +330,3 @@ class TestPlanValidator:
         assert validation_results.get("summary", {}).get("critical_count", 0) == len(critical_errors)
 
 
-if __name__ == "__main__":
-    pytest.main(["-xvs", "tests/test_plan_validator.py"])

--- a/tests/test_pre_planner_json_enforced.py
+++ b/tests/test_pre_planner_json_enforced.py
@@ -599,5 +599,3 @@ DESCRIPTION: Add error handling for connection failures
         # Verify the result
         assert result == json_data
 
-if __name__ == "__main__":
-    pytest.main(["-xvs", "test_pre_planner_json_enforced.py"])

--- a/tests/test_system_integration.py
+++ b/tests/test_system_integration.py
@@ -546,6 +546,3 @@ class TestErrorHandling:
         assert result["phases"]["implementation"]["attempts"][0]["validation"]["success"] is False
         assert result["phases"]["implementation"]["attempts"][1]["validation"]["success"] is True
 
-
-if __name__ == "__main__":
-    pytest.main(["-xvs", __file__])


### PR DESCRIPTION
## Summary
- remove `pytest.main()` blocks from multiple test modules

## Testing
- `python -m pytest tests/test_coordinator_json_preplanning.py::TestCoordinatorJsonPrePlanning::test_pre_planning_prioritizes_enforced_json -q` *(fails: No module named pytest)*
- `pip install pytest` *(fails: No route to host)*