### PR TITLE
Add module-level docstring for Supabase tests

### DIFF
--- a/tests/test_llm_utils_supabase.py
+++ b/tests/test_llm_utils_supabase.py
@@ -1,0 +1,8 @@
+"""Tests for Supabase-backed LLM integration utilities.
+
+This module verifies that the ``call_llm_via_supabase`` helper constructs
+requests correctly, applies authentication headers, parses Supabase
+responses, and handles error conditions gracefully. All network
+interactions are mocked to ensure deterministic behavior.
+"""
+


### PR DESCRIPTION
## Summary
- add a descriptive docstring for `tests/test_llm_utils_supabase.py`

## Testing
- `ruff check agent_s3/ tests/`
- `mypy agent_s3/`
- `python -m pytest tests/test_llm_utils_supabase.py -q` *(fails: No module named pytest)*