### PR TITLE
Update default progress log filename

### DIFF
--- a/STREAMING_UI_CHANGES.md
+++ b/STREAMING_UI_CHANGES.md
@@ -10,7 +10,7 @@
 
 - **Eliminated File Polling Mechanism**
   - Replaced polling with WebSocket streaming
-  - The file-based log (`progress_log.json`/`progress_log.jsonl`) is still written for compatibility with existing watchers
+  - The file-based log (`progress_log.jsonl`) is still written for compatibility with existing watchers
 
 - **Removed Simulated Chat UI**
   - No explicit setTimeout simulation was found, but the architecture has been updated to use real-time streaming

--- a/agent_s3/config.py
+++ b/agent_s3/config.py
@@ -100,7 +100,7 @@ class ModelsConfig(BaseModel):
 class LogFilesConfig(BaseModel):
     """Paths to log files relative to workspace."""
 
-    development: str = "progress_log.json"
+    development: str = "progress_log.jsonl"
     debug: str = "debug_log.json"
     error: str = "error_log.json"
 

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -67,7 +67,7 @@ Agent-S3 provides real-time status updates in the VS Code interface as it works 
 
 Detailed logs are available in your workspace:
 - `scratchpad.txt` - Detailed internal chain-of-thought log
-- `progress_log.json` - Structured progress updates
+- `progress_log.jsonl` - Structured progress updates
 - `development_status.json` - Overall development status tracking
 
 ## Feedback and Contributions


### PR DESCRIPTION
## Summary
- default to `progress_log.jsonl` in configuration
- update docs to reference `progress_log.jsonl`

## Testing
- `pytest -q` *(fails: `pytest` not found due to network restrictions)*