### PR TITLE
Implement progress polling fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Agent-S3 is not just a tool for automation; it is a partner in development that 
   - Comprehensive test validation including unit, integration, property-based, and acceptance tests
   - Test quality metrics including coverage ratio and diversity score
   - Warning system for uncovered critical files and missing test types
-- Progress tracking in `progress_log.json` (`agent_s3.progress_tracker`) and detailed chain-of-thought logs via enhanced scratchpad management (`agent_s3.enhanced_scratchpad_manager`)
+- Progress tracking in `progress_log.jsonl` (`agent_s3.progress_tracker`) and detailed chain-of-thought logs via enhanced scratchpad management (`agent_s3.enhanced_scratchpad_manager`)
 - Interactive user prompts, plan reviews, patch diffs, and explanations via `agent_s3.prompt_moderator`
 - Workspace initialization (`/init`): Validates workspace (checks for `README.md`), creates default `.github/copilot-instructions.md`, `personas.md`, and `llm.json` if missing
 - Task State Management & Resumption (`TaskStateManager`):
@@ -149,7 +149,7 @@ See `docs/summarization.md` for details.
 - Command Palette integration: Initialize workspace, Make change request, Show help, Show config, Reload LLM config, Explain last LLM interaction, Open Chat Window
 - Status bar item (`$(sparkle) Agent-S3`) to start change requests
 - Dedicated terminal panel for backend interactions
-- Real-time progress monitoring by polling `progress_log.json`
+- Real-time progress updates via WebSocket with a fallback to polling `progress_log.jsonl` if the connection fails
 - Optional Copilot-style chat UI for input; terminal shows actual outputs
 - WebView panels for structured information display:
   - Code change plan reviews

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -67,7 +67,7 @@ Agent-S3 provides real-time status updates in the VS Code interface as it works 
 
 Detailed logs are available in your workspace:
 - `scratchpad.txt` - Detailed internal chain-of-thought log
-- `progress_log.json` - Structured progress updates
+- `progress_log.jsonl` - Structured progress updates
 - `development_status.json` - Overall development status tracking
 
 ## Feedback and Contributions

--- a/vscode/backend-connection.ts
+++ b/vscode/backend-connection.ts
@@ -4,6 +4,8 @@
  */
 
 import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
 import { WebSocketClient } from './websocket-client';
 import { InteractiveWebviewManager } from './webview-ui-loader';
 
@@ -15,6 +17,8 @@ export class BackendConnection implements vscode.Disposable {
   private interactiveWebviewManager: InteractiveWebviewManager | undefined;
   private activeStreams: Map<string, StreamingContent> = new Map();
   private outputChannel: vscode.OutputChannel;
+  private progressPollingInterval: NodeJS.Timeout | null = null;
+  private progressFilePosition = 0;
   
   /**
    * Create a new backend connection
@@ -22,6 +26,15 @@ export class BackendConnection implements vscode.Disposable {
   constructor() {
     // Create WebSocket client
     this.webSocketClient = new WebSocketClient();
+
+    // Monitor connection state to toggle progress polling
+    this.webSocketClient.registerConnectionListener((connected) => {
+      if (connected) {
+        this.stopMonitoringProgress();
+      } else {
+        this.monitorProgress();
+      }
+    });
     
     // Create output channel for messages
     this.outputChannel = vscode.window.createOutputChannel("Agent-S3");
@@ -41,7 +54,11 @@ export class BackendConnection implements vscode.Disposable {
    * Connect to the backend
    */
   public async connect(): Promise<boolean> {
-    return this.webSocketClient.connect();
+    const result = await this.webSocketClient.connect();
+    if (!result) {
+      this.monitorProgress();
+    }
+    return result;
   }
   
   /**
@@ -309,12 +326,78 @@ export class BackendConnection implements vscode.Disposable {
     // Show the interactive panel if not already visible
     if (this.interactiveWebviewManager) {
       const panel = this.interactiveWebviewManager.createOrShowPanel();
-      
+
       // Forward the message to the webview
       this.interactiveWebviewManager.postMessage({
         type: 'PROGRESS_INDICATOR',
         content: message.content
       });
+    }
+  }
+
+  /**
+   * Start polling progress_log.jsonl for updates when WebSocket is unavailable
+   */
+  private monitorProgress(): void {
+    if (this.progressPollingInterval) {
+      return;
+    }
+
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (!workspaceFolders || workspaceFolders.length === 0) {
+      return;
+    }
+
+    const progressFile = path.join(
+      workspaceFolders[0].uri.fsPath,
+      'progress_log.jsonl'
+    );
+
+    this.progressPollingInterval = setInterval(() => {
+      fs.stat(progressFile, (err, stats) => {
+        if (err || !stats.isFile()) {
+          return;
+        }
+
+        if (stats.size <= this.progressFilePosition) {
+          return;
+        }
+
+        const stream = fs.createReadStream(progressFile, {
+          start: this.progressFilePosition,
+          end: stats.size,
+          encoding: 'utf-8'
+        });
+
+        let data = '';
+        stream.on('data', chunk => {
+          data += chunk;
+        });
+
+        stream.on('end', () => {
+          this.progressFilePosition = stats.size;
+          const lines = data.split(/\n/).filter(l => l.trim() !== '');
+          lines.forEach(line => {
+            try {
+              const entry = JSON.parse(line);
+              this.handleProgressIndicator({ content: entry });
+            } catch (e) {
+              console.error('Failed to parse progress log entry', e);
+            }
+          });
+        });
+      });
+    }, 2000);
+  }
+
+  /**
+   * Stop progress file polling
+   */
+  private stopMonitoringProgress(): void {
+    if (this.progressPollingInterval) {
+      clearInterval(this.progressPollingInterval);
+      this.progressPollingInterval = null;
+      this.progressFilePosition = 0;
     }
   }
   


### PR DESCRIPTION
## Summary
- monitor progress log when WebSocket unavailable
- hook progress polling into connection state events
- expose connection listeners in `WebSocketClient`
- document progress polling fallback in README
- update VS Code docs for progress log name

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
- `npm run compile` in `vscode` *(fails: Cannot find a tsconfig.json file)*