### PR TITLE
Update Supabase env vars in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,10 +277,11 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
   - **GitHub OAuth:** `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`
   - **GitHub App:** `GITHUB_APP_ID`, `GITHUB_PRIVATE_KEY`
   - `GITHUB_ORG` (optional membership filter)
-  - `OPENROUTER_KEY` (or other LLM keys)
+  - `OPENROUTER_KEY` (or other LLM keys such as `OPENAI_KEY`)
   - **Token Encryption:** `AGENT_S3_ENCRYPTION_KEY` (required for GitHub token storage)
   - `DENYLIST_COMMANDS`, `COMMAND_TIMEOUT`, `CLI_COMMAND_WARNINGS` in config
-  - `SUPABASE_URL` and `SUPABASE_SERVICE_KEY` for Supabase integration
+  - `SUPABASE_URL`, `SUPABASE_SERVICE_KEY`, `SUPABASE_SERVICE_ROLE_KEY` for Supabase integration
+  - `SUPABASE_EDGE_FUNCTION_PATH` (optional, defaults to the root function)
   - `USE_REMOTE_LLM` to toggle remote LLM usage
 
   Example `.env`:
@@ -288,6 +289,8 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
   ```env
   SUPABASE_URL=https://your-project.supabase.co
   SUPABASE_SERVICE_KEY=your-service-key
+  SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+  # SUPABASE_EDGE_FUNCTION_PATH=/functions/v1/call-llm
   USE_REMOTE_LLM=true
   ```
 
@@ -371,12 +374,13 @@ python -m agent_s3.cli /db query <db_name> "SELECT * FROM users"
 ```
 
 ### Remote LLM via Supabase
-Set `USE_REMOTE_LLM=true` to forward prompts to a remote Supabase service. Ensure `SUPABASE_URL` and `SUPABASE_ANON_KEY` are set:
+Set `USE_REMOTE_LLM=true` to forward prompts to a remote Supabase service. Ensure `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are set. `SUPABASE_EDGE_FUNCTION_PATH` is optional and defaults to the root function:
 
 ```bash
 USE_REMOTE_LLM=true \
 SUPABASE_URL=https://your-project.supabase.co \
-SUPABASE_ANON_KEY=your-anon-key \
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key \
+# SUPABASE_EDGE_FUNCTION_PATH=/functions/v1/call-llm \
 python -m agent_s3.cli "Generate a README outline"
 ```
 


### PR DESCRIPTION
## Summary
- document the SUPABASE_SERVICE_ROLE_KEY variable
- mention optional SUPABASE_EDGE_FUNCTION_PATH
- update the remote LLM example to use the new variables

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*