### PR TITLE
Add Supabase LLM helper

### DIFF
--- a/agent_s3/llm_utils.py
+++ b/agent_s3/llm_utils.py
@@ -13,6 +13,12 @@ import threading
 import numpy as np
 import logging
 
+try:
+    # Supabase client is optional and only loaded when available
+    from supabase import create_client  # type: ignore
+except Exception:  # pragma: no cover - library may not be installed
+    create_client = None
+
 # Import GPTCache
 try:
     from gptcache import cache
@@ -293,6 +299,79 @@ def call_llm_with_retry(
                  (f" and fallback" if fallback_strategy != 'none' else "")),
         'details': f"Last error: {last_error_details}: {last_error}"
     }
+
+
+def call_llm_via_supabase(
+    prompt_data: Dict[str, Any],
+    config: Any,
+    github_token: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Invoke an LLM through a Supabase edge function with retries.
+
+    Parameters
+    ----------
+    prompt_data: Dict[str, Any]
+        Payload to forward to the edge function. The key ``edge_function_path``
+        can be provided to override the default path ``"/functions/v1/llm"``.
+    config: Any
+        Configuration object containing ``supabase_url`` and
+        ``supabase_service_key`` along with retry settings.
+    github_token: Optional[str]
+        GitHub token to include in the ``Authorization`` header.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Parsed JSON response from the edge function.
+    """
+
+    if create_client is None:
+        raise ImportError("supabase package is required for Supabase integration")
+
+    supabase_url = getattr(config, "supabase_url", None)
+    service_key = getattr(config, "supabase_service_key", None)
+    if not supabase_url or not service_key:
+        raise ValueError("Missing Supabase configuration")
+
+    supabase = create_client(supabase_url, service_key)
+
+    path = prompt_data.get("edge_function_path", "/functions/v1/llm")
+    if not path.startswith("/"):
+        path = "/" + path
+    url = f"{supabase_url.rstrip('/')}{path}"
+
+    payload = prompt_data.get("payload", prompt_data)
+
+    headers = {
+        "Content-Type": "application/json",
+        "apikey": service_key,
+    }
+    if github_token:
+        headers["Authorization"] = f"Bearer {github_token}"
+
+    max_retries = getattr(config, "llm_max_retries", 3)
+    initial_backoff = getattr(config, "llm_initial_backoff", 1.0)
+    backoff_factor = getattr(config, "llm_backoff_factor", 2.0)
+    timeout = getattr(config, "llm_default_timeout", 60.0)
+
+    for attempt in range(max_retries):
+        try:
+            resp = requests.post(url, json=payload, headers=headers, timeout=timeout)
+            resp.raise_for_status()
+            return resp.json()
+        except requests.HTTPError as exc:
+            status = getattr(exc.response, "status_code", 0)
+            if attempt < max_retries - 1 and 500 <= status < 600:
+                backoff = initial_backoff * (backoff_factor ** attempt)
+                time.sleep(backoff)
+                continue
+            raise
+        except requests.RequestException:
+            if attempt < max_retries - 1:
+                backoff = initial_backoff * (backoff_factor ** attempt)
+                time.sleep(backoff)
+                continue
+            raise
 
 
 def get_embedding(

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ psycopg2-binary>=2.9.0
 pymysql>=1.0.0
 jsonschema>=4.0.0
 cryptography>=41.0.0
+requests>=2.31.0
+supabase-py>=2.0.0

--- a/tests/test_llm_utils_supabase.py
+++ b/tests/test_llm_utils_supabase.py
@@ -1,0 +1,64 @@
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+# Provide a minimal 'requests' stub for the module under test
+requests_stub = types.ModuleType("requests")
+class HTTPError(Exception):
+    def __init__(self, response=None):
+        super().__init__("HTTP error")
+        self.response = response
+class RequestException(Exception):
+    pass
+requests_stub.HTTPError = HTTPError
+requests_stub.RequestException = RequestException
+requests_stub.post = lambda *a, **k: None
+sys.modules.setdefault("requests", requests_stub)
+
+from agent_s3.llm_utils import call_llm_via_supabase, requests as llm_requests
+
+class DummyConfig:
+    supabase_url = "https://example.supabase.co"
+    supabase_service_key = "service-key"
+    llm_max_retries = 2
+    llm_initial_backoff = 0
+    llm_backoff_factor = 1
+    llm_default_timeout = 5
+
+def test_call_llm_via_supabase_success(monkeypatch):
+    dummy_resp = MagicMock()
+    dummy_resp.json.return_value = {"result": "ok"}
+    dummy_resp.raise_for_status.return_value = None
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        assert url.endswith("/functions/v1/llm")
+        return dummy_resp
+
+    monkeypatch.setattr("agent_s3.llm_utils.create_client", lambda u, k: object())
+    monkeypatch.setattr(llm_requests, "post", fake_post)
+
+    result = call_llm_via_supabase({"prompt": "hi"}, DummyConfig())
+    assert result == {"result": "ok"}
+
+def test_call_llm_via_supabase_retry(monkeypatch):
+    attempts = {"count": 0}
+    err = HTTPError(types.SimpleNamespace(status_code=500))
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        attempts["count"] += 1
+        resp = MagicMock()
+        if attempts["count"] == 1:
+            resp.raise_for_status.side_effect = err
+        else:
+            resp.raise_for_status.return_value = None
+            resp.json.return_value = {"ok": True}
+        return resp
+
+    monkeypatch.setattr("agent_s3.llm_utils.create_client", lambda u, k: object())
+    monkeypatch.setattr(llm_requests, "post", fake_post)
+
+    result = call_llm_via_supabase({"prompt": "hi"}, DummyConfig())
+    assert attempts["count"] == 2
+    assert result == {"ok": True}


### PR DESCRIPTION
## Summary
- allow optional Supabase integration for LLM calls
- specify `requests` and `supabase-py` dependencies
- test Supabase caller logic

## Testing
- `pip install pytest requests supabase-py` *(fails: No route to host)*
- `python -m pytest tests/test_llm_utils_supabase.py::test_call_llm_via_supabase_success -q` *(fails: No module named pytest)*