### PR TITLE
Implement progress polling fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Agent-S3 is not just a tool for automation; it is a partner in development that 
   - Comprehensive test validation including unit, integration, property-based, and acceptance tests
   - Test quality metrics including coverage ratio and diversity score
   - Warning system for uncovered critical files and missing test types
-- Progress tracking in `progress_log.json` (`agent_s3.progress_tracker`) and detailed chain-of-thought logs via enhanced scratchpad management (`agent_s3.enhanced_scratchpad_manager`)
+- Progress tracking in `progress_log.jsonl` (`agent_s3.progress_tracker`) and detailed chain-of-thought logs via enhanced scratchpad management (`agent_s3.enhanced_scratchpad_manager`)
 - Interactive user prompts, plan reviews, patch diffs, and explanations via `agent_s3.prompt_moderator`
 - Workspace initialization (`/init`): Validates workspace (checks for `README.md`), creates default `.github/copilot-instructions.md`, `personas.md`, and `llm.json` if missing
 - Task State Management & Resumption (`TaskStateManager`):
@@ -149,7 +149,7 @@ See `docs/summarization.md` for details.
 - Command Palette integration: Initialize workspace, Make change request, Show help, Show config, Reload LLM config, Explain last LLM interaction, Open Chat Window
 - Status bar item (`$(sparkle) Agent-S3`) to start change requests
 - Dedicated terminal panel for backend interactions
-- Real-time progress monitoring by polling `progress_log.json`
+- Real-time progress updates via WebSocket with a fallback to polling `progress_log.jsonl` if the connection fails
 - Optional Copilot-style chat UI for input; terminal shows actual outputs
 - WebView panels for structured information display:
   - Code change plan reviews

--- a/STORIES.md
+++ b/STORIES.md
@@ -100,7 +100,7 @@ Agent-S3. Refer to both documents for a complete understanding of the project.
     *   It shows the terminal (`terminal.show()`).
     *   It sends the developer's request (from input box or chat message) to the CLI, escaping quotes: `python -m agent_s3.cli "<user_request>"` (`terminal.sendText`).
     *   It shows an information notification: `Processing request: <user_request>` (`vscode.window.showInformationMessage`).
-    *   It starts monitoring the `progress_log.json` file for updates by calling `monitorProgress`.
+    *   It starts monitoring the `progress_log.jsonl` file for updates by calling `monitorProgress`.
 3.  **Backend CLI Action (`agent_s3/cli.py`):**
     *   The `main` function parses the command-line arguments, receiving the request text.
     *   It loads the configuration (`Config`).
@@ -159,7 +159,7 @@ Agent-S3. Refer to both documents for a complete understanding of the project.
             *   Includes database schema metadata in PR descriptions when database changes are involved
         *   Clears the task state and reports completion.
 5.  **VS Code Monitoring (`vscode/extension.ts`):**
-    *   The `monitorProgress` function periodically reads `progress_log.json`.
+    *   The `monitorProgress` function periodically reads `progress_log.jsonl`.
     *   Updates the status bar with current phase and status.
     *   When a final state is reached, shows a notification with result summary.
     *   If a PR was created, includes the PR URL in the notification.

--- a/agent_s3/config.py
+++ b/agent_s3/config.py
@@ -138,7 +138,7 @@ class Config:
             # Default paths
             "workspace_path": ".",
             "log_files": {
-                "development": "progress_log.json",
+                "development": "progress_log.jsonl",
             },
             # Context Management Configuration
             "context_management": {

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -67,7 +67,7 @@ Agent-S3 provides real-time status updates in the VS Code interface as it works 
 
 Detailed logs are available in your workspace:
 - `scratchpad.txt` - Detailed internal chain-of-thought log
-- `progress_log.json` - Structured progress updates
+- `progress_log.jsonl` - Structured progress updates
 - `development_status.json` - Overall development status tracking
 
 ## Feedback and Contributions


### PR DESCRIPTION
## Summary
- monitor progress log when WebSocket unavailable
- hook progress polling into connection state events
- expose connection listeners in `WebSocketClient`
- document progress polling fallback in README
- update VS Code docs for progress log name
- cleanup progress polling implementation

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
- `npm run compile` *(fails: Missing script: "compile")*