### PR TITLE
Add supabase-py dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Build/Test Commands
-- Setup environment: `python -m pip install -e .`
+ - Setup environment: `python -m pip install -e . && pip install -r requirements.txt`
 - Run tests: `pytest`
 - Run single test: `pytest tests/path_to_test.py::TestClass::test_function`
 - Run the CLI: `python -m agent_s3.cli`

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ This architecture enables a Copilot-like, interactive experience with immediate 
 - Required packages: `sqlalchemy` with optional adapters
   - `psycopg2-binary` for PostgreSQL
   - `pymysql` for MySQL
+  - `supabase-py` for Supabase integration
 - GitHub account and relevant tokens or app credentials
 
 ## Tree-sitter Grammar Setup
@@ -261,6 +262,7 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
    `pyproject.toml`:
    ```bash
    pip install -e .
+   pip install -r requirements.txt
    ```
 2. **VS Code Extension:**
    - Open the `vscode` folder in VS Code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "gptcache>=1.0.0",
     "sqlalchemy>=2.0.0",
     "jsonschema>=4.0.0",
+    "supabase-py",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ psycopg2-binary>=2.9.0
 pymysql>=1.0.0
 jsonschema>=4.0.0
 cryptography>=41.0.0
+supabase-py


### PR DESCRIPTION
## Summary
- include supabase-py in project dependencies
- mirror the dependency in requirements.txt
- document the extra dependency and new install step
- update CLAUDE instructions to install requirements

## Testing
- `ruff check agent_s3`
- `mypy agent_s3`
- `python -m pytest -q` *(fails: No module named pytest)*