### PR TITLE
Fix newline at end of test file

### DIFF
--- a/tests/test_command_processor.py
+++ b/tests/test_command_processor.py
@@ -245,3 +245,4 @@ class TestCommandProcessor:
 
         mock_coordinator.execute_continue.assert_called_once_with("implementation")
         assert "continued" in result
+


### PR DESCRIPTION
## Summary
- ensure `tests/test_command_processor.py` ends with a newline

## Testing
- `ruff check tests/test_command_processor.py`
- `python -m pytest -q` *(fails: No module named pytest)*