### PR TITLE
Refactor ConfigModel supabase fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,14 +280,16 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
   - `OPENROUTER_KEY` (or other LLM keys)
   - **Token Encryption:** `AGENT_S3_ENCRYPTION_KEY` (required for GitHub token storage)
   - `DENYLIST_COMMANDS`, `COMMAND_TIMEOUT`, `CLI_COMMAND_WARNINGS` in config
-  - `SUPABASE_URL` and `SUPABASE_SERVICE_KEY` for Supabase integration
+  - `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` for Supabase integration
+  - `SUPABASE_ANON_KEY` (optional anonymous key)
   - `USE_REMOTE_LLM` to toggle remote LLM usage
 
   Example `.env`:
 
   ```env
   SUPABASE_URL=https://your-project.supabase.co
-  SUPABASE_SERVICE_KEY=your-service-key
+  SUPABASE_SERVICE_ROLE_KEY=your-service-key
+  SUPABASE_ANON_KEY=your-anon-key
   USE_REMOTE_LLM=true
   ```
 

--- a/agent_s3/config.py
+++ b/agent_s3/config.py
@@ -200,16 +200,15 @@ class ConfigModel(BaseModel):
     summarizer_max_chunk_size: int = SUMMARIZER_MAX_CHUNK_SIZE
     summarizer_timeout: float = SUMMARIZER_TIMEOUT
     supabase_url: str = os.environ.get("SUPABASE_URL", "")
-    supabase_service_key: str = os.environ.get("SUPABASE_SERVICE_KEY", "")
-    use_remote_llm: bool = os.environ.get("USE_REMOTE_LLM", "false").lower() == "true"
+    supabase_service_role_key: str = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
+    supabase_anon_key: str = os.getenv("SUPABASE_ANON_KEY", "")
+    edge_function_path: str = os.getenv("SUPABASE_EDGE_FUNCTION_PATH", "")
+    use_remote_llm: bool = os.getenv("USE_REMOTE_LLM", "false").lower() == "true"
     adaptive_config_enabled: bool = ADAPTIVE_CONFIG_ENABLED
     adaptive_config_repo_path: str = ADAPTIVE_CONFIG_REPO_PATH
     adaptive_config_dir: str = ADAPTIVE_CONFIG_DIR
     adaptive_metrics_dir: str = ADAPTIVE_METRICS_DIR
     adaptive_optimization_interval: int = ADAPTIVE_OPTIMIZATION_INTERVAL
-    supabase_url: str = os.environ.get("SUPABASE_URL", "")
-    supabase_service_role_key: str = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
-    use_remote_llm: bool = os.getenv("USE_REMOTE_LLM", "false").lower() == "true"
 
     class Config:
         extra = "allow"


### PR DESCRIPTION
## Summary
- consolidate duplicate Supabase fields in `ConfigModel`
- remove unused `supabase_service_key`
- add optional `supabase_anon_key` and `edge_function_path`
- document new env vars in README

## Testing
- `ruff check agent_s3/config.py | head -n 5`
- `mypy agent_s3/config.py | head -n 4`
- `python -m pytest -q` *(fails: No module named pytest)*