### PR TITLE
Add remote LLM path via Supabase

### DIFF
--- a/agent_s3/config.py
+++ b/agent_s3/config.py
@@ -204,6 +204,9 @@ class ConfigModel(BaseModel):
     adaptive_config_dir: str = ADAPTIVE_CONFIG_DIR
     adaptive_metrics_dir: str = ADAPTIVE_METRICS_DIR
     adaptive_optimization_interval: int = ADAPTIVE_OPTIMIZATION_INTERVAL
+    supabase_url: str = os.environ.get("SUPABASE_URL", "")
+    supabase_service_role_key: str = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
+    use_remote_llm: bool = os.getenv("USE_REMOTE_LLM", "false").lower() == "true"
 
     class Config:
         extra = "allow"


### PR DESCRIPTION
## Summary
- support using a remote Supabase endpoint for LLM calls
- add `use_remote_llm` flag and Supabase configuration options
- keep caching and retry logic when using remote LLM

## Testing
- `python -m py_compile agent_s3/llm_utils.py`
- `python -m py_compile agent_s3/config.py`
- `pytest -q` *(fails: command not found)*