### PR TITLE
Redact tokens in logs

### DIFF
--- a/agent_s3/auth.py
+++ b/agent_s3/auth.py
@@ -14,6 +14,8 @@ import sys
 import logging
 from cryptography.fernet import Fernet, InvalidToken
 
+from .logging_utils import strip_sensitive_headers
+
 # Define required dependencies - use proper requirements.txt for actual dependency management
 try:
     import requests
@@ -88,7 +90,7 @@ def save_token(token_data: Dict[str, Any]) -> None:
             import stat
             os.chmod(TOKEN_FILE, stat.S_IRUSR | stat.S_IWUSR)  # 0o600 - owner read/write only
     except Exception as e:
-        print(f"Warning: Could not securely save token: {e}")
+        print(strip_sensitive_headers(f"Warning: Could not securely save token: {e}"))
         # Fallback to basic storage if encryption fails
         with open(TOKEN_FILE, "w") as f:
             json.dump(token_data, f)
@@ -116,12 +118,12 @@ def load_token() -> Optional[Dict[str, Any]]:
             fernet = Fernet(key.encode() if isinstance(key, str) else key)
             decrypted = fernet.decrypt(content)
         except (InvalidToken, ValueError) as e:
-            print(f"Warning: Could not decrypt token: {e}")
+            print(strip_sensitive_headers(f"Warning: Could not decrypt token: {e}"))
             return None
 
         return json.loads(decrypted.decode("utf-8"))
     except Exception as e:
-        print(f"Warning: Could not load token: {e}")
+        print(strip_sensitive_headers(f"Warning: Could not load token: {e}"))
         return None
 
 
@@ -341,7 +343,7 @@ def _validate_token_and_check_org(token: str, target_org: str = "", expected_use
         return False, None
             
     except Exception as e:
-        print(f"Error in token validation: {e}")
+        print(strip_sensitive_headers(f"Error in token validation: {e}"))
         return False, None
 
 

--- a/agent_s3/logging_utils.py
+++ b/agent_s3/logging_utils.py
@@ -1,0 +1,19 @@
+"""Logging utilities for sanitizing sensitive information."""
+
+from __future__ import annotations
+
+import re
+
+# Pre-compiled regex to find Authorization headers with tokens
+_AUTH_HEADER_RE = re.compile(
+    r'(?i)("?authorization"?\s*[:=]\s*"?(?:bearer|token)\s*)([^"\s]+)("?)'
+)
+
+
+def strip_sensitive_headers(message: str) -> str:
+    """Redact Authorization header values in a log message.
+
+    This prevents accidental exposure of secrets when logging exceptions
+    that include HTTP headers.
+    """
+    return _AUTH_HEADER_RE.sub(lambda m: m.group(1) + "[REDACTED]" + m.group(3), message)

--- a/tests/test_auth_redaction.py
+++ b/tests/test_auth_redaction.py
@@ -1,0 +1,14 @@
+from agent_s3 import auth
+
+
+def test_token_redacted_on_exception(monkeypatch, capsys):
+    token = "abc123"
+
+    def fake_get(*args, **kwargs):
+        raise Exception(f"401 Unauthorized: Authorization: token {token}")
+
+    monkeypatch.setattr(auth.requests, "get", fake_get)
+
+    auth._validate_token_and_check_org(token, "org")
+    captured = capsys.readouterr()
+    assert token not in captured.out


### PR DESCRIPTION
## Summary
- add `strip_sensitive_headers` utility to remove Authorization token values
- sanitize error messages in `auth.py`
- test redaction behaviour on token validation errors

## Testing
- `ruff check agent_s3/logging_utils.py tests/test_auth_redaction.py`
- `mypy agent_s3/logging_utils.py --ignore-missing-imports --config-file=/dev/null` *(fails: unterminated string literal in unrelated file)*
- `pytest tests/test_auth_redaction.py -q` *(fails: pytest not installed)*