### PR TITLE
Improve logging security

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
   - `OPENROUTER_KEY` (or other LLM keys)
   - **Token Encryption:** `AGENT_S3_ENCRYPTION_KEY` (required for GitHub token storage)
   - `DENYLIST_COMMANDS`, `COMMAND_TIMEOUT`, `CLI_COMMAND_WARNINGS` in config
+  
+For hosted deployments, store secrets as environment variables or use a provider like **Supabase secrets** to manage API keys securely.
 
 ## Coding Guidelines
 

--- a/agent_s3/llm_utils.py
+++ b/agent_s3/llm_utils.py
@@ -393,9 +393,11 @@ def get_embedding(
             
             # If we couldn't extract the embedding, log and retry
             print(f"Failed to extract embedding from response: {data}")
-            
+
         except Exception as e:
-            print(f"Embedding generation attempt {attempt+1} failed: {e}")
+            from agent_s3.security_utils import strip_sensitive_headers
+            sanitized = strip_sensitive_headers(str(e))
+            print(f"Embedding generation attempt {attempt+1} failed: {sanitized}")
             if attempt == retry_count - 1:
                 # Final attempt failed
                 return None

--- a/agent_s3/security_utils.py
+++ b/agent_s3/security_utils.py
@@ -1,0 +1,26 @@
+"""Security-related utility functions for Agent-S3."""
+
+import re
+
+SENSITIVE_HEADERS = {
+    "authorization",
+    "x-api-key",
+    "api-key",
+    "x-auth-token",
+    "token",
+    "openai-api-key",
+}
+
+
+def strip_sensitive_headers(message: str) -> str:
+    """Remove sensitive header values from a log or error message."""
+    if not message:
+        return message
+
+    pattern = re.compile(r"(?i)(" + "|".join(map(re.escape, SENSITIVE_HEADERS)) + r")\s*:\s*[^\s\n]+")
+
+    def _replacer(match: re.Match[str]) -> str:
+        header = match.group(1)
+        return f"{header}: <redacted>"
+
+    return pattern.sub(_replacer, message)

--- a/tests/test_security_utils.py
+++ b/tests/test_security_utils.py
@@ -1,0 +1,13 @@
+import pytest
+
+from agent_s3.security_utils import strip_sensitive_headers
+
+
+def test_strip_sensitive_headers_removes_tokens():
+    msg = "Error: Authorization: Bearer SECRET123 X-Api-Key: key456"
+    sanitized = strip_sensitive_headers(msg)
+    assert "SECRET123" not in sanitized
+    assert "key456" not in sanitized
+    assert "Authorization: <redacted>" in sanitized
+    assert "X-Api-Key: <redacted>" in sanitized
+


### PR DESCRIPTION
## Summary
- sanitize sensitive headers in error messages
- provide helper to remove Authorization tokens
- mention Supabase secrets in the docs
- add unit test for header stripping

## Testing
- `ruff check agent_s3`
- `mypy agent_s3`
- `pytest -q` *(fails: command not found)*