### PR TITLE
docs(readme): document Supabase edge function path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Description: Release notes for Agent-S3.
 - `SUPABASE_URL` – base URL of the Supabase instance.
 - `SUPABASE_SERVICE_ROLE_KEY` – key used for privileged Supabase operations.
 - `SUPABASE_ANON_KEY` – optional key for anonymous access when applicable.
+- `SUPABASE_EDGE_FUNCTION_PATH` – optional path to the Supabase Edge function used for LLM calls.
 
 ### Security
 - API keys are now stored remotely via Supabase, reducing local exposure risk.

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
   SUPABASE_URL=https://your-project.supabase.co
   SUPABASE_SERVICE_KEY=your-service-key
   SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
-  # SUPABASE_EDGE_FUNCTION_PATH=/functions/v1/call-llm
+  SUPABASE_EDGE_FUNCTION_PATH=/functions/v1/call-llm
   USE_REMOTE_LLM=true
   ```
 
@@ -374,13 +374,13 @@ python -m agent_s3.cli /db query <db_name> "SELECT * FROM users"
 ```
 
 ### Remote LLM via Supabase
-Set `USE_REMOTE_LLM=true` to forward prompts to a remote Supabase service. Ensure `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are set. `SUPABASE_EDGE_FUNCTION_PATH` is optional and defaults to the root function:
+Set `USE_REMOTE_LLM=true` to forward prompts to a remote Supabase service. Ensure `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` (or `SUPABASE_SERVICE_KEY`) are set. `SUPABASE_EDGE_FUNCTION_PATH` is optional and defaults to the root function:
 
 ```bash
 USE_REMOTE_LLM=true \
 SUPABASE_URL=https://your-project.supabase.co \
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key \
-# SUPABASE_EDGE_FUNCTION_PATH=/functions/v1/call-llm \
+SUPABASE_EDGE_FUNCTION_PATH=/functions/v1/call-llm \
 python -m agent_s3.cli "Generate a README outline"
 ```
 


### PR DESCRIPTION
## Summary
- document SUPABASE_EDGE_FUNCTION_PATH in the configuration list and .env example
- clarify Supabase remote LLM instructions to mention service role key
- update changelog

## Testing
- `pytest tests/test_llm_utils_supabase.py tests/test_remote_llm.py -q` *(fails: `pytest` not installed)*