### PR TITLE
Fix JSON decode errors in Supabase LLM calls

### DIFF
--- a/agent_s3/llm_utils.py
+++ b/agent_s3/llm_utils.py
@@ -73,7 +73,13 @@ def call_llm_via_supabase(prompt: str, github_token: str, config: Dict[str, Any]
         timeout=timeout or config.get("llm_default_timeout", 60.0),
     )
     response.raise_for_status()
-    data = response.json()
+    try:
+        data = response.json()
+    except json.JSONDecodeError as e:
+        snippet = response.text[:100]
+        raise ValueError(
+            f"Invalid JSON response from Supabase: {e}. Response snippet: {snippet}"
+        ) from e
     if isinstance(data, dict):
         if "response" in data:
             return data["response"]


### PR DESCRIPTION
## Summary
- handle JSON decoding errors from Supabase in `call_llm_via_supabase`

## Testing
- `ruff check agent_s3/llm_utils.py` *(fails: unused imports)*
- `ruff check agent_s3/` *(fails: unused imports)*
- `mypy agent_s3/` *(fails: unterminated string literal)*
- `pytest tests/test_cli.py::TestCliProcessCommand::test_plan_command -q` *(fails: pytest command not found)*
- This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.