### PR TITLE
Add Supabase LLM helper

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ psycopg2-binary>=2.9.0
 pymysql>=1.0.0
 jsonschema>=4.0.0
 cryptography>=41.0.0
+requests>=2.31.0
+supabase-py>=2.0.0

--- a/tests/test_llm_utils_supabase.py
+++ b/tests/test_llm_utils_supabase.py
@@ -1,0 +1,64 @@
+import sys
+import types
+from unittest.mock import MagicMock
+
+
+# Provide a minimal 'requests' stub for the module under test
+requests_stub = types.ModuleType("requests")
+class HTTPError(Exception):
+    def __init__(self, response=None):
+        super().__init__("HTTP error")
+        self.response = response
+class RequestException(Exception):
+    pass
+requests_stub.HTTPError = HTTPError
+requests_stub.RequestException = RequestException
+requests_stub.post = lambda *a, **k: None
+sys.modules.setdefault("requests", requests_stub)
+
+# ruff: noqa: E402
+from agent_s3.llm_utils import call_llm_via_supabase, requests as llm_requests
+
+class DummyConfig:
+    supabase_url = "https://example.supabase.co"
+    supabase_service_key = "service-key"
+    llm_max_retries = 2
+    llm_initial_backoff = 0
+    llm_backoff_factor = 1
+    llm_default_timeout = 5
+
+def test_call_llm_via_supabase_success(monkeypatch):
+    dummy_resp = MagicMock()
+    dummy_resp.json.return_value = {"result": "ok"}
+    dummy_resp.raise_for_status.return_value = None
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        assert url.endswith("/functions/v1/llm")
+        return dummy_resp
+
+    monkeypatch.setattr("agent_s3.llm_utils.create_client", lambda u, k: object())
+    monkeypatch.setattr(llm_requests, "post", fake_post)
+
+    result = call_llm_via_supabase({"prompt": "hi"}, DummyConfig())
+    assert result == {"result": "ok"}
+
+def test_call_llm_via_supabase_retry(monkeypatch):
+    attempts = {"count": 0}
+    err = HTTPError(types.SimpleNamespace(status_code=500))
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        attempts["count"] += 1
+        resp = MagicMock()
+        if attempts["count"] == 1:
+            resp.raise_for_status.side_effect = err
+        else:
+            resp.raise_for_status.return_value = None
+            resp.json.return_value = {"ok": True}
+        return resp
+
+    monkeypatch.setattr("agent_s3.llm_utils.create_client", lambda u, k: object())
+    monkeypatch.setattr(llm_requests, "post", fake_post)
+
+    result = call_llm_via_supabase({"prompt": "hi"}, DummyConfig())
+    assert attempts["count"] == 2
+    assert result == {"ok": True}


### PR DESCRIPTION
## Summary
- allow optional Supabase integration for LLM calls
- specify `requests` and `supabase-py` dependencies
- test Supabase caller logic

## Testing
- `ruff check agent_s3/llm_utils.py tests/test_llm_utils_supabase.py` *(fails: various existing lint errors)*
- `mypy agent_s3` *(fails: syntax error in unrelated file)*
- `python -m pytest tests/test_llm_utils_supabase.py::test_call_llm_via_supabase_success -q` *(fails: No module named pytest)*
