### PR TITLE
Add implementation facade methods

### DIFF
--- a/agent_s3/coordinator.py
+++ b/agent_s3/coordinator.py
@@ -1403,3 +1403,45 @@ class Coordinator:
     def deploy(self, design_file: str = "design.txt") -> Dict[str, Any]:
         """Facade used by CommandProcessor to start deployment."""
         return self.execute_deployment(design_file)
+
+    def execute_implementation(self, design_file: str = "design.txt") -> Dict[str, Any]:
+        """Execute implementation using the implementation manager."""
+        try:
+            if not hasattr(self, "implementation_manager"):
+                return {"success": False, "error": "Implementation manager not available"}
+
+            if not os.path.exists(design_file):
+                return {"success": False, "error": f"Design file not found: {design_file}"}
+
+            if hasattr(self, "scratchpad"):
+                self.scratchpad.log("Coordinator", f"Starting implementation from {design_file}")
+
+            return self.implementation_manager.start_implementation(design_file)
+        except Exception as e:
+            self.error_handler.handle_exception(
+                exc=e,
+                operation="execute_implementation",
+                level=logging.ERROR,
+            )
+            return {"success": False, "error": str(e)}
+
+    def execute_continue(self, continue_type: str = "implementation") -> Dict[str, Any]:
+        """Continue a workflow such as implementation or design."""
+        try:
+            if continue_type == "implementation":
+                if not hasattr(self, "implementation_manager"):
+                    return {"success": False, "error": "Implementation manager not available"}
+
+                if hasattr(self, "scratchpad"):
+                    self.scratchpad.log("Coordinator", "Continuing implementation")
+
+                return self.implementation_manager.continue_implementation()
+
+            return {"success": False, "error": f"Unsupported continuation type: {continue_type}"}
+        except Exception as e:
+            self.error_handler.handle_exception(
+                exc=e,
+                operation="execute_continue",
+                level=logging.ERROR,
+            )
+            return {"success": False, "error": str(e)}

--- a/tests/test_command_processor.py
+++ b/tests/test_command_processor.py
@@ -224,3 +224,26 @@ class TestCommandProcessor:
         result = command_processor.execute_request_command("Add feature")
         mock_coordinator.process_change_request.assert_called_once_with("Add feature")
         assert result == ""
+
+    @patch('pathlib.Path.exists')
+    def test_execute_implement_command(self, mock_exists, command_processor, mock_coordinator):
+        """Test execute_implement_command calls coordinator.execute_implementation."""
+        mock_exists.return_value = True
+        mock_coordinator.execute_implementation.return_value = {"success": True, "message": "done"}
+
+        result = command_processor.execute_implement_command("design.txt")
+
+        mock_coordinator.execute_implementation.assert_called_once_with("design.txt")
+        assert "done" in result
+
+    def test_execute_continue_command(self, command_processor, mock_coordinator):
+        """Test execute_continue_command calls coordinator.execute_continue."""
+        mock_coordinator.execute_continue.return_value = {
+            "success": True,
+            "message": "continued"
+        }
+
+        result = command_processor.execute_continue_command("implementation")
+
+        mock_coordinator.execute_continue.assert_called_once_with("implementation")
+        assert "continued" in result

--- a/tests/test_coordinator_implementation_methods.py
+++ b/tests/test_coordinator_implementation_methods.py
@@ -1,0 +1,35 @@
+import os
+from unittest.mock import MagicMock, patch
+
+from agent_s3.coordinator import Coordinator
+
+
+def create_coordinator():
+    coord = Coordinator.__new__(Coordinator)
+    coord.scratchpad = MagicMock()
+    coord.scratchpad.log = MagicMock()
+    coord.error_handler = MagicMock()
+    coord.error_handler.handle_exception = MagicMock()
+    coord.implementation_manager = MagicMock()
+    return coord
+
+
+@patch('os.path.exists', return_value=True)
+def test_execute_implementation_delegates(mock_exists):
+    coord = create_coordinator()
+    coord.implementation_manager.start_implementation.return_value = {"success": True}
+
+    result = coord.execute_implementation("design.txt")
+
+    coord.implementation_manager.start_implementation.assert_called_once_with("design.txt")
+    assert result["success"] is True
+
+
+def test_execute_continue_delegates():
+    coord = create_coordinator()
+    coord.implementation_manager.continue_implementation.return_value = {"success": True}
+
+    result = coord.execute_continue("implementation")
+
+    coord.implementation_manager.continue_implementation.assert_called_once_with()
+    assert result["success"] is True


### PR DESCRIPTION
## Summary
- add `execute_implementation` and `execute_continue` to Coordinator
- update command processor tests for implement and continue commands
- add unit tests for Coordinator's new implementation methods

## Testing
- `pytest` *(fails: `pytest` not available)*