### PR TITLE
Expose strip_sensitive_headers in package init

### DIFF
--- a/agent_s3/__init__.py
+++ b/agent_s3/__init__.py
@@ -15,6 +15,7 @@ from agent_s3.command_processor import CommandProcessor
 from agent_s3.pre_planning_validator import PrePlanningValidator
 from agent_s3.complexity_analyzer import ComplexityAnalyzer
 from agent_s3.database_manager import DatabaseManager
+from agent_s3.security_utils import strip_sensitive_headers
 from agent_s3.pre_planning_errors import (
     AgentS3BaseError, PrePlanningError, ValidationError,
     SchemaError, RepairError, ComplexityError, handle_pre_planning_errors
@@ -37,4 +38,5 @@ __all__ = [
     'handle_pre_planning_errors',
     'CommandProcessor',
     'DatabaseManager',
+    'strip_sensitive_headers',
 ]

--- a/agent_s3/security_utils.py
+++ b/agent_s3/security_utils.py
@@ -1,0 +1,27 @@
+"""Security-related utility functions for Agent-S3."""
+
+from typing import MutableMapping, Dict
+
+SENSITIVE_HEADERS = {"authorization", "cookie", "set-cookie"}
+
+
+def strip_sensitive_headers(headers: MutableMapping[str, str]) -> Dict[str, str]:
+    """Return a copy of ``headers`` with sensitive values redacted.
+
+    This is useful when logging or debugging HTTP requests and responses.
+    Only non-sensitive headers retain their original values. Sensitive
+    headers are replaced with the string ``"[REDACTED]"``.
+
+    Args:
+        headers: Mapping of header names to values.
+
+    Returns:
+        A new dictionary with sensitive header values redacted.
+    """
+    sanitized: Dict[str, str] = {}
+    for name, value in headers.items():
+        if name.lower() in SENSITIVE_HEADERS:
+            sanitized[name] = "[REDACTED]"
+        else:
+            sanitized[name] = value
+    return sanitized


### PR DESCRIPTION
## Summary
- export `strip_sensitive_headers` from package init
- provide security utilities module with `strip_sensitive_headers`

## Testing
- `ruff check agent_s3/__init__.py agent_s3/security_utils.py`
- `mypy --follow-imports=skip agent_s3/__init__.py agent_s3/security_utils.py`
