### PR TITLE
Add OAuth token support for remote LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,13 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
   - `GITHUB_ORG` (optional membership filter)
   - `OPENROUTER_KEY` (or other LLM keys)
   - **Token Encryption:** `AGENT_S3_ENCRYPTION_KEY` (required for GitHub token storage)
+  - `USE_REMOTE_LLM` to route LLM requests through Supabase
+  - `SUPABASE_URL` and `SUPABASE_FUNCTION` for the remote endpoint
   - `DENYLIST_COMMANDS`, `COMMAND_TIMEOUT`, `CLI_COMMAND_WARNINGS` in config
+
+When `USE_REMOTE_LLM` is enabled, LLM requests are sent through the configured
+Supabase function. This function verifies that the provided OAuth token belongs
+to a member of your `GITHUB_ORG` before processing the request.
 
 ## Coding Guidelines
 

--- a/agent_s3/cli.py
+++ b/agent_s3/cli.py
@@ -6,7 +6,6 @@ import argparse
 import json
 import logging
 from pathlib import Path
-from typing import Optional, List, Dict, Any, Tuple
 
 from agent_s3.config import Config
 from agent_s3.coordinator import Coordinator
@@ -221,6 +220,8 @@ def main() -> None:
 
     # Authenticate the user if needed
     github_token = os.getenv("GITHUB_TOKEN")
+    if github_token:
+        config.set_oauth_token(github_token)
     if not github_token and not prompt.startswith("/"):
         # Import here to avoid circular imports
         from agent_s3.auth import authenticate_user
@@ -228,6 +229,7 @@ def main() -> None:
         if not github_token:
             print("Authentication required. Run agent-s3 /init to initialize or set GITHUB_TOKEN.")
             sys.exit(1)
+        config.set_oauth_token(github_token)
 
     # Re-initialize coordinator with authentication
     coordinator = Coordinator(config, github_token=github_token)

--- a/agent_s3/config.py
+++ b/agent_s3/config.py
@@ -91,6 +91,11 @@ SUMMARIZER_ROLE_NAME     = os.getenv('SUMMARIZER_ROLE_NAME',   'summarizer')
 SUMMARIZER_MAX_CHUNK_SIZE = int(os.getenv('SUMMARIZER_MAX_CHUNK_SIZE', '2048'))
 SUMMARIZER_TIMEOUT       = float(os.getenv('SUMMARIZER_TIMEOUT',      '45.0'))
 
+# Remote LLM configuration
+USE_REMOTE_LLM           = os.getenv('USE_REMOTE_LLM', 'false').lower() == 'true'
+SUPABASE_URL             = os.getenv('SUPABASE_URL', '')
+SUPABASE_FUNCTION        = os.getenv('SUPABASE_FUNCTION', 'call-llm')
+
 
 class ModelsConfig(BaseModel):
     """Model names for various agent components."""
@@ -204,6 +209,10 @@ class ConfigModel(BaseModel):
     adaptive_config_dir: str = ADAPTIVE_CONFIG_DIR
     adaptive_metrics_dir: str = ADAPTIVE_METRICS_DIR
     adaptive_optimization_interval: int = ADAPTIVE_OPTIMIZATION_INTERVAL
+    use_remote_llm: bool = USE_REMOTE_LLM
+    supabase_url: str = SUPABASE_URL
+    supabase_function: str = SUPABASE_FUNCTION
+    github_oauth_token: Optional[str] = None
 
     class Config:
         extra = "allow"
@@ -232,8 +241,9 @@ class Config:
         # Flag to track if config loading failed
         self.load_failed = False
         
-        # GitHub token placeholder
+        # GitHub token placeholders
         self.github_token = None
+        self.github_oauth_token = None
         
         self.guidelines: List[str] = []
         self.settings: ConfigModel = ConfigModel()
@@ -380,6 +390,13 @@ class Config:
             return os.path.join(os.getcwd(), self.settings.log_files.dict()[log_type])
         else:
             return os.path.join(os.getcwd(), f"{log_type}_log.jsonl")
+
+    def set_oauth_token(self, token: str) -> None:
+        """Store OAuth token in configuration."""
+        self.github_oauth_token = token
+        cfg = self.config
+        cfg['github_oauth_token'] = token
+        self.config = cfg
 
 
 def get_config():

--- a/agent_s3/router_agent.py
+++ b/agent_s3/router_agent.py
@@ -7,6 +7,7 @@ import time
 import re  # Add import for regex pattern matching
 from time import sleep
 import requests
+from agent_s3.llm_utils import call_llm_via_supabase
 import traceback  # Added import
 from typing import Dict, Any, Optional, Tuple, List
 
@@ -694,13 +695,16 @@ class RouterAgent:
                       f"(Role: {role}, est. tokens: {total_tokens:.0f})")
 
         try:
-            response = requests.request(
-                method,
-                endpoint,
-                headers=headers,
-                json=payload,
-                timeout=timeout
-            )
+            if config.get("use_remote_llm"):
+                response = call_llm_via_supabase(payload, config, headers=headers)
+            else:
+                response = requests.request(
+                    method,
+                    endpoint,
+                    headers=headers,
+                    json=payload,
+                    timeout=timeout
+                )
             response.raise_for_status()  # Raises HTTPError for bad responses (4xx or 5xx)
 
             response_data = response.json()

--- a/tests/test_remote_llm.py
+++ b/tests/test_remote_llm.py
@@ -1,0 +1,32 @@
+import pytest
+from agent_s3.llm_utils import call_llm_via_supabase
+from agent_s3.config import ConfigModel
+
+
+def test_call_llm_via_supabase_includes_token(monkeypatch):
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured['url'] = url
+        captured['headers'] = headers
+        class Resp:
+            status_code = 200
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {'ok': True}
+        return Resp()
+
+    monkeypatch.setattr('requests.post', fake_post)
+    config = ConfigModel(
+        use_remote_llm=True,
+        supabase_url='https://example.supabase.co',
+        supabase_function='edge-llm',
+        github_oauth_token='test-token',
+        llm_default_timeout=5
+    )
+    payload = {'prompt': 'hi'}
+    resp = call_llm_via_supabase(payload, config)
+    assert resp.status_code == 200
+    assert captured['headers']['Authorization'] == 'Bearer test-token'
+    assert 'edge-llm' in captured['url']


### PR DESCRIPTION
## Summary
- expose OAuth token in configuration
- add remote LLM options
- include token when calling Supabase
- store token via CLI when authenticating
- document Supabase validation
- add test for call_llm_via_supabase

## Testing
- `ruff check agent_s3/config.py agent_s3/llm_utils.py agent_s3/router_agent.py agent_s3/cli.py tests/test_remote_llm.py`
- `mypy agent_s3` *(fails: unterminated string literal)*
- `pytest tests/test_remote_llm.py -q` *(fails: command not found)*