### PR TITLE
Add changelog entry for Supabase LLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+<!--
+File: CHANGELOG.md
+Description: Release notes for Agent-S3.
+-->
+
+# Changelog
+
+## [Unreleased]
+### Added
+- **Supabase-based remote LLM option** enabling prompts and responses to be stored remotely.
+- Dependency on the `supabase-py` client for interacting with Supabase.
+
+### Environment Variables
+- `SUPABASE_URL` – base URL of the Supabase instance.
+- `SUPABASE_SERVICE_ROLE_KEY` – key used for privileged Supabase operations.
+- `SUPABASE_ANON_KEY` – optional key for anonymous access when applicable.
+
+### Security
+- API keys are now stored remotely via Supabase, reducing local exposure risk.


### PR DESCRIPTION
## Summary
- document Supabase-based remote LLM option
- list new `supabase-py` dependency
- describe `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY`
- note security benefit of remote key storage

## Testing
- `pip install -r requirements.txt` *(fails: Could not fetch packages)*