### PR TITLE
Add docstring to Supabase LLM utils tests

### DIFF
--- a/tests/test_llm_utils_supabase.py
+++ b/tests/test_llm_utils_supabase.py
@@ -1,3 +1,5 @@
+"""Tests for the Supabase-based LLM invocation helper."""
+
 from agent_s3.llm_utils import call_llm_via_supabase
 
 class DummyResponse:


### PR DESCRIPTION
## Summary
- add a module-level docstring for the Supabase LLM utils tests

## Testing
- `ruff check tests/test_llm_utils_supabase.py`
- `mypy agent_s3/` *(fails: Name "Coordinator" is not defined)*
- `python -m pytest tests/test_llm_utils_supabase.py -q` *(fails: No module named pytest)*