### PR TITLE
Add explain helpers

### DIFF
--- a/STORIES.md
+++ b/STORIES.md
@@ -267,7 +267,7 @@ Agent-S3. Refer to both documents for a complete understanding of the project.
     *   `main` parses arguments and identifies `/explain`.
     *   `process_command` handles it and prints "Explaining the last LLM interaction with context...".
     *   It initializes the `Coordinator`.
-    *   It gathers context via `coordinator._gather_context()` to provide tech stack and code snippets for better explanation context.
+    *   It gathers context via `coordinator._gather_context()` (a wrapper around `_prepare_context`) to provide tech stack details and relevant code snippets for context.
     *   It calls `coordinator.explain_last_llm_interaction(context)`, passing in the gathered context.
 3.  **Explanation Content (Enhanced with Tech Stack and Code Context):**
     *   The `role` (model identifier used, e.g., "gemini-2.5-pro" or "mistral-7b-instruct") is shown.

--- a/agent_s3/command_processor.py
+++ b/agent_s3/command_processor.py
@@ -821,7 +821,7 @@ Type /help <command> for more information on a specific command."""
 
         try:
             # Gather context: tech stack and code snippets
-            context = self.coordinator._gather_context() if hasattr(self.coordinator, '_gather_context') else {}
+            context = self.coordinator._gather_context()
             self.coordinator.explain_last_llm_interaction(context)
             return ""  # Return empty string as output is already printed by the explain method
         except Exception as e:


### PR DESCRIPTION
## Summary
- support context gathering snippet retrieval in coordinator
- print formatted LLM interaction explanations
- use the new helpers from command processor
- document the updated `/explain` workflow in STORIES

## Testing
- `ruff check agent_s3` *(fails: Found 784 errors)*
- `mypy agent_s3` *(fails: unterminated string literal)*
- `python -m pytest -q` *(fails: No module named pytest)*