### PR TITLE
Handle edge function path for Supabase LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
   - `DENYLIST_COMMANDS`, `COMMAND_TIMEOUT`, `CLI_COMMAND_WARNINGS` in config
   - `SUPABASE_URL` and `SUPABASE_SERVICE_KEY` for Supabase integration
   - `USE_REMOTE_LLM` to toggle remote LLM usage
+  - `SUPABASE_EDGE_FUNCTION_PATH` (optional path for the remote LLM function)
 
   Example `.env`:
 
@@ -377,6 +378,7 @@ Set `USE_REMOTE_LLM=true` to forward prompts to a remote Supabase service. Ensur
 USE_REMOTE_LLM=true \
 SUPABASE_URL=https://your-project.supabase.co \
 SUPABASE_ANON_KEY=your-anon-key \
+SUPABASE_EDGE_FUNCTION_PATH=functions/v1/llm \
 python -m agent_s3.cli "Generate a README outline"
 ```
 

--- a/agent_s3/config.py
+++ b/agent_s3/config.py
@@ -5,13 +5,11 @@ Handles configuration loading and default parameters.
 
 import os
 import re
-import glob
 import json
-import time
 import logging
 import platform
 from pathlib import Path
-from typing import Optional, Dict, List, Any, Union
+from typing import Optional, Dict, List, Any
 
 from pydantic import BaseModel, ValidationError
 
@@ -201,15 +199,14 @@ class ConfigModel(BaseModel):
     summarizer_timeout: float = SUMMARIZER_TIMEOUT
     supabase_url: str = os.environ.get("SUPABASE_URL", "")
     supabase_service_key: str = os.environ.get("SUPABASE_SERVICE_KEY", "")
+    supabase_anon_key: str = os.environ.get("SUPABASE_ANON_KEY", "")
+    supabase_edge_function_path: str = os.environ.get("SUPABASE_EDGE_FUNCTION_PATH", "")
     use_remote_llm: bool = os.environ.get("USE_REMOTE_LLM", "false").lower() == "true"
     adaptive_config_enabled: bool = ADAPTIVE_CONFIG_ENABLED
     adaptive_config_repo_path: str = ADAPTIVE_CONFIG_REPO_PATH
     adaptive_config_dir: str = ADAPTIVE_CONFIG_DIR
     adaptive_metrics_dir: str = ADAPTIVE_METRICS_DIR
     adaptive_optimization_interval: int = ADAPTIVE_OPTIMIZATION_INTERVAL
-    supabase_url: str = os.environ.get("SUPABASE_URL", "")
-    supabase_service_role_key: str = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
-    use_remote_llm: bool = os.getenv("USE_REMOTE_LLM", "false").lower() == "true"
 
     class Config:
         extra = "allow"


### PR DESCRIPTION
## Summary
- append optional `SUPABASE_EDGE_FUNCTION_PATH` to the Supabase URL
- avoid forwarding the path in the payload
- document new env var for remote LLM

## Testing
- `ruff check agent_s3/llm_utils.py agent_s3/config.py`
- `mypy agent_s3/llm_utils.py agent_s3/config.py`
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=42)*
- `pytest -q` *(fails: command not found)*