### PR TITLE
Add commit message guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing
+
+We welcome contributions that improve Agent-S3. Before opening a pull request, please ensure the following:
+
+- **Testing and linting:**
+  - Run `pytest` and confirm all tests pass.
+  - Run `mypy agent_s3` for static type checking.
+  - Run `ruff check agent_s3` for linting.
+  - Write commit messages according to the [Conventional Commits](#commit-messages) specification.
+
+## Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) with the format `<type>(<scope>): <description>`.
+Keep the description concise and in the imperative mood.
+Examples:
+
+```
+fix(security): sanitize header logs
+docs(readme): mention Supabase secrets
+```
+
+For details on development workflows and project guidelines, see `.github/copilot-instructions.md` and `README.md`.
+
+

--- a/README.md
+++ b/README.md
@@ -396,8 +396,8 @@ python -m agent_s3.cli "Generate a README outline"
 
 Contributions welcome! Please:
 - Ensure tests pass and lint/type checks are clean
-- Follow PEP 8 and core criteria in `.github/copilot-instructions.md`
-- Use conventional commits
+- Follow PEP 8 and the core criteria in `.github/copilot-instructions.md`
+- Use [Conventional Commits](CONTRIBUTING.md#commit-messages) for commit messages
 
 ## License
 


### PR DESCRIPTION
## Summary
- document commit message format
- link contributing guidelines from README

## Testing
- `ruff check agent_s3` *(fails: unused imports and other errors)*
- `mypy agent_s3` *(fails: syntax error)*
- `pytest -q` *(fails: pytest not installed)*
