### PR TITLE
Remove migration comments from coordinator and tests

### DIFF
--- a/agent_s3/coordinator.py
+++ b/agent_s3/coordinator.py
@@ -273,8 +273,6 @@ class Coordinator:
             # Now that we have the prompt moderator, update the workspace initializer
             self.workspace_initializer.prompt_moderator = self.prompt_moderator
             
-            # Pre-planning functionality has been moved to pre_planner_json_enforced.py
-            
             # Initialize task resumer
             self.task_resumer = TaskResumer(
                 coordinator=self,

--- a/tests/test_pre_planner_function_tests.py
+++ b/tests/test_pre_planner_function_tests.py
@@ -1,8 +1,4 @@
-"""Tests for function-level test requirements in pre_planner_json_enforced.
-
-This file has been updated to use pre_planner_json_enforced directly rather than the
-legacy PrePlanningManager class which is now just a compatibility wrapper.
-"""
+"""Tests for function-level test requirements in pre_planner_json_enforced."""
 import os
 import pytest
 from pathlib import Path


### PR DESCRIPTION
## Summary
- remove outdated pre-planning migration comment in `coordinator.py`
- simplify header note in `test_pre_planner_function_tests.py`

## Testing
- `ruff check agent_s3/coordinator.py tests/test_pre_planner_function_tests.py`
- `mypy agent_s3/coordinator.py tests/test_pre_planner_function_tests.py` *(fails: library stubs missing)*
