### PR TITLE
Add remote LLM fallback

### DIFF
--- a/agent_s3/llm_utils.py
+++ b/agent_s3/llm_utils.py
@@ -160,6 +160,25 @@ def cached_call_llm(prompt, llm, return_kv=False, **kwargs):
         scratchpad_manager=scratchpad_manager,
         prompt_summary=prompt_summary
     )
+
+    if not result.get('success') and use_remote_llm:
+        if scratchpad_manager:
+            scratchpad_manager.log(
+                "LLM Utils",
+                "Remote LLM failed, falling back to local"
+            )
+        else:
+            logging.warning("Remote LLM failed, falling back to local")
+
+        llm_to_use = llm
+        result = call_llm_with_retry(
+            llm_client_instance=llm_to_use,
+            method_name=method_name,
+            prompt_data=prompt_data,
+            config=config,
+            scratchpad_manager=scratchpad_manager,
+            prompt_summary=prompt_summary
+        )
     
     if result['success']:
         response = result['response']

--- a/tests/test_remote_llm.py
+++ b/tests/test_remote_llm.py
@@ -1,0 +1,46 @@
+import builtins
+from unittest.mock import patch
+
+import pytest
+
+from agent_s3.llm_utils import cached_call_llm
+from agent_s3.config import ConfigModel
+
+class DummyLLM:
+    def __init__(self):
+        self.calls = []
+
+    def generate(self, params):
+        self.calls.append(params)
+        return "local"
+
+def test_remote_llm_invocation(monkeypatch):
+    cfg = ConfigModel(use_remote_llm=True, supabase_url="http://test", supabase_service_role_key="key")
+    dummy = DummyLLM()
+    called = {}
+
+    def fake_remote(prompt, token, config, timeout=None):
+        called["args"] = (prompt, token, config, timeout)
+        return "remote"
+
+    monkeypatch.setattr("agent_s3.llm_utils.call_llm_via_supabase", fake_remote)
+    result = cached_call_llm("hi", dummy, config=cfg, github_token="tok")
+    assert result == "remote"
+    assert called["args"][0] == "hi"
+    assert called["args"][1] == "tok"
+    assert called["args"][2] == cfg
+    assert not dummy.calls
+
+
+def test_remote_llm_fallback(monkeypatch):
+    cfg = ConfigModel(use_remote_llm=True, supabase_url="http://test", supabase_service_role_key="key")
+    dummy = DummyLLM()
+
+    def failing_remote(*_args, **_kwargs):
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr("agent_s3.llm_utils.call_llm_via_supabase", failing_remote)
+    result = cached_call_llm("hi", dummy, config=cfg, github_token="tok")
+    assert result == "local"
+    assert dummy.calls
+


### PR DESCRIPTION
## Summary
- fall back to local LLM when remote Supabase call fails
- add tests covering remote invocation and fallback logic

## Testing
- `python -m pytest tests/test_remote_llm.py::test_remote_llm_invocation -q` *(fails: No module named pytest)*