### PR TITLE
Fix dispose cleanup for progress monitor

### DIFF
--- a/vscode/backend-connection.ts
+++ b/vscode/backend-connection.ts
@@ -17,6 +17,7 @@ export class BackendConnection implements vscode.Disposable {
   private outputChannel: vscode.OutputChannel;
   private offlineQueue: any[] = [];
   private workspaceState: vscode.Memento | undefined;
+  private progressInterval: NodeJS.Timeout | undefined;
   
   /**
    * Create a new backend connection
@@ -369,11 +370,22 @@ export class BackendConnection implements vscode.Disposable {
     queue.forEach(msg => this.sendMessage(msg));
     this.persistOfflineQueue();
   }
-  
+
+  /**
+   * Stop monitoring progress updates
+   */
+  private stopMonitoringProgress(): void {
+    if (this.progressInterval) {
+      clearInterval(this.progressInterval);
+      this.progressInterval = undefined;
+    }
+  }
+
   /**
    * Dispose of resources
    */
   public dispose(): void {
+    this.stopMonitoringProgress();
     this.webSocketClient.dispose();
     this.outputChannel.dispose();
   }


### PR DESCRIPTION
## Summary
- ensure `BackendConnection.dispose` stops progress monitoring before cleaning up WebSocket and output channel

## Testing
- `ruff check vscode/backend-connection.ts`
- `mypy agent_s3` *(fails: unterminated string literal in refinement_manager.py)*
- `python3 -m pytest -q` *(fails: `pytest` missing and could not be installed due to network issues)*