### PR TITLE
Remove obsolete TestCritic tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Agent-S3 is a modern AI coding agent designed to empower engineers by emphasizing transparency, control, and strict adherence to guidelines. Recognizing that AI can and will make mistakes, Agent-S3 ensures that the engineer remains in control at every stage of the development process.
 
+This README and the companion `STORIES.md` file serve as the canonical project
+documentation. Both documents provide authoritative information on setup,
+workflows, and design decisions.
+
 ## Overview
 
 Agent-S3 automates feature planning, code generation, and execution while maintaining a step-by-step approach to prioritize correctness over convenience. Key features include:
@@ -104,6 +108,7 @@ Agent-S3 is not just a tool for automation; it is a partner in development that 
   - Enhanced scratchpad with structured CoT logging (`agent_s3.enhanced_scratchpad_manager`)
   - Specialized error categorization and handling for 12+ error types (`agent_s3.debugging_manager`)
   - Context-aware error resolution with historical reasoning extraction
+  - Requests engineer guidance if automated debugging fails after repeated attempts
   - See [DEBUGGING.md](DEBUGGING.md) for details
 - Comprehensive test framework:
   - TestCritic for analyzing test quality and coverage (`agent_s3.tools.test_critic`)

--- a/STORIES.md
+++ b/STORIES.md
@@ -2,6 +2,9 @@
 
 This document outlines common user scenarios and provides step-by-step walkthroughs for interacting with Agent-S3, based on the actual implementation in the `agent_s3` Python package and the `vscode` extension.
 
+Together with `README.md`, this file constitutes the canonical documentation for
+Agent-S3. Refer to both documents for a complete understanding of the project.
+
 ## Story 1: Initializing Agent-S3 in a New Workspace
 
 **Goal:** Set up Agent-S3 for the first time in a project workspace and authenticate with GitHub.

--- a/agent_s3/__init__.py
+++ b/agent_s3/__init__.py
@@ -12,6 +12,7 @@ from agent_s3.tech_stack_detector import TechStackDetector
 from agent_s3.file_history_analyzer import FileHistoryAnalyzer
 from agent_s3.task_resumer import TaskResumer
 from agent_s3.command_processor import CommandProcessor
+from agent_s3.database_manager import DatabaseManager
 
 __all__ = [
     'Coordinator',
@@ -20,4 +21,5 @@ __all__ = [
     'FileHistoryAnalyzer',
     'TaskResumer',
     'CommandProcessor',
+    'DatabaseManager',
 ]

--- a/agent_s3/command_processor.py
+++ b/agent_s3/command_processor.py
@@ -943,7 +943,7 @@ Type /help <command> for more information on a specific command."""
         Returns:
             Command result message
         """
-        if not hasattr(self.coordinator, 'database_tool') or not self.coordinator.database_tool:
+        if not hasattr(self.coordinator, 'database_manager') or not self.coordinator.database_manager:
             return "Database tool is not available."
 
         # Parse db_command from args
@@ -1013,7 +1013,7 @@ Type /help <command> for more information on a specific command."""
             db_configs = self.coordinator.config.config.get("databases", {})
             for db_name in db_configs:
                 result += f"\n=== Schema for {db_name} database ===\n"
-                schema_result = self.coordinator.database_tool.get_schema_info(db_name)
+                schema_result = self.coordinator.database_manager.database_tool.get_schema_info(db_name)
                 if schema_result.get("success", False):
                     schema = schema_result.get("schema", {})
                     for table, columns in schema.items():
@@ -1025,7 +1025,7 @@ Type /help <command> for more information on a specific command."""
                     result += f"Error: {schema_result.get('error', 'Unknown error')}\n"
         else:
             # Show schema for specific database
-            schema_result = self.coordinator.database_tool.get_schema_info(db_name)
+            schema_result = self.coordinator.database_manager.database_tool.get_schema_info(db_name)
             if schema_result.get("success", False):
                 schema = schema_result.get("schema", {})
                 for table, columns in schema.items():
@@ -1047,14 +1047,14 @@ Type /help <command> for more information on a specific command."""
             db_configs = self.coordinator.config.config.get("databases", {})
             for db_name in db_configs:
                 result += f"Testing connection to {db_name}...\n"
-                test_result = self.coordinator.database_tool.test_connection(db_name)
+                test_result = self.coordinator.database_manager.setup_database(db_name)
                 if test_result.get("success", False):
                     result += f"  Success: {test_result.get('message', 'Connection successful')}\n"
                 else:
                     result += f"  Failed: {test_result.get('error', 'Unknown error')}\n"
         else:
             # Test specific database connection
-            test_result = self.coordinator.database_tool.test_connection(db_name)
+            test_result = self.coordinator.database_manager.setup_database(db_name)
             if test_result.get("success", False):
                 result += f"Connection to {db_name} successful: {test_result.get('message', 'Connection successful')}\n"
             else:
@@ -1071,7 +1071,7 @@ Type /help <command> for more information on a specific command."""
         sql = parts[1]
 
         result = f"Executing query on {db_name}...\n"
-        query_result = self.coordinator.database_tool.execute_query(sql, db_name=db_name)
+        query_result = self.coordinator.database_manager.execute_query(sql, db_name=db_name)
         if query_result.get("success", False):
             result += "\nQuery Results:\n"
             results = query_result.get("results", [])
@@ -1106,7 +1106,7 @@ Type /help <command> for more information on a specific command."""
             return f"Script file not found: {script_path}"
 
         result = f"Executing script on {db_name}...\n"
-        script_result = self.coordinator.database_tool.execute_script(script_path, db_name=db_name)
+        script_result = self.coordinator.database_manager.run_migration(script_path, db_name=db_name)
         if script_result.get("success", False):
             result += f"Script executed successfully: {script_result.get('queries_executed', 0)} queries executed\n"
         else:
@@ -1123,7 +1123,7 @@ Type /help <command> for more information on a specific command."""
         sql = parts[1]
 
         result = f"Explaining query on {db_name}...\n"
-        explain_result = self.coordinator.database_tool.explain_query(sql, db_name=db_name)
+        explain_result = self.coordinator.database_manager.database_tool.explain_query(sql, db_name=db_name)
         if explain_result.get("success", False):
             result += "\nQuery Execution Plan:\n"
             plan = explain_result.get("plan", [])

--- a/agent_s3/database_manager.py
+++ b/agent_s3/database_manager.py
@@ -1,0 +1,40 @@
+"""High level database operations using DatabaseTool."""
+
+from typing import Optional, Dict, Any
+
+from agent_s3.tools.database_tool import DatabaseTool
+
+
+class DatabaseManager:
+    """Wrapper around :class:`DatabaseTool` providing higher level operations."""
+
+    def __init__(self, coordinator=None, database_tool: Optional[DatabaseTool] = None) -> None:
+        self.coordinator = coordinator
+        self.database_tool = database_tool or getattr(coordinator, "database_tool", None)
+        self.scratchpad = getattr(coordinator, "scratchpad", None)
+
+    def _log(self, message: str) -> None:
+        if self.scratchpad:
+            self.scratchpad.log("DatabaseManager", message)
+
+    def setup_database(self, db_name: str = "default") -> Dict[str, Any]:
+        """Verify and prepare the given database."""
+        if not self.database_tool:
+            return {"success": False, "error": "Database tool not available"}
+        self._log(f"Setting up database {db_name}")
+        return self.database_tool.test_connection(db_name)
+
+    def run_migration(self, script_path: str, db_name: str = "default") -> Dict[str, Any]:
+        """Run a SQL migration script using ``DatabaseTool``."""
+        if not self.database_tool:
+            return {"success": False, "error": "Database tool not available"}
+        self._log(f"Running migration {script_path} on {db_name}")
+        return self.database_tool.execute_script(script_path, db_name=db_name)
+
+    def execute_query(self, sql: str, db_name: str = "default") -> Dict[str, Any]:
+        """Execute a SQL query."""
+        if not self.database_tool:
+            return {"success": False, "error": "Database tool not available"}
+        self._log(f"Executing query on {db_name}")
+        return self.database_tool.execute_query(sql, db_name=db_name)
+

--- a/agent_s3/prompt_moderator.py
+++ b/agent_s3/prompt_moderator.py
@@ -960,6 +960,24 @@ Focus on explaining the "why" behind the decisions, not just describing what's i
                 self.scratchpad.log("Moderator", "Free-form modification received, no apparent structure")
             return "\n".join(lines)
 
+    def request_debugging_guidance(self, group_name: str, max_attempts: int) -> Optional[str]:
+        """Request engineer guidance when automated debugging fails.
+
+        Args:
+            group_name: Name of the feature group that failed.
+            max_attempts: Number of automated attempts that were made.
+
+        Returns:
+            Modification text provided by the engineer, or None to abort.
+        """
+        question = (
+            f"Implementation for {group_name} failed after {max_attempts} attempts. "
+            "Would you like to provide modifications before retrying?"
+        )
+        if self.ask_yes_no_question(question):
+            return self.ask_for_modification("Enter your modifications:")
+        return None
+
     def show_code_snippet(self, snippet: str, title: str = "Code Snippet") -> None:
         """Display a code snippet with proper formatting.
         

--- a/test_analysis_recommendations.md
+++ b/test_analysis_recommendations.md
@@ -161,7 +161,7 @@ The agent-s3 project has a substantial test suite covering various components an
 1. **Task Execution Workflow:**
    - **Pre-Planning Phase:**
      - No tests for the complexity threshold branch where /design is suggested
-     - Exception handling in _execute_pre_planning_phase isn't fully tested
+    - Exception handling in the pre-planning integration isn't fully tested
    - **Planning Phase:**
      - Missing tests for when Planner.generate_plan returns failure
      - No handling if test_planner.plan_tests returns success=False

--- a/tests/integration/test_enforced_json_coordinator_integration.py
+++ b/tests/integration/test_enforced_json_coordinator_integration.py
@@ -114,7 +114,8 @@ class TestEnforcedJsonCoordinatorIntegration:
             coordinator.code_analysis_tool = MagicMock()
             coordinator.embedding_client = MagicMock()
             coordinator.memory_manager = MagicMock()
-            coordinator.database_tool = MagicMock()
+            coordinator.database_manager = MagicMock()
+            coordinator.database_manager.database_tool = MagicMock()
             coordinator.env_tool = MagicMock()
             coordinator.test_frameworks = MagicMock()
             coordinator.test_critic = MagicMock()
@@ -137,113 +138,50 @@ class TestEnforcedJsonCoordinatorIntegration:
             
             yield coordinator
 
-    def test_execute_pre_planning_phase_with_enforced_json(self, mock_coordinator):
-        """Test that coordinator correctly uses enforced JSON pre-planning when enabled."""
-        # Execute pre-planning with a test task
-        task_description = "Implement user authentication system"
-        result = mock_coordinator._execute_pre_planning_phase(task_description)
-        
-        # Verify results
+    def test_pre_planning_with_enforced_json(self, mock_coordinator):
+        """Test that enforced JSON integration works."""
+        with patch(
+            "agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json"
+        ) as mock_call:
+            mock_call.return_value = (
+                True,
+                {
+                    "original_request": "Implement user authentication system",
+                    "feature_groups": [],
+                    "complexity_score": 50.0,
+                },
+            )
+
+            result = integrate_with_coordinator(
+                mock_coordinator, "Implement user authentication system"
+            )
+
         assert result["success"] is True
-        assert result["status"] == "completed"
-        assert "uses_enforced_json" in result
         assert result["uses_enforced_json"] is True
-        
-        # Verify the call to router_agent was made
-        mock_coordinator.router_agent.call_llm_by_role.assert_called_once()
-        
-        # Verify progress tracker was updated
-        mock_coordinator.progress_tracker.update_progress.assert_called()
-        
-        # Extract the first update_progress call arguments
-        first_call_args = mock_coordinator.progress_tracker.update_progress.call_args_list[0][0][0]
-        
-        # Verify pre-planning was started
-        assert first_call_args["phase"] == "pre_planning"
-        assert first_call_args["status"] == "started"
-        
-        # Extract the second update_progress call arguments
-        second_call_args = mock_coordinator.progress_tracker.update_progress.call_args_list[1][0][0]
-        
-        # Verify pre-planning was completed
-        assert second_call_args["phase"] == "pre_planning"
-        assert second_call_args["status"] == "completed"
-        assert second_call_args["json_formatted"] is True
-        assert second_call_args["enforced_json"] is True
+        mock_call.assert_called_once_with(
+            mock_coordinator.router_agent, "Implement user authentication system"
+        )
 
     @patch('agent_s3.pre_planner_json_enforced.integrate_with_coordinator')
     def test_coordinator_fallback_to_standard_json(self, mock_integrate, mock_coordinator):
-        """Test that coordinator falls back to standard JSON when enforced JSON fails."""
-        # Make enforced JSON fail
+        """Test that an error is raised when enforced JSON fails."""
         mock_integrate.side_effect = Exception("Enforced JSON failed")
-        
-        # Setup standard JSON to succeed
-        with patch('agent_s3.pre_planner_json.integrate_with_pre_planning_manager') as mock_standard_json:
-            mock_standard_json.return_value = {
-                "status": "completed",
-                "success": True,
-                "complexity_score": 50.0,
-                "json_formatted": True
-            }
-            
-            # Enable standard JSON as fallback
-            mock_coordinator.config.config["use_json_pre_planning"] = True
-            
-            # Execute pre-planning
-            result = mock_coordinator._execute_pre_planning_phase("Test task")
-            
-            # Verify standard JSON was used as fallback
-            assert result["success"] is True
-            assert result["status"] == "completed"
-            assert "uses_enforced_json" not in result
-            assert mock_standard_json.called
-            
-            # Verify progress tracker was updated with fallback info
-            second_call_args = mock_coordinator.progress_tracker.update_progress.call_args_list[1][0][0]
-            assert second_call_args["json_formatted"] is True
-            assert not second_call_args.get("enforced_json", False)
+
+        with pytest.raises(Exception):
+            integrate_with_coordinator(mock_coordinator, "Test task")
 
     @patch('agent_s3.pre_planner_json_enforced.integrate_with_coordinator')
     @patch('agent_s3.pre_planner_json.integrate_with_pre_planning_manager')
     def test_coordinator_fallback_to_standard_planning(self, mock_standard_json, mock_enforced_json, mock_coordinator):
-        """Test that coordinator falls back to standard planning when both JSON formats fail."""
-        # Make both JSON formats fail
+        """Test that errors propagate when all integrations fail."""
         mock_enforced_json.side_effect = Exception("Enforced JSON failed")
         mock_standard_json.side_effect = Exception("Standard JSON failed")
-        
-        # Setup mocks for standard planning
-        mock_coordinator.pre_planner.collect_impacted_files.return_value = ["file1.py", "file2.py"]
-        mock_coordinator.pre_planner.estimate_complexity_from_request.return_value = {"risk": "medium"}
-        mock_coordinator.pre_planner.get_complexity_breakdown.return_value = {
-            "total_lines": 100, 
-            "total_branches": 20
-        }
-        mock_coordinator.pre_planner.identify_test_requirements.return_value = ["Test requirement 1"]
-        mock_coordinator.pre_planner.analyze_dependencies.return_value = {"internal": ["dep1"]}
-        
-        # Enable both JSON formats to test complete fallback
+
         mock_coordinator.config.config["use_json_pre_planning"] = True
         mock_coordinator.config.config["use_enforced_json_pre_planning"] = True
-        
-        # Execute pre-planning
-        result = mock_coordinator._execute_pre_planning_phase("Test task")
-        
-        # Verify standard planning was used
-        assert result["success"] is True
-        assert result["status"] == "completed"
-        assert "impacted_files" in result
-        assert "complexity_score" in result
-        assert "test_requirements" in result
-        assert "dependencies" in result
-        
-        # Verify both JSON methods were attempted
-        assert mock_enforced_json.called
-        assert mock_standard_json.called
-        
-        # Verify standard pre-planning methods were called
-        assert mock_coordinator.pre_planner.collect_impacted_files.called
-        assert mock_coordinator.pre_planner.estimate_complexity_from_request.called
-        assert mock_coordinator.pre_planner.get_complexity_breakdown.called
+
+        with pytest.raises(Exception):
+            integrate_with_coordinator(mock_coordinator, "Test task")
 
     @patch('agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json')
     def test_direct_integration_with_coordinator(self, mock_call, mock_coordinator):

--- a/tests/test_advanced_workflows.py
+++ b/tests/test_advanced_workflows.py
@@ -104,7 +104,8 @@ def mock_coordinator(setup_test_files):
     with patch('agent_s3.coordinator.Config') as mock_config_cls, \
          patch('agent_s3.coordinator.EnhancedScratchpadManager') as mock_scratchpad_cls, \
          patch('agent_s3.coordinator.ProgressTracker') as mock_progress_tracker_cls, \
-         patch('agent_s3.coordinator.PrePlanningManager') as mock_pre_planner_cls, \
+         patch('agent_s3.pre_planner_json_enforced.pre_planning_workflow') as mock_pre_planning_workflow, \
+         patch('agent_s3.pre_planner_json_enforced.regenerate_pre_planning_with_modifications') as mock_regen_pre_planning, \
          patch('agent_s3.coordinator.Planner') as mock_planner_cls, \
          patch('agent_s3.coordinator.CodeGenerator') as mock_code_generator_cls, \
          patch('agent_s3.coordinator.PromptModerator') as mock_prompt_moderator_cls, \
@@ -129,7 +130,6 @@ def mock_coordinator(setup_test_files):
         # Set up other mocks
         mock_scratchpad = MagicMock()
         mock_progress_tracker = MagicMock()
-        mock_pre_planner = MagicMock()
         mock_planner = MagicMock()
         mock_code_generator = MagicMock()
         mock_prompt_moderator = MagicMock()
@@ -139,7 +139,6 @@ def mock_coordinator(setup_test_files):
         # Set up class return values
         mock_scratchpad_cls.return_value = mock_scratchpad
         mock_progress_tracker_cls.return_value = mock_progress_tracker
-        mock_pre_planner_cls.return_value = mock_pre_planner
         mock_planner_cls.return_value = mock_planner
         mock_code_generator_cls.return_value = mock_code_generator
         mock_prompt_moderator_cls.return_value = mock_prompt_moderator
@@ -150,11 +149,37 @@ def mock_coordinator(setup_test_files):
         mock_dirname.return_value = test_dir
         
         # Default pre-planning setup
-        mock_pre_planner.collect_impacted_files.return_value = [
-            f"{test_dir}/data_processor.py",
-            f"{test_dir}/auth_service.py"
-        ]
-        mock_pre_planner.estimate_complexity.return_value = 65.0
+        pre_plan_data = {
+            "original_request": "",
+            "feature_groups": [
+                {
+                    "group_name": "fg",
+                    "features": [
+                        {
+                            "name": "feat",
+                            "description": "",
+                            "files_affected": [
+                                f"{test_dir}/data_processor.py",
+                                f"{test_dir}/auth_service.py",
+                            ],
+                            "test_requirements": {
+                                "unit_tests": [],
+                                "integration_tests": [],
+                                "property_based_tests": [],
+                                "acceptance_tests": [],
+                                "test_strategy": {},
+                            },
+                            "dependencies": {},
+                        }
+                    ],
+                }
+            ],
+            "complexity_score": 65.0,
+            "complexity_breakdown": {},
+            "is_complex": False,
+        }
+        mock_pre_planning_workflow.return_value = (True, pre_plan_data)
+        mock_regen_pre_planning.return_value = pre_plan_data
         
         # Create coordinator with mocks
         coordinator = Coordinator(config=mock_config)
@@ -168,7 +193,8 @@ def mock_coordinator(setup_test_files):
         yield coordinator, {
             'scratchpad': mock_scratchpad,
             'progress_tracker': mock_progress_tracker,
-            'pre_planner': mock_pre_planner,
+            'pre_planning_workflow': mock_pre_planning_workflow,
+            'regenerate_pre_planning_with_modifications': mock_regen_pre_planning,
             'planner': mock_planner,
             'code_generator': mock_code_generator,
             'prompt_moderator': mock_prompt_moderator,
@@ -193,7 +219,9 @@ class TestRefactoringWorkflows:
         # Target file in the test directory
         test_dir = mocks['test_dir']
         target_file = f"{test_dir}/data_processor.py"
-        mocks['pre_planner'].collect_impacted_files.return_value = [target_file]
+        pre_plan = mocks['pre_planning_workflow'].return_value[1].copy()
+        pre_plan['feature_groups'][0]['features'][0]['files_affected'] = [target_file]
+        mocks['pre_planning_workflow'].return_value = (True, pre_plan)
         
         # Execute task
         task_description = "Optimize the data processing code for better performance"
@@ -256,7 +284,9 @@ class TestDebuggingWorkflows:
         # Target file in the test directory
         test_dir = mocks['test_dir']
         target_file = f"{test_dir}/auth_service.py"
-        mocks['pre_planner'].collect_impacted_files.return_value = [target_file]
+        pre_plan = mocks['pre_planning_workflow'].return_value[1].copy()
+        pre_plan['feature_groups'][0]['features'][0]['files_affected'] = [target_file]
+        mocks['pre_planning_workflow'].return_value = (True, pre_plan)
         
         # Set up error context for debugging
         mocks['error_context'].collect_error_context.return_value = {

--- a/tests/test_coordinator_json_preplanning.py
+++ b/tests/test_coordinator_json_preplanning.py
@@ -17,97 +17,43 @@ class TestCoordinatorJsonPrePlanning:
     """Tests for the coordinator's pre-planning functionality with JSON enforcement."""
     
     @patch('agent_s3.pre_planner_json_enforced.integrate_with_coordinator')
-    @patch('agent_s3.pre_planner_json.integrate_with_pre_planning_manager')
-    def test_execute_pre_planning_phase_prioritizes_enforced_json(self, mock_std_json, mock_enforced_json):
-        """Test that coordinator prioritizes enforced JSON when both are enabled."""
-        # Setup for the test
+    def test_pre_planning_prioritizes_enforced_json(self, mock_enforced_json):
+        """Test that enforced JSON integration is used."""
         coordinator = MagicMock()
         coordinator.config = MagicMock()
         coordinator.config.config = {
             "use_enforced_json_pre_planning": True,
-            "use_json_pre_planning": True  # Both enabled
+            "use_json_pre_planning": True
         }
-        coordinator.scratchpad = MagicMock()
-        coordinator.progress_tracker = MagicMock()
-        coordinator.pre_planner = MagicMock()
-        
-        # Mock the enforced JSON integration to return success
+
         mock_enforced_json.return_value = {
             "status": "completed",
             "success": True,
             "complexity_score": 50,
-            "uses_enforced_json": True
+            "uses_enforced_json": True,
         }
-        
-        # Original method to intercept to avoid testing everything
-        original_method = Coordinator._execute_pre_planning_phase
-        
-        try:
-            # Mock the pre-planning method to call our implementation
-            task_description = "Test task"
-            result = original_method(coordinator, task_description)
-            
-            # Verify that enforced JSON was called and standard JSON was not
-            mock_enforced_json.assert_called_once()
-            mock_std_json.assert_not_called()
-            
-            # Verify the result
-            assert result.get("status") == "completed"
-            assert result.get("success") is True
-            assert result.get("uses_enforced_json") is True
-            
-        except Exception as e:
-            # Restore original method and re-raise if there's an error
-            pytest.fail(f"Test failed: {str(e)}")
+
+        result = integrate_with_coordinator(coordinator, "Test task")
+
+        mock_enforced_json.assert_called_once()
+        assert result.get("status") == "completed"
+        assert result.get("success") is True
+        assert result.get("uses_enforced_json") is True
     
     @patch('agent_s3.pre_planner_json_enforced.integrate_with_coordinator')
-    @patch('agent_s3.pre_planner_json.integrate_with_pre_planning_manager')
-    def test_fallback_to_standard_json_when_enforced_fails(self, mock_std_json, mock_enforced_json):
-        """Test that coordinator falls back to standard JSON when enforced JSON fails."""
-        # Setup for the test
+    def test_fallback_to_standard_json_when_enforced_fails(self, mock_enforced_json):
+        """Test that errors propagate when enforced JSON fails."""
         coordinator = MagicMock()
         coordinator.config = MagicMock()
         coordinator.config.config = {
             "use_enforced_json_pre_planning": True,
-            "use_json_pre_planning": True  # Both enabled
+            "use_json_pre_planning": True,
         }
-        coordinator.scratchpad = MagicMock()
-        coordinator.progress_tracker = MagicMock()
-        coordinator.pre_planner = MagicMock()
-        
-        # Make enforced JSON fail
+
         mock_enforced_json.side_effect = Exception("Enforced JSON failed")
-        
-        # Make standard JSON succeed
-        mock_std_json.return_value = {
-            "status": "completed",
-            "success": True,
-            "complexity_score": 50,
-            "json_formatted": True
-        }
-        
-        # Original method to patch
-        original_method = Coordinator._execute_pre_planning_phase
-        
-        try:
-            # Mock the pre-planning method to call our implementation
-            task_description = "Test task"
-            result = original_method(coordinator, task_description)
-            
-            # Verify that enforced JSON was attempted
-            mock_enforced_json.assert_called_once()
-            
-            # Verify that standard JSON was used as fallback
-            mock_std_json.assert_called_once()
-            
-            # Verify the result
-            assert result.get("status") == "completed"
-            assert result.get("success") is True
-            assert result.get("json_formatted") is True
-            
-        except Exception as e:
-            # Re-raise if there's an error
-            pytest.fail(f"Test failed: {str(e)}")
+
+        with pytest.raises(Exception):
+            integrate_with_coordinator(coordinator, "Test task")
     
     @patch('agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json')
     def test_direct_integration_function(self, mock_call):
@@ -232,67 +178,63 @@ class TestCoordinatorJsonPrePlanning:
         assert "approval_baseline" in result["test_requirements"]
         assert result["test_requirements"]["approval_baseline"] == ["Baseline test"]
 
-    def test_execute_pre_planning_phase_with_updated_complexity(self):
-        """Test that updated complexity scoring is reflected in JSON pre-planning."""
-        # Setup for the test
+    def test_pre_planning_with_updated_complexity(self):
+        """Test that complexity scoring is reflected in results."""
         coordinator = MagicMock()
         coordinator.config = MagicMock()
         coordinator.config.config = {
             "use_enforced_json_pre_planning": True,
-            "use_json_pre_planning": True
+            "use_json_pre_planning": True,
         }
         coordinator.pre_planner.assess_complexity.return_value = {
             "score": 60,
-            "is_complex": True
+            "is_complex": True,
         }
 
-        # Mock enforced JSON integration
-        with patch('agent_s3.pre_planner_json_enforced.integrate_with_coordinator') as mock_enforced_json:
-            mock_enforced_json.return_value = {
-                "status": "completed",
-                "success": True,
-                "complexity_score": 60,
-                "uses_enforced_json": True
-            }
+        with patch(
+            'agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json'
+        ) as mock_call:
+            mock_call.return_value = (
+                True,
+                {
+                    "original_request": "Test task",
+                    "feature_groups": [],
+                    "complexity_score": 60,
+                },
+            )
 
-            # Execute
-            result = coordinator._execute_pre_planning_phase("Test task")
+            result = integrate_with_coordinator(coordinator, "Test task")
 
-            # Verify
-            assert result["success"] is True
-            assert result["complexity_score"] == 60
-            mock_enforced_json.assert_called_once()
+        assert result["success"] is True
+        assert result["complexity_score"] == 60
+        mock_call.assert_called_once_with(coordinator.router_agent, "Test task")
 
-    def test_execute_pre_planning_phase_with_caching(self):
-        """Test that caching is applied to pre-planning phase."""
-        # Setup for the test
+    def test_pre_planning_with_repeated_calls(self):
+        """Test repeated integration calls."""
         coordinator = MagicMock()
         coordinator.config = MagicMock()
         coordinator.config.config = {
             "use_enforced_json_pre_planning": True,
-            "use_json_pre_planning": True
+            "use_json_pre_planning": True,
         }
-        coordinator.pre_planner.collect_impacted_files = MagicMock()
-        coordinator.pre_planner.collect_impacted_files.return_value = ["file1.py", "file2.py"]
 
-        # Mock enforced JSON integration
-        with patch('agent_s3.pre_planner_json_enforced.integrate_with_coordinator') as mock_enforced_json:
-            mock_enforced_json.return_value = {
-                "status": "completed",
-                "success": True,
-                "complexity_score": 60,
-                "uses_enforced_json": True
-            }
+        with patch(
+            'agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json'
+        ) as mock_call:
+            mock_call.return_value = (
+                True,
+                {
+                    "original_request": "Test task",
+                    "feature_groups": [],
+                    "complexity_score": 60,
+                },
+            )
 
-            # Execute twice to test caching
-            result1 = coordinator._execute_pre_planning_phase("Test task")
-            result2 = coordinator._execute_pre_planning_phase("Test task")
+            result1 = integrate_with_coordinator(coordinator, "Test task")
+            result2 = integrate_with_coordinator(coordinator, "Test task")
 
-            # Verify
-            assert result1["success"] is True
-            assert result2["success"] is True
-            coordinator.pre_planner.collect_impacted_files.assert_called_once()  # Cached result used
-            mock_enforced_json.assert_called_once()
+        assert result1 == result2
+        assert mock_call.call_count == 2
 
 
 if __name__ == "__main__":

--- a/tests/test_coordinator_phases.py
+++ b/tests/test_coordinator_phases.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, patch
 from agent_s3.coordinator import Coordinator
 from agent_s3.config import Config
 from agent_s3.enhanced_scratchpad_manager import LogLevel
+from agent_s3.pre_planner_json_enforced import integrate_with_coordinator
 
 # Test fixtures
 
@@ -61,6 +62,7 @@ def coordinator(mock_config):
         coordinator.file_tool = MagicMock()
         coordinator.error_context_manager = MagicMock()
         coordinator.debugging_manager = MagicMock()
+        coordinator.router_agent = MagicMock()
         
         yield coordinator
 
@@ -154,199 +156,172 @@ def test_initialize_workspace_exception(coordinator):
         assert result["errors"][0]["type"] == "exception"
         coordinator.workspace_initializer.initialize_workspace.assert_called_once()
 
-# Test _execute_pre_planning_phase method
+# Test pre-planning integration
 
 def test_pre_planning_phase_normal_flow(coordinator):
-    """Test normal flow of pre-planning phase."""
-    # Set up mocks
-    coordinator.pre_planner.collect_impacted_files.return_value = ["file1.py", "file2.py"]
-    coordinator.pre_planner.estimate_complexity.return_value = 150.0
-    coordinator.prompt_moderator.ask_binary_question.return_value = False  # Don't switch to design
-    
-    # Execute
-    result = coordinator._execute_pre_planning_phase("Add feature X")
-    
-    # Assert
+    """Test normal flow of pre-planning phase using the new workflow."""
+    coordinator.pre_planner.assess_complexity.return_value = {
+        "score": 150.0,
+        "is_complex": False,
+    }
+    with patch(
+        "agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json"
+    ) as mock_call:
+        mock_call.return_value = (
+            True,
+            {"original_request": "Add feature X", "feature_groups": [], "complexity_score": 150.0},
+        )
+
+        result = integrate_with_coordinator(coordinator, "Add feature X")
+
     assert result["success"] is True
     assert result["status"] == "completed"
-    assert result["switch_workflow"] is False
-    assert len(result["impacted_files"]) == 2
+    assert result["is_complex"] is False
     assert result["complexity_score"] == 150.0
-    coordinator.pre_planner.collect_impacted_files.assert_called_once()
-    coordinator.pre_planner.estimate_complexity.assert_called_once()
+    mock_call.assert_called_once_with(coordinator.router_agent, "Add feature X")
+    coordinator.pre_planner.assess_complexity.assert_called_once()
 
 def test_pre_planning_phase_high_complexity(coordinator):
-    """Test pre-planning phase with high complexity leading to workflow switch."""
-    # Set up mocks
-    coordinator.pre_planner.collect_impacted_files.return_value = ["file1.py", "file2.py", "file3.py", "file4.py"]
-    coordinator.pre_planner.estimate_complexity.return_value = 400.0  # Above threshold
-    coordinator.prompt_moderator.ask_binary_question.return_value = True  # Switch to design
-    
-    # Execute
-    result = coordinator._execute_pre_planning_phase("Refactor module Y")
-    
-    # Assert
+    """Test pre-planning phase identifies complex tasks."""
+    coordinator.pre_planner.assess_complexity.return_value = {
+        "score": 400.0,
+        "is_complex": True,
+    }
+    with patch(
+        "agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json"
+    ) as mock_call:
+        mock_call.return_value = (
+            True,
+            {"original_request": "Refactor module Y", "feature_groups": [], "complexity_score": 400.0},
+        )
+
+        result = integrate_with_coordinator(coordinator, "Refactor module Y")
+
     assert result["success"] is True
     assert result["status"] == "completed"
-    assert result["switch_workflow"] is True
-    assert result["workflow"] == "design"
-    assert len(result["impacted_files"]) == 4
+    assert result["is_complex"] is True
     assert result["complexity_score"] == 400.0
-    coordinator.pre_planner.collect_impacted_files.assert_called_once()
-    coordinator.pre_planner.estimate_complexity.assert_called_once()
-    coordinator.prompt_moderator.ask_binary_question.assert_called_once()
+    mock_call.assert_called_once_with(coordinator.router_agent, "Refactor module Y")
+    coordinator.pre_planner.assess_complexity.assert_called_once()
 
-def test_pre_planning_file_collection_error(coordinator):
-    """Test pre-planning phase with file collection error."""
-    # Set up mocks
-    coordinator.pre_planner.collect_impacted_files.side_effect = Exception("File collection error")
-    coordinator.pre_planner.estimate_complexity.return_value = 100.0  # Will use empty list
-    
-    # Execute
-    result = coordinator._execute_pre_planning_phase("Add feature Z")
-    
-    # Assert
-    assert result["success"] is True  # Still succeeds with fallback
+def test_pre_planning_assess_complexity_error(coordinator):
+    """Test assess_complexity errors are handled gracefully."""
+    coordinator.pre_planner.assess_complexity.side_effect = Exception("complexity error")
+    with patch(
+        "agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json"
+    ) as mock_call:
+        mock_call.return_value = (
+            True,
+            {"original_request": "Add feature Z", "feature_groups": [], "complexity_score": 0},
+        )
+
+        result = integrate_with_coordinator(coordinator, "Add feature Z")
+
+    assert result["success"] is True
     assert result["status"] == "completed"
-    assert "file_collection_error" in result
-    assert result["impacted_files"] == []
-    coordinator.pre_planner.collect_impacted_files.assert_called_once()
-    coordinator.pre_planner.estimate_complexity.assert_called_once_with([])
+    assert result["is_complex"] is False
+    mock_call.assert_called_once_with(coordinator.router_agent, "Add feature Z")
+    coordinator.pre_planner.assess_complexity.assert_called_once()
 
 def test_pre_planning_complexity_estimation_error(coordinator):
-    """Test pre-planning phase with complexity estimation error."""
-    # Set up mocks
-    coordinator.pre_planner.collect_impacted_files.return_value = ["file1.py", "file2.py"]
-    coordinator.pre_planner.estimate_complexity.side_effect = Exception("Complexity estimation error")
-    
-    # Execute
-    result = coordinator._execute_pre_planning_phase("Add feature W")
-    
-    # Assert
-    assert result["success"] is True  # Still succeeds with fallback
+    """Test that invalid complexity assessment does not raise."""
+    coordinator.pre_planner.assess_complexity.side_effect = Exception("boom")
+    with patch(
+        "agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json"
+    ) as mock_call:
+        mock_call.return_value = (
+            True,
+            {"original_request": "Add feature W", "feature_groups": [], "complexity_score": None},
+        )
+
+        result = integrate_with_coordinator(coordinator, "Add feature W")
+
+    assert result["success"] is True
     assert result["status"] == "completed"
-    assert "complexity_error" in result
-    assert result["complexity_estimated"] is False
-    assert result["complexity_score"] == 250  # Default value
-    coordinator.pre_planner.collect_impacted_files.assert_called_once()
-    coordinator.pre_planner.estimate_complexity.assert_called_once()
+    assert result["complexity_score"] is None
+    assert result["is_complex"] is False
+    mock_call.assert_called_once_with(coordinator.router_agent, "Add feature W")
+    coordinator.pre_planner.assess_complexity.assert_called_once()
 
 def test_pre_planning_prompt_error(coordinator):
-    """Test pre-planning phase with prompt error."""
-    # Set up mocks
-    coordinator.pre_planner.collect_impacted_files.return_value = ["file1.py", "file2.py"]
-    coordinator.pre_planner.estimate_complexity.return_value = 400.0  # Above threshold
-    coordinator.prompt_moderator.ask_binary_question.side_effect = Exception("Prompt error")
-    
-    # Execute
-    result = coordinator._execute_pre_planning_phase("Add feature V")
-    
-    # Assert
-    assert result["success"] is True  # Still succeeds
-    assert result["status"] == "completed"
-    assert result["switch_workflow"] is False  # Default to not switching
-    assert "prompt_error" in result
-    coordinator.pre_planner.collect_impacted_files.assert_called_once()
-    coordinator.pre_planner.estimate_complexity.assert_called_once()
-    coordinator.prompt_moderator.ask_binary_question.assert_called_once()
+    """Test errors from the pre-planner are surfaced."""
+    with patch(
+        "agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json",
+        side_effect=Exception("Prompt error"),
+    ):
+        with pytest.raises(Exception):
+            integrate_with_coordinator(coordinator, "Add feature V")
 
 def test_pre_planning_complete_failure(coordinator):
-    """Test pre-planning phase with complete failure."""
-    # Set up mocks for complete failure
-    coordinator.pre_planner.collect_impacted_files.side_effect = Exception("Critical error")
-    coordinator.pre_planner.estimate_complexity.side_effect = Exception("Should not be called")
-    
-    # Make sure the error propagates to the top level
-    with patch('traceback.format_exc', return_value="Mock traceback"):
-        # Execute
-        result = coordinator._execute_pre_planning_phase("Invalid query")
-        
-        # Assert
-        assert result["success"] is False
-        assert result["status"] == "error"
-        assert "error" in result
-        assert "error_context" in result
-        assert result["error_context"]["error_type"] == "Exception"
-        coordinator.pre_planner.collect_impacted_files.assert_called_once()
-        coordinator.pre_planner.estimate_complexity.assert_not_called()
-        coordinator.progress_tracker.update_progress.assert_any_call({
-            "phase": "pre_planning", 
-            "status": "error",
-            "error": result["error"]
-        })
+    """Test that failures bubble up when JSON validation fails."""
+    with patch(
+        "agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json",
+        return_value=(False, {}),
+    ):
+        with pytest.raises(Exception):
+            integrate_with_coordinator(coordinator, "Invalid query")
 
 def test_pre_planning_phase_updated_requirements(coordinator):
-    """Test pre-planning phase with updated test requirements."""
-    # Set up mocks
-    coordinator.pre_planner.collect_impacted_files.return_value = ["file1.py", "file2.py"]
-    coordinator.pre_planner.estimate_complexity.return_value = 200.0
-    coordinator.pre_planner.get_test_requirements.return_value = {
-        "unit": ["Test case 1"],
-        "integration": ["Integration test 1"],
-        "property_based": ["Property-based test 1"],
-        "acceptance": [
+    """Test pre-planning returns updated test requirements."""
+    coordinator.pre_planner.assess_complexity.return_value = {"score": 200.0, "is_complex": False}
+    with patch(
+        "agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json"
+    ) as mock_call:
+        mock_call.return_value = (
+            True,
             {
-                "given": "Condition",
-                "when": "Action",
-                "then": "Result"
-            }
-        ],
-        "approval_baseline": ["Baseline test"]
-    }
+                "original_request": "Add feature X",
+                "feature_groups": [],
+                "test_requirements": {"approval_baseline": ["Baseline test"]},
+                "complexity_score": 200.0,
+            },
+        )
 
-    # Execute
-    result = coordinator._execute_pre_planning_phase("Add feature X")
+        result = integrate_with_coordinator(coordinator, "Add feature X")
 
-    # Assert
     assert result["success"] is True
     assert result["status"] == "completed"
     assert result["test_requirements"]["approval_baseline"] == ["Baseline test"]
-    coordinator.pre_planner.collect_impacted_files.assert_called_once()
-    coordinator.pre_planner.estimate_complexity.assert_called_once()
-    coordinator.pre_planner.get_test_requirements.assert_called_once()
+    mock_call.assert_called_once_with(coordinator.router_agent, "Add feature X")
+    coordinator.pre_planner.assess_complexity.assert_called_once()
 
 def test_pre_planning_phase_updated_complexity(coordinator):
-    """Test pre-planning phase with updated complexity scoring."""
-    # Set up mocks
-    coordinator.pre_planner.collect_impacted_files.return_value = ["file1.py", "file2.py", "file3.py"]
-    coordinator.pre_planner.assess_complexity.return_value = {
-        "score": 55,
-        "is_complex": True
-    }
-    coordinator.prompt_moderator.ask_binary_question.return_value = True  # Switch to design
+    """Test updated complexity scoring is returned."""
+    coordinator.pre_planner.assess_complexity.return_value = {"score": 55, "is_complex": True}
+    with patch(
+        "agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json"
+    ) as mock_call:
+        mock_call.return_value = (
+            True,
+            {"original_request": "Add feature X", "feature_groups": [], "complexity_score": 55},
+        )
 
-    # Execute
-    result = coordinator._execute_pre_planning_phase("Add feature X")
+        result = integrate_with_coordinator(coordinator, "Add feature X")
 
-    # Assert
     assert result["success"] is True
     assert result["status"] == "completed"
-    assert result["switch_workflow"] is True
-    assert result["workflow"] == "design"
+    assert result["is_complex"] is True
     assert result["complexity_score"] == 55
-    coordinator.pre_planner.collect_impacted_files.assert_called_once()
+    mock_call.assert_called_once_with(coordinator.router_agent, "Add feature X")
     coordinator.pre_planner.assess_complexity.assert_called_once()
 
 def test_pre_planning_phase_with_caching(coordinator):
     """Test pre-planning phase with caching applied."""
-    # Set up mocks
-    coordinator.pre_planner.collect_impacted_files.return_value = ["file1.py", "file2.py"]
-    coordinator.pre_planner.assess_complexity.return_value = {
-        "score": 55,
-        "is_complex": True
-    }
-    coordinator.prompt_moderator.ask_binary_question.return_value = True  # Switch to design
+    coordinator.pre_planner.assess_complexity.return_value = {"score": 55, "is_complex": True}
+    with patch(
+        "agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json"
+    ) as mock_call:
+        mock_call.return_value = (
+            True,
+            {"original_request": "Add feature X", "feature_groups": [], "complexity_score": 55},
+        )
 
-    # Execute twice to test caching
-    result1 = coordinator._execute_pre_planning_phase("Add feature X")
-    result2 = coordinator._execute_pre_planning_phase("Add feature X")
+        result1 = integrate_with_coordinator(coordinator, "Add feature X")
+        result2 = integrate_with_coordinator(coordinator, "Add feature X")
 
-    # Assert
-    assert result1["success"] is True
-    assert result2["success"] is True
-    assert result1 == result2  # Cached result should be identical
-    coordinator.pre_planner.collect_impacted_files.assert_called_once()  # Cached result used
-    coordinator.pre_planner.assess_complexity.assert_called_once()
+    assert result1 == result2
+    assert mock_call.call_count == 2
+    coordinator.pre_planner.assess_complexity.assert_called()
 
 # Test consolidated workflow through feature_group_processor
 
@@ -480,3 +455,23 @@ def test_feature_group_processor_error_handling(coordinator):
         "Feature group processing failed: Failed to process feature groups", 
         level=LogLevel.ERROR
     )
+
+def test_implementation_retry_requests_user_guidance(coordinator):
+    coordinator.config.config["max_attempts"] = 1
+    plan = {"plan_id": "1", "group_name": "auth"}
+
+    coordinator.code_generator.generate_code.return_value = {"auth.py": "code"}
+    coordinator._apply_changes_and_manage_dependencies = MagicMock(return_value=True)
+    coordinator._run_validation_phase.side_effect = [
+        {"success": False, "output": "fail"},
+        {"success": True},
+    ]
+    coordinator.debugging_manager.handle_error.return_value = {"success": False}
+    coordinator.prompt_moderator.request_debugging_guidance.return_value = "Fix plan"
+    coordinator.feature_group_processor.update_plan_with_modifications.return_value = plan
+
+    changes, success = coordinator._implementation_workflow([plan])
+
+    coordinator.prompt_moderator.request_debugging_guidance.assert_called_once_with("auth", 1)
+    coordinator.feature_group_processor.update_plan_with_modifications.assert_called_once_with(plan, "Fix plan")
+    assert success is True

--- a/tests/test_feature_based_workflow.py
+++ b/tests/test_feature_based_workflow.py
@@ -41,7 +41,6 @@ class TestFeatureBasedWorkflow:
         }
         
         # Mock the methods used in the new consolidated workflow
-        coordinator._execute_pre_planning_phase = MagicMock()
         coordinator._validate_pre_planning_data = MagicMock(return_value=True)
         coordinator._regenerate_pre_planning_with_modifications = MagicMock()
         coordinator._present_pre_planning_results_to_user = MagicMock(return_value=("yes", None))

--- a/tests/test_integration_run_task.py
+++ b/tests/test_integration_run_task.py
@@ -7,9 +7,40 @@ from agent_s3.coordinator import Coordinator
 
 def test_run_task_simple(monkeypatch):
     # Patch all external effects
-    monkeypatch.setattr("agent_s3.coordinator.PrePlanningManager.collect_impacted_files", lambda self, req: ["agent_s3/cli.py"])
-    monkeypatch.setattr("agent_s3.coordinator.PrePlanningManager.estimate_complexity", lambda self, files: 10.0)
-    monkeypatch.setattr("agent_s3.coordinator.PrePlanningManager.identify_arch_implications", lambda self, files: {})
+    pre_plan_data = {
+        "original_request": "Add a hello world print statement",
+        "feature_groups": [
+            {
+                "group_name": "default",
+                "features": [
+                    {
+                        "name": "hello-world",
+                        "description": "Add print statement",
+                        "files_affected": ["agent_s3/cli.py"],
+                        "test_requirements": {
+                            "unit_tests": [],
+                            "integration_tests": [],
+                            "property_based_tests": [],
+                            "acceptance_tests": [],
+                            "test_strategy": {},
+                        },
+                        "dependencies": {},
+                    }
+                ],
+            }
+        ],
+        "complexity_score": 10.0,
+        "complexity_breakdown": {},
+        "is_complex": False,
+    }
+    monkeypatch.setattr(
+        "agent_s3.pre_planner_json_enforced.pre_planning_workflow",
+        lambda router, task, context=None: (True, pre_plan_data),
+    )
+    monkeypatch.setattr(
+        "agent_s3.pre_planner_json_enforced.regenerate_pre_planning_with_modifications",
+        lambda router, results, modification_text: results,
+    )
     monkeypatch.setattr("agent_s3.coordinator.Planner.create_plan", lambda self, req: "# Plan\nDo X\n")
     monkeypatch.setattr("agent_s3.coordinator.PromptModerator.present_plan", lambda self, plan, summary: (True, plan))
     monkeypatch.setattr("agent_s3.coordinator.Planner.generate_prompt", lambda self: "Prompt")

--- a/tests/test_json_editor_bridge.py
+++ b/tests/test_json_editor_bridge.py
@@ -1,0 +1,41 @@
+import importlib.util
+import types
+import sys
+from pathlib import Path
+
+
+def load_json_editor_bridge(monkeypatch):
+    """Load json_editor_bridge module with stubbed VSCode dependencies."""
+    comm_pkg = types.ModuleType("agent_s3.communication")
+    vb_pkg = types.ModuleType("agent_s3.communication.vscode_bridge")
+    vb_pkg.VSCodeBridge = type("VSCodeBridge", (), {})
+    mpkg = types.ModuleType("agent_s3.communication.message_protocol")
+    mpkg.Message = type("Message", (), {})
+    mpkg.MessageType = type("MessageType", (), {})
+
+    monkeypatch.setitem(sys.modules, "agent_s3.communication", comm_pkg)
+    monkeypatch.setitem(sys.modules, "agent_s3.communication.vscode_bridge", vb_pkg)
+    monkeypatch.setitem(sys.modules, "agent_s3.communication.message_protocol", mpkg)
+
+    module_path = Path(__file__).resolve().parents[1] / "agent_s3" / "communication" / "json_editor_bridge.py"
+    spec = importlib.util.spec_from_file_location("agent_s3.communication.json_editor_bridge", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_path(monkeypatch):
+    mod = load_json_editor_bridge(monkeypatch)
+    path = "feature_groups[0].features[1].name"
+    components = mod.JSONPath.parse_path(path)
+    assert components == ["feature_groups", 0, "features", 1, "name"]
+
+
+def test_set_and_get_value(monkeypatch):
+    mod = load_json_editor_bridge(monkeypatch)
+    data = {}
+    mod.JSONPath.set_value(data, "a.b[0].c", 42)
+    assert data == {"a": {"b": [{"c": 42}]}}
+    value = mod.JSONPath.get_value(data, "a.b[0].c")
+    assert value == 42
+

--- a/tests/test_schema_validator.py
+++ b/tests/test_schema_validator.py
@@ -1,0 +1,41 @@
+import importlib.util
+from pathlib import Path
+from pydantic import BaseModel
+
+
+module_path = Path(__file__).resolve().parents[1] / "agent_s3" / "schema_validator.py"
+spec = importlib.util.spec_from_file_location("schema_validator", module_path)
+schema_validator = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(schema_validator)
+
+
+def test_extract_json_from_code_block():
+    text = "Here is data:\n```json\n{\"a\": 1}\n```"
+    result = schema_validator.extract_json(text)
+    assert result == {"a": 1}
+
+
+def test_extract_json_from_braces():
+    text = "prefix {\"b\": 2} suffix"
+    result = schema_validator.extract_json(text)
+    assert result == {"b": 2}
+
+
+def test_validate_llm_response_success():
+    class Simple(BaseModel):
+        foo: int
+
+    success, model_or_error = schema_validator.validate_llm_response("{\"foo\": 5}", Simple)
+    assert success is True
+    assert isinstance(model_or_error, Simple)
+    assert model_or_error.foo == 5
+
+
+def test_validate_llm_response_failure():
+    class Simple(BaseModel):
+        foo: int
+
+    success, error = schema_validator.validate_llm_response("not json", Simple)
+    assert success is False
+    assert isinstance(error, str)
+

--- a/tests/test_signature_normalizer.py
+++ b/tests/test_signature_normalizer.py
@@ -1,0 +1,117 @@
+import importlib.util
+import types
+import sys
+from pathlib import Path
+import copy
+
+
+def load_signature_normalizer(monkeypatch):
+    """Load signature_normalizer module with stubbed dependencies."""
+    # Stub plan_validator.validate_code_syntax to avoid heavy imports
+    pv_stub = types.ModuleType("agent_s3.tools.plan_validator")
+    pv_stub.validate_code_syntax = lambda signature, language=None: True
+
+    # Create minimal package structure
+    pkg = types.ModuleType("agent_s3")
+    pkg.tools = types.ModuleType("agent_s3.tools")
+    monkeypatch.setitem(sys.modules, "agent_s3", pkg)
+    monkeypatch.setitem(sys.modules, "agent_s3.tools", pkg.tools)
+    monkeypatch.setitem(sys.modules, "agent_s3.tools.plan_validator", pv_stub)
+
+    module_path = Path(__file__).resolve().parents[1] / "agent_s3" / "signature_normalizer.py"
+    spec = importlib.util.spec_from_file_location("signature_normalizer", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_normalize_pre_plan_basic(monkeypatch):
+    sn_module = load_signature_normalizer(monkeypatch)
+    SignatureNormalizer = sn_module.SignatureNormalizer
+
+    pre_plan = {
+        "feature_groups": [
+            {
+                "group_name": "Group A",
+                "features": [
+                    {
+                        "name": "AwesomeFeature",
+                        "system_design": {
+                            "code_elements": [
+                                {
+                                    "name": "FirstFunc",
+                                    "element_type": "function",
+                                    "element_id": "FirstID!",
+                                    "target_file": "src/Utilities/FirstFunc.py",
+                                    "signature": "def FirstFunc(arg)"
+                                },
+                                {
+                                    "name": "SecondFunc",
+                                    "element_type": "function",
+                                    "signature": "",
+                                    "target_file": "",
+                                    "element_id": ""
+                                }
+                            ]
+                        },
+                        "test_requirements": {
+                            "unit_tests": [
+                                {"target_element": "FirstFunc"},
+                                {"target_element": "SecondFunc"}
+                            ]
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+
+    normalizer = SignatureNormalizer(".")
+    result = normalizer.normalize_pre_plan(copy.deepcopy(pre_plan))
+
+    elems = result["feature_groups"][0]["features"][0]["system_design"]["code_elements"]
+    first, second = elems[0], elems[1]
+
+    assert first["element_id"] == "firstid_"
+    assert first["target_file"].endswith("first_func.py")
+    assert first["signature"].endswith(":")
+
+    assert second["element_id"].startswith("awesomefeature_secondfunc_function")
+    assert second["target_file"] == "src/secondfunc.py"
+    assert second["signature"] == "def SecondFunc():"
+
+    unit_tests = result["feature_groups"][0]["features"][0]["test_requirements"]["unit_tests"]
+    assert unit_tests[0]["target_element_id"] == first["element_id"]
+    assert unit_tests[1]["target_element_id"] == second["element_id"]
+
+
+def test_normalize_element_id_uniqueness(monkeypatch):
+    sn_module = load_signature_normalizer(monkeypatch)
+    SignatureNormalizer = sn_module.SignatureNormalizer
+
+    pre_plan = {
+        "feature_groups": [
+            {
+                "group_name": "G",
+                "features": [
+                    {
+                        "name": "FeatureA",
+                        "system_design": {
+                            "code_elements": [
+                                {"name": "Func", "element_type": "function"},
+                                {"name": "Func", "element_type": "function"}
+                            ]
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+
+    normalizer = SignatureNormalizer(".")
+    result = normalizer.normalize_pre_plan(copy.deepcopy(pre_plan))
+    elems = result["feature_groups"][0]["features"][0]["system_design"]["code_elements"]
+
+    assert elems[0]["element_id"] == "featurea_func_function"
+    assert elems[1]["element_id"] == "featurea_func_function_1"
+

--- a/tests/test_test_critic.py
+++ b/tests/test_test_critic.py
@@ -1,53 +1,110 @@
-"""Unit tests for the TestCritic class."""
+"""Unit tests for the current TestCritic implementation.
+
+This module provides a minimal smoke test for the TestCritic class. The
+previous tests for the old ``TestCriticRunner`` have been removed.
+"""
 
 import unittest
-from unittest.mock import MagicMock, patch
 import pytest
 
-from agent_s3.tools.test_critic.core import TestCritic, TestType, TestVerdict
+import agent_s3.tools.test_critic.core as core
+from agent_s3.tools.test_critic.core import TestCritic, TestVerdict
+
 
 @pytest.fixture
 def sample_workspace(tmp_path):
     (tmp_path / "test_sample.py").write_text("def test_example(): assert True")
     return tmp_path
 
-# These tests won't work since TestCriticRunner class has been replaced with TestCritic
-# Commenting them out for now but keeping the class structure in case it needs to be reactivated
-# with updated implementation in the future
-"""
-class TestPytestAdapterIntegration:
-    def test_collect_errors(self, sample_workspace):
-        critic = TestCritic(sample_workspace)
-        result = critic.run_analysis()
-        assert "collect_errors" not in result['details'] or not result['details']['collect_errors']
-        
-    def test_smoke_run(self, sample_workspace):
-        critic = TestCritic(sample_workspace)
-        result = critic.run_analysis()
-        assert result['details']['smoke_passed'] is True
-        
-    def test_coverage_threshold(self, sample_workspace):
-        critic = TestCritic(sample_workspace)
-        result = critic.run_analysis()
-        assert result['details']['coverage_percent'] >= 80.0
-        
-    def test_mutation_threshold(self, sample_workspace):
-        critic = TestCritic(sample_workspace)
-        result = critic.run_analysis()
-        assert result['details']['mutation_score'] >= 70.0
 
-    def test_full_verdict(self, sample_workspace):
-        critic = TestCritic(sample_workspace)
-        result = critic.run_analysis()
-        assert result['verdict'] == 'pass'
-"""
+class DummyAdapter:
+    """Simple adapter returning deterministic results for testing."""
 
-# We keep a marker but skip all tests rather than deleting them completely
-# This provides documentation that these tests were intentionally disabled
-@pytest.mark.skip("Tests for deprecated TestCriticRunner APIs - current TestCritic implementation differs")
-class TestTestCritic(unittest.TestCase):
-    """Tests for the TestCritic class with advanced APIs that have changed in the current implementation."""
-    pass
+    name = "dummy"
+
+    def detect(self, workspace):
+        return True
+
+    def collect_only(self, workspace):
+        return []
+
+    def smoke_run(self, workspace):
+        return True
+
+    def coverage(self, workspace):
+        return 85.0
+
+    def mutation(self, workspace):
+        return 72.0
+
+
+@pytest.fixture
+def critic(monkeypatch):
+    adapter = DummyAdapter()
+    monkeypatch.setattr(core, "select_adapter", lambda workspace, lang_hint=None: adapter)
+
+    class NoOpReporter:
+        def __init__(self, workspace):
+            self.workspace = workspace
+
+        def write(self, results):
+            pass
+
+    monkeypatch.setattr(core, "Reporter", NoOpReporter)
+    return core.TestCritic()
+
+
+class TestCriticRunAnalysis:
+    def test_collect_errors(self, critic, sample_workspace):
+        result = critic.run_analysis(sample_workspace)
+        assert result["details"]["collect_errors"] == []
+
+    def test_smoke_run(self, critic, sample_workspace):
+        result = critic.run_analysis(sample_workspace)
+        assert result["details"]["smoke_passed"] is True
+
+    def test_coverage_threshold(self, critic, sample_workspace):
+        result = critic.run_analysis(sample_workspace)
+        assert result["details"]["coverage_percent"] >= 80.0
+
+    def test_mutation_threshold(self, critic, sample_workspace):
+        result = critic.run_analysis(sample_workspace)
+        assert result["details"]["mutation_score"] >= 70.0
+
+    def test_full_verdict(self, critic, sample_workspace):
+        result = critic.run_analysis(sample_workspace)
+        assert result["verdict"] == TestVerdict.PASS
+
+
+def test_run_analysis_returns_pass(critic, sample_workspace):
+    """Test that ``run_analysis`` aggregates results correctly."""
+    result = critic.run_analysis(sample_workspace)
+    assert result["verdict"] == TestVerdict.PASS
+    details = result["details"]
+    assert details == {
+        "collect_errors": [],
+        "smoke_passed": True,
+        "coverage_percent": 85.0,
+        "mutation_score": 72.0,
+    }
+
+
+def test_analyze_test_file_detects_unit_tests():
+    """Ensure static analysis recognises unit tests with assertions."""
+    critic = TestCritic()
+    code = """\
+import pytest
+
+
+def test_example():
+    assert 1 == 1
+"""
+    result = critic.analyze_test_file("test_example.py", code)
+    assert result["verdict"] == TestVerdict.PASS
+    assert "unit" in result["test_types"]
+    assert result["test_count"] == 1
+    assert result["assertion_count"] >= 1
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- drop old TestPytestAdapterIntegration and TestTestCritic stubs
- add new unit tests for TestCritic using a dummy adapter
- merge latest `design-workflow-cleanup` changes
- clean up unused imports in the updated tests

## Testing
- `ruff check tests/test_test_critic.py`
- `ruff check agent_s3/ tests/test_test_critic.py` *(fails: existing lint errors)*
- `mypy agent_s3/` *(fails: unterminated string literal)*
- `pytest tests/test_test_critic.py -q` *(fails: pytest not installed)*