### PR TITLE
Add execute_generate facade and tests

### DIFF
--- a/agent_s3/coordinator.py
+++ b/agent_s3/coordinator.py
@@ -724,3 +724,15 @@ class Coordinator:
                 "design_file": os.path.join(os.getcwd(), "design.txt"),
                 "next_action": next_action,
             }
+
+    def execute_generate(self) -> str:
+        """Trigger code generation workflow via the command processor."""
+
+        with self.error_handler.error_context(
+            phase="generate",
+            operation="execute_generate",
+        ):
+            if not hasattr(self, "command_processor") or not self.command_processor:
+                raise CoordinationError("Command processor is not available")
+
+            return self.command_processor.execute_generate_command("")

--- a/tests/test_coordinator_facade_methods.py
+++ b/tests/test_coordinator_facade_methods.py
@@ -440,6 +440,16 @@ class TestCoordinatorFacadeMethods:
         # Verify delegate was called
         coordinator.command_processor.execute_generate_command.assert_called_once_with("")
         assert result == expected_result
+
+    def test_execute_generate_facade_exists(self, real_coordinator):
+        """Coordinator should delegate generate requests to its CommandProcessor."""
+        real_coordinator.command_processor = MagicMock()
+        real_coordinator.command_processor.execute_generate_command.return_value = "ok"
+
+        result = real_coordinator.execute_generate()
+
+        real_coordinator.command_processor.execute_generate_command.assert_called_once_with("")
+        assert result == "ok"
     
     def test_execute_implementation_facade(self, coordinator):
         """Test that the execute_implementation facade method delegates to ImplementationManager."""


### PR DESCRIPTION
## Summary
- add `execute_generate` facade method on Coordinator
- verify `execute_generate` delegates to CommandProcessor

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*