### PR TITLE
docs: document remote llm usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,17 @@ python -m agent_s3.cli "Implement user authentication using JWT"
 python -m agent_s3.cli /db list
 python -m agent_s3.cli /db schema
 python -m agent_s3.cli /db query <db_name> "SELECT * FROM users"
-``` 
+```
+
+### Remote LLM via Supabase
+Set `USE_REMOTE_LLM=true` to forward prompts to a remote Supabase service. Ensure `SUPABASE_URL` and `SUPABASE_ANON_KEY` are set:
+
+```bash
+USE_REMOTE_LLM=true \
+SUPABASE_URL=https://your-project.supabase.co \
+SUPABASE_ANON_KEY=your-anon-key \
+python -m agent_s3.cli "Generate a README outline"
+```
 
 ### VS Code
 - **Initialize:** `Agent-S3: Initialize workspace`


### PR DESCRIPTION
## Summary
- explain how to enable `USE_REMOTE_LLM` in **README**
- show example CLI command forwarding prompts to Supabase

## Testing
- `ruff check agent_s3` *(fails: 795 errors)*
- `mypy agent_s3` *(fails: unterminated string literal)*
- `pytest` *(fails: command not found)*