### PR TITLE
Remove MagicMock import from integration test

### DIFF
--- a/tests/test_integration_run_task.py
+++ b/tests/test_integration_run_task.py
@@ -2,7 +2,7 @@
 Integration test for Coordinator.run_task simulating a simple feature request.
 """
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from agent_s3.coordinator import Coordinator
 
 def test_run_task_simple(monkeypatch):


### PR DESCRIPTION
## Summary
- clean up `tests/test_integration_run_task.py` by removing an unused `MagicMock` import

## Testing
- `python3 -m pytest -k test_integration_run_task.py -q` *(fails: No module named pytest)*