### PR TITLE
fix(llm_utils): report snippet on JSON decode error

### DIFF
--- a/agent_s3/llm_utils.py
+++ b/agent_s3/llm_utils.py
@@ -85,7 +85,11 @@ def call_llm_via_supabase(prompt: str, github_token: str, config: Dict[str, Any]
         headers=headers,
         timeout=timeout or config.get("llm_default_timeout", 60.0),
     )
-    data = response.json()
+    try:
+        data = response.json()
+    except json.JSONDecodeError as exc:  # pragma: no cover - network failure branch
+        snippet = response.text[:200].replace("\n", " ")
+        raise ValueError(f"Invalid JSON response: {snippet!r}") from exc
     if isinstance(data, dict):
         if "response" in data:
             return data["response"]

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -1,0 +1,54 @@
+import json
+
+import pytest
+
+from agent_s3.llm_utils import call_llm_via_supabase
+
+
+class DummyResponse:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+    def json(self) -> dict:
+        raise json.JSONDecodeError("error", self.text, 0)
+
+
+class DummyFunctions:
+    def __init__(self) -> None:
+        pass
+
+    def invoke(self, *args, **kwargs):
+        import requests  # delayed import for patching
+
+        return requests.post("http://example.com")
+
+
+class DummyClient:
+    def __init__(self) -> None:
+        self.functions = DummyFunctions()
+
+
+# fake create_client to avoid network
+
+def fake_create_client(url: str, key: str) -> DummyClient:
+    return DummyClient()
+
+
+def test_invalid_json_snippet(monkeypatch):
+    monkeypatch.setattr("agent_s3.llm_utils.create_client", fake_create_client)
+
+    def fake_post(*_args, **_kwargs):
+        return DummyResponse("{bad")
+
+    monkeypatch.setattr("requests.post", fake_post)
+
+    cfg = {
+        "supabase_url": "http://supabase",
+        "supabase_service_role_key": "key",
+        "supabase_function_name": "func",
+    }
+
+    with pytest.raises(ValueError) as exc:
+        call_llm_via_supabase("hi", "tok", cfg)
+
+    assert "{bad" in str(exc.value)


### PR DESCRIPTION
## Summary
- add snippet to call_llm_via_supabase when JSON decoding fails
- test error snippet handling for remote LLM

## Testing
- `ruff check agent_s3/llm_utils.py tests/test_llm_utils.py`
- `mypy --follow-imports=skip agent_s3/llm_utils.py`
- `pytest tests/test_llm_utils.py -q` *(fails: command not found)*