### PR TITLE
Remove legacy planning wrappers

### DIFF
--- a/agent_s3/feature_group_processor.py
+++ b/agent_s3/feature_group_processor.py
@@ -113,6 +113,7 @@ class FeatureGroupProcessor:
                         "group": group_name
                     })
                     
+                    from .planner_json_enforced import generate_refined_test_specifications
                     refined_test_specs_data = generate_refined_test_specifications(
                         self.coordinator.router_agent,
                         feature_group,
@@ -137,6 +138,7 @@ class FeatureGroupProcessor:
                         "group": group_name
                     })
                     
+                    from .planner_json_enforced import generate_test_implementations
                     test_implementations_data = generate_test_implementations(
                         self.coordinator.router_agent,
                         refined_test_specs,
@@ -166,6 +168,7 @@ class FeatureGroupProcessor:
                         "group": group_name
                     })
                     
+                    from .planner_json_enforced import generate_implementation_plan
                     implementation_plan_data = generate_implementation_plan(
                         self.coordinator.router_agent,
                         system_design,
@@ -192,6 +195,7 @@ class FeatureGroupProcessor:
                     })
                     
                     try:
+                        from .planner_json_enforced import validate_planning_semantic_coherence
                         validation_results = validate_planning_semantic_coherence(
                             self.coordinator.router_agent,
                             architecture_review,
@@ -609,49 +613,3 @@ class FeatureGroupProcessor:
             f"Revalidation complete. Overall valid: {status.get('is_valid', False)}",
         )
             
-# Import here to avoid circular references
-def generate_refined_test_specifications(router_agent, feature_group, architecture_review, task_description, context=None):
-    """Import from planner_json_enforced to avoid circular imports and ensure JSON enforcement."""
-    from .planner_json_enforced import generate_refined_test_specifications
-    return generate_refined_test_specifications(router_agent, feature_group, architecture_review, task_description, context)
-
-def generate_test_implementations(router_agent, refined_test_specs, system_design, task_description, context=None):
-    """Import from planner_json_enforced to avoid circular imports and ensure JSON enforcement."""
-    from .planner_json_enforced import generate_test_implementations
-    return generate_test_implementations(router_agent, refined_test_specs, system_design, task_description, context)
-
-def generate_implementation_plan(router_agent, system_design, architecture_review, tests, task_description, context=None):
-    """Import from planner_json_enforced to avoid circular imports and ensure JSON enforcement."""
-    from .planner_json_enforced import generate_implementation_plan
-    return generate_implementation_plan(router_agent, system_design, architecture_review, tests, task_description, context)
-
-def validate_planning_semantic_coherence(router_agent, architecture_review, refined_test_specs, test_implementations, implementation_plan, task_description, context=None):
-    """
-    Validates the semantic coherence between different planning phase outputs.
-    
-    This function ensures that there is consistency and logical coherence between the architecture review,
-    test specifications, test implementations, and implementation plan. It helps identify any disconnects
-    that might lead to issues in later phases.
-    
-    Args:
-        router_agent: The LLM router agent
-        architecture_review: The architecture review data
-        refined_test_specs: The refined test specifications data
-        test_implementations: The test implementation data
-        implementation_plan: The implementation plan data
-        task_description: Original task description
-        context: Optional additional context
-        
-    Returns:
-        Dictionary containing validation results
-    """
-    from .planner_json_enforced import validate_planning_semantic_coherence
-    return validate_planning_semantic_coherence(
-        router_agent,
-        architecture_review,
-        refined_test_specs,
-        test_implementations,
-        implementation_plan,
-        task_description,
-        context
-    )

--- a/agent_s3/test_generator.py
+++ b/agent_s3/test_generator.py
@@ -494,44 +494,6 @@ Before finalizing your output, verify that:
 Your test implementations will be used to validate the actual code implementation, so they must be accurate, complete, and ready to run with minimal adjustments.
 """
 
-def generate_refined_test_specifications(
-    router_agent, 
-    feature_group: Dict[str, Any],
-    architecture_review: Dict[str, Any],
-    task_description: str,
-    context: Optional[Dict[str, Any]] = None
-) -> Dict[str, Any]:
-    """
-    Generate refined test specifications based on architecture review and system design.
-    
-    This function is now imported from planner_json_enforced.py to ensure architectural consistency
-    and benefit from enhanced JSON enforcement. The implementation in planner_json_enforced.py:
-    
-    1. Uses the more advanced get_test_specification_refinement_system_prompt() which includes:
-       - Quality over quantity focus
-       - Test priority ratings (Critical/High/Medium/Low)
-       - Improved sequential processing instructions
-       - Better traceability to architectural elements
-       
-    2. Maintains consistent error handling with other planner_json_enforced functions
-       
-    3. Provides centralized JSON handling with the rest of the planning pipeline
-    
-    Args:
-        router_agent: The LLM router agent for making LLM calls
-        feature_group: The feature group data
-        architecture_review: The architecture review data
-        task_description: Original task description
-        context: Optional additional context
-        
-    Returns:
-        Dictionary containing refined test specifications
-    """
-    # Import here to avoid circular imports
-    from .planner_json_enforced import generate_refined_test_specifications as json_enforced_test_specs
-    
-    # Call the implementation from planner_json_enforced.py
-    return json_enforced_test_specs(router_agent, feature_group, architecture_review, task_description, context)
 
 def generate_test_implementations(
     router_agent, 
@@ -682,9 +644,3 @@ Each test must include complete runnable code - not stubs or pseudocode.
         logger.error(f"Error generating test implementations: {e}")
         logger.error(traceback.format_exc())
         raise TestGenerationError(f"Error generating test implementations: {e}")
-
-# Implementation planning has been moved to planner_json_enforced.py
-# to maintain architectural consistency across the codebase.
-# 
-# To generate implementation plans, import the function from planner_json_enforced:
-# from .planner_json_enforced import generate_implementation_plan

--- a/tests/integration/test_run_task_consolidated_plan.py
+++ b/tests/integration/test_run_task_consolidated_plan.py
@@ -114,7 +114,7 @@ def test_run_task_with_mocked_llm(monkeypatch):
         lambda router, sys_design, arch, tests, task_description, context=None: IMPL_PLAN
     )
     monkeypatch.setattr(
-        'agent_s3.feature_group_processor.validate_planning_semantic_coherence',
+        'agent_s3.planner_json_enforced.validate_planning_semantic_coherence',
         lambda router, arch, specs, impls, impl_plan, task_description, context=None: SEM_VALID
     )
 


### PR DESCRIPTION
## Summary
- remove obsolete wrapper functions from `feature_group_processor`
- drop deprecated test spec wrapper and old comments in `test_generator`
- patch integration test to reference canonical validator

## Testing
- `ruff check agent_s3/feature_group_processor.py agent_s3/test_generator.py tests/integration/test_run_task_consolidated_plan.py`
- `pytest -q` *(fails: command not found)*