### PR TITLE
docs(readme): add run tests script instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ pip install -r requirements-dev.txt
 ```
 
 - **Tests:** `pytest`
+- **Run Tests via Script:** `./scripts/run_tests.sh`
 - **Type Checking:** `mypy agent_s3`
 - **Linting:** `ruff check agent_s3`
 


### PR DESCRIPTION
## Summary
- clarify README Development section with a bullet to run `./scripts/run_tests.sh`

## Testing
- `pytest -q` *(fails: command not found)*