### PR TITLE
Fix progress indicator handler

### DIFF
--- a/vscode/backend-connection.ts
+++ b/vscode/backend-connection.ts
@@ -337,8 +337,9 @@ export class BackendConnection implements vscode.Disposable {
   private handleProgressIndicator(message: any): void {
     // Show the interactive panel if not already visible
     if (this.interactiveWebviewManager) {
-      const panel = this.interactiveWebviewManager.createOrShowPanel();
-      
+      // Ensure the interactive panel is visible
+      this.interactiveWebviewManager.createOrShowPanel();
+
       // Forward the message to the webview
       this.interactiveWebviewManager.postMessage({
         type: 'PROGRESS_INDICATOR',


### PR DESCRIPTION
## Summary
- remove unused variable in progress indicator handler

## Testing
- `pytest -q` *(fails: command not found)*
- `npm test` *(fails: missing script)*