### PR TITLE
Add module-level docstring for Supabase tests

### DIFF
--- a/tests/test_llm_utils_supabase.py
+++ b/tests/test_llm_utils_supabase.py
@@ -1,0 +1,7 @@
+"""Integration tests for Supabase-based LLM utilities.
+
+These tests ensure that :func:`call_llm_via_supabase` builds requests with the
+proper authentication headers, parses responses, and gracefully handles error
+conditions. All HTTP interactions are mocked for deterministic behavior.
+"""
+


### PR DESCRIPTION
## Summary
- add a descriptive docstring for `tests/test_llm_utils_supabase.py`
- refine wording for clarity

## Testing
- `ruff check agent_s3/ tests/` *(fails: Found 1574 errors, 558 fixable)*
- `mypy agent_s3/` *(fails: unterminated string literal)*
- `python -m pytest tests/test_llm_utils_supabase.py -q` *(fails: No module named pytest)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.