### PR TITLE
Use logging instead of print in get_embedding

### DIFF
--- a/agent_s3/llm_utils.py
+++ b/agent_s3/llm_utils.py
@@ -478,10 +478,10 @@ def get_embedding(
                     return embedding
             
             # If we couldn't extract the embedding, log and retry
-            print(f"Failed to extract embedding from response: {data}")
+            logging.debug("Failed to extract embedding from response: %s", data)
             
         except Exception as e:
-            print(f"Embedding generation attempt {attempt+1} failed: {e}")
+            logging.debug("Embedding generation attempt %d failed: %s", attempt + 1, e)
             if attempt == retry_count - 1:
                 # Final attempt failed
                 return None


### PR DESCRIPTION
## Summary
- log embedding errors with `logging.debug` instead of `print`

## Testing
- `python -m pytest tests/test_incremental_indexing.py::TestIncrementalIndexing.test_incremental_indexing -k get_embedding -q` *(fails: No module named pytest)*