### PR TITLE
Refactor Supabase LLM utils test

### DIFF
--- a/tests/test_llm_utils_supabase.py
+++ b/tests/test_llm_utils_supabase.py
@@ -1,0 +1,61 @@
+import pytest
+
+from agent_s3.llm_utils import call_llm_via_supabase
+
+class DummyResponse:
+    def __init__(self, json_data=None, text='', status_code=200):
+        self._json = json_data or {}
+        self.text = text
+        self.status_code = status_code
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if not (200 <= self.status_code < 300):
+            raise Exception('Error')
+
+
+def test_missing_config_raises_value_error():
+    with pytest.raises(ValueError):
+        call_llm_via_supabase('prompt', 'token', {})
+
+
+def test_call_llm_via_supabase(monkeypatch):
+    def fake_post(url, json=None, headers=None, timeout=None):
+        assert url == 'https://example.supabase.co/edge'
+        assert json == {'prompt': 'hello'}
+        assert headers['X-GitHub-Token'] == 'gh-token'
+        return DummyResponse({'response': 'hi'})
+
+    monkeypatch.setattr('requests.post', fake_post)
+
+    result = call_llm_via_supabase(
+        'hello',
+        'gh-token',
+        {
+            'supabase_url': 'https://example.supabase.co/edge',
+            'supabase_service_role_key': 'key',
+            'llm_default_timeout': 10,
+        },
+    )
+
+    assert result == 'hi'
+
+
+def test_openai_style_response(monkeypatch):
+    def fake_post(url, json=None, headers=None, timeout=None):
+        return DummyResponse({'choices': [{'text': 'openai text'}]})
+
+    monkeypatch.setattr('requests.post', fake_post)
+
+    result = call_llm_via_supabase(
+        'hello',
+        'gh-token',
+        {
+            'supabase_url': 'https://example.supabase.co/edge',
+            'supabase_service_role_key': 'key',
+        },
+    )
+
+    assert result == 'openai text'


### PR DESCRIPTION
## Summary
- create `tests/test_llm_utils_supabase.py`
- patch `requests.post` using `monkeypatch` for Supabase LLM util tests

## Testing
- `python -m pytest tests/test_llm_utils_supabase.py -q` *(fails: No module named pytest)*