### PR TITLE
Add module docstring for Supabase LLM tests

### DIFF
--- a/tests/test_llm_utils_supabase.py
+++ b/tests/test_llm_utils_supabase.py
@@ -1,0 +1,8 @@
+"""Integration tests for Supabase-backed LLM utilities.
+
+These tests verify that :func:`call_llm_via_supabase` formats requests
+properly, attaches required authentication headers, parses responses, and
+handles error scenarios gracefully. All HTTP calls are mocked to keep the
+tests deterministic.
+"""
+


### PR DESCRIPTION
## Summary
- clarify module-level docstring for `test_llm_utils_supabase.py`

## Testing
- `ruff check tests/test_llm_utils_supabase.py`
- `mypy agent_s3/` *(fails: unterminated string literal in refinement_manager.py)*
- `python -m pytest tests/test_llm_utils_supabase.py -q` *(fails: No module named pytest)*
