### PR TITLE
Improve Supabase test typing

### DIFF
--- a/tests/test_llm_utils_supabase.py
+++ b/tests/test_llm_utils_supabase.py
@@ -1,34 +1,46 @@
-"""Tests for the Supabase-based LLM invocation helper."""
+"""Unit tests for :func:`call_llm_via_supabase`.
+
+These tests verify that the helper interacts correctly with a mocked
+Supabase client and returns the expected response.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
 
 from agent_s3.llm_utils import call_llm_via_supabase
 
 class DummyResponse:
-    def __init__(self, data):
+    def __init__(self, data: dict[str, Any]) -> None:
         self._data = data
-    def json(self):
+
+    def json(self) -> dict[str, Any]:
         return self._data
 
 class DummyFunctions:
-    def __init__(self):
+    def __init__(self) -> None:
         self.invoked = False
-        self.args = None
-        self.kwargs = None
-    def invoke(self, *args, **kwargs):
+        self.args: tuple[Any, ...] | None = None
+        self.kwargs: dict[str, Any] | None = None
+
+    def invoke(self, *args: Any, **kwargs: Any) -> DummyResponse:
         self.invoked = True
         self.args = args
         self.kwargs = kwargs
         return DummyResponse({"response": "ok"})
 
 class DummyClient:
-    def __init__(self):
-        self.functions = DummyFunctions()
+    def __init__(self) -> None:
+        self.functions: DummyFunctions = DummyFunctions()
 
-def fake_create_client(url, key):
+def fake_create_client(url: str, key: str) -> DummyClient:
     assert url == "https://example.com"
     assert key == "servicekey"
     return DummyClient()
 
-def test_call_llm_via_supabase(monkeypatch):
+def test_call_llm_via_supabase(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("agent_s3.llm_utils.create_client", fake_create_client)
     result = call_llm_via_supabase(
         "hello",


### PR DESCRIPTION
## Summary
- add module-level docstring for Supabase helper tests
- annotate DummyResponse and helper functions with typing
- use typed argument in the test case

## Testing
- `ruff check tests/test_llm_utils_supabase.py`