### PR TITLE
Add jsonschema validation for llm.json

### DIFF
--- a/agent_s3/llm_entry_schema.json
+++ b/agent_s3/llm_entry_schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["model", "role", "context_window", "parameters", "api"],
+  "properties": {
+    "model": {"type": "string"},
+    "role": {
+      "anyOf": [
+        {"type": "string"},
+        {"type": "array", "items": {"type": "string"}, "minItems": 1}
+      ]
+    },
+    "context_window": {"type": "integer", "minimum": 1},
+    "parameters": {"type": "object"},
+    "pricing_per_million": {
+      "type": "object",
+      "properties": {
+        "input": {"type": "number"},
+        "output": {"type": "number"}
+      },
+      "additionalProperties": false
+    },
+    "capabilities": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "api": {
+      "type": "object",
+      "required": ["endpoint", "auth_header"],
+      "properties": {
+        "endpoint": {"type": "string", "minLength": 1},
+        "auth_header": {"type": "string", "minLength": 1}
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "pytest>=6.2.0",
     "gptcache>=1.0.0",
     "sqlalchemy>=2.0.0",
+    "jsonschema>=4.0.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ sqlalchemy>=2.0.0
 # Optional adapters for database support
 psycopg2-binary>=2.9.0
 pymysql>=1.0.0
+jsonschema>=4.0.0

--- a/tests/test_llm_config_schema.py
+++ b/tests/test_llm_config_schema.py
@@ -1,0 +1,52 @@
+import os
+import json
+import unittest
+import tempfile
+from pathlib import Path
+import importlib.util
+import sys
+import types
+
+module_path = Path(__file__).resolve().parents[1] / "agent_s3" / "router_agent.py"
+spec = importlib.util.spec_from_file_location("router_agent", module_path)
+router_agent = importlib.util.module_from_spec(spec)
+sys.modules.setdefault("requests", types.ModuleType("requests"))
+jsonschema_stub = types.ModuleType("jsonschema")
+
+class _ValidationError(Exception):
+    def __init__(self, message, path=None):
+        super().__init__(message)
+        self.message = message
+        self.path = path or []
+
+def _validate(instance, schema):
+    required = ["model", "role", "context_window", "parameters", "api"]
+    for key in required:
+        if key not in instance:
+            raise _ValidationError(f"Missing {key}", path=[key])
+    if not isinstance(instance["context_window"], int):
+        raise _ValidationError("context_window must be int", path=["context_window"])
+jsonschema_stub.validate = _validate
+jsonschema_stub.exceptions = types.SimpleNamespace(ValidationError=_ValidationError)
+sys.modules.setdefault("jsonschema", jsonschema_stub)
+spec.loader.exec_module(router_agent)
+
+
+class TestLLMConfigSchema(unittest.TestCase):
+    def test_invalid_schema_rejected(self):
+        """LLM config with wrong types should raise ValueError."""
+        invalid = [{"model": 123, "role": "test"}]
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            llm_path = Path(tmp_dir) / "llm.json"
+            llm_path.write_text(json.dumps(invalid))
+            cwd = os.getcwd()
+            os.chdir(tmp_dir)
+            try:
+                with self.assertRaises(ValueError):
+                    router_agent._load_llm_config()
+            finally:
+                os.chdir(cwd)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- define a JSON Schema for llm.json entries
- validate llm.json against schema in `router_agent`
- surface clear errors for invalid configs
- test config validation logic
- include jsonschema dependency

## Testing
- `ruff check agent_s3/router_agent.py tests/test_llm_config_schema.py`
- `python -m unittest tests.test_llm_config_schema -v`