### PR TITLE
Fix refinement prompt f-string

### DIFF
--- a/agent_s3/tools/code_analysis_tool.py
+++ b/agent_s3/tools/code_analysis_tool.py
@@ -141,9 +141,17 @@ class CodeAnalysisTool:
             logging.warning("FileTool not available to CodeAnalysisTool during __init__. Some operations might fail if not set later.")
 
     def lint(self, paths: Optional[List[str]] = None) -> List[Dict[str, Any]]:
-        """
+        """Run Ruff lint on the provided paths and return parsed results."""
+        paths = paths or ["."]
+        cmd = ["ruff", "--format", "json", *paths]
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, check=False, timeout=60
+            )
+        except Exception as e:
             logger.error(f"Error running Ruff lint: {e}")
             return []
+        output = result.stdout
         if not output:
             return []
         try:

--- a/agent_s3/tools/summarization/refinement_manager.py
+++ b/agent_s3/tools/summarization/refinement_manager.py
@@ -35,11 +35,22 @@ class SummaryRefinementManager:
         return f"You are an expert code summarizer. {lang_specific}Your task is to improve an existing summary based on feedback. Focus on accuracy, preserving important details, and maintaining the code's structural elements. Do not add information that isn't in the original code. Return only the improved summary without explanations."
 
     def _create_refinement_prompt(self, source: str, summary: str, validation: Dict[str, Any], language: Optional[str]) -> str:
-        issues = '\n- '.join([''] + validation["issues"])
-        return f"I need to improve this summary of the following {language or 'code'} source:\n\n```
+        issues = "\n- ".join([""] + validation["issues"])
+        return f"""I need to improve this summary of the following {language or 'code'} source:
+
+```{language or 'code'}
 {source}
 ```
-\nCurrent summary:\n```
+Current summary:
+```
 {summary}
 ```
-\nThe current summary has these issues:{issues}\n\nMetrics:\n- Faithfulness: {validation["metrics"]["faithfulness"]:.2f}\n- Detail Preservation: {validation["metrics"]["detail_preservation"]:.2f}\n- Structural Coherence: {validation["metrics"]["structural_coherence"]:.2f}\n- Overall Quality: {validation["metrics"]["overall"]:.2f}\n\nPlease provide an improved summary that addresses these issues."
+The current summary has these issues:{issues}
+
+Metrics:
+- Faithfulness: {validation['metrics']['faithfulness']:.2f}
+- Detail Preservation: {validation['metrics']['detail_preservation']:.2f}
+- Structural Coherence: {validation['metrics']['structural_coherence']:.2f}
+- Overall Quality: {validation['metrics']['overall']:.2f}
+
+Please provide an improved summary that addresses these issues."""


### PR DESCRIPTION
## Summary
- fix `_create_refinement_prompt` f-string
- close dangling docstring in `CodeAnalysisTool.lint`
- implement basic Ruff invocation for lint method

## Testing
- `ruff check agent_s3/tools/summarization/refinement_manager.py`
- `ruff check agent_s3/tools/code_analysis_tool.py`
- `python -m py_compile agent_s3/tools/code_analysis_tool.py`
- `python -m py_compile agent_s3/tools/summarization/refinement_manager.py`
- `mypy agent_s3/tools/summarization/refinement_manager.py agent_s3/tools/code_analysis_tool.py --ignore-missing-imports --follow-imports=skip`