### PR TITLE
Remove generate command support

### DIFF
--- a/agent_s3/cli.py
+++ b/agent_s3/cli.py
@@ -42,8 +42,7 @@ Agent-S3 Command-Line Interface
 Commands:
   agent-s3 <prompt>        - Process a change request (full workflow)
   agent-s3 /plan <prompt>        - Generate a plan only (bypass execution)
-  agent-s3 /generate        - Generate code from plan.txt
-  agent-s3 /request <prompt>     - Full change request (plan, generate, execute)
+  agent-s3 /request <prompt>     - Full change request (plan, execute)
   agent-s3 /init           - Initialize the workspace
   agent-s3 /help           - Display this help message
   agent-s3 /config         - Show current configuration
@@ -63,7 +62,6 @@ Special Commands (can be used in prompt):
   /reload-llm-config       - Reload LLM configuration
   /explain                 - Explain the last LLM interaction
   /plan <prompt>           - Generate a plan only (bypass execution)
-  /generate                - Generate code from plan.txt
   /request <prompt>        - Full change request (plan + execution)
   /terminal <command>      - Execute shell commands literally (bypassing LLM)
   /design <objective>      - Start a design process

--- a/agent_s3/command_processor.py
+++ b/agent_s3/command_processor.py
@@ -27,7 +27,6 @@ class CommandProcessor:
         self.command_map = {
             "init": self.execute_init_command,
             "plan": self.execute_plan_command,
-            "generate": self.execute_generate_command,
             "test": self.execute_test_command,
             "debug": self.execute_debug_command,
             "terminal": self.execute_terminal_command,
@@ -190,67 +189,6 @@ class CommandProcessor:
             if hasattr(self.coordinator, 'progress_tracker'):
                 self.coordinator.progress_tracker.update_progress({
                     "phase": "plan",
-                    "status": "failed",
-                    "error": str(e),
-                    "timestamp": datetime.now().isoformat()
-                })
-            
-            return error_msg
-    
-    def execute_generate_command(self, args: str) -> str:
-        """Execute the generate command to generate code from a plan.
-        
-        Args:
-            args: Optional arguments (unused, plan is read from plan.txt)
-            
-        Returns:
-            Command result message
-        """
-        plan_file = Path("plan.txt")
-        if not plan_file.exists():
-            return "plan.txt not found. Please run /plan first."
-        
-        try:
-            plan_text = plan_file.read_text(encoding="utf-8").strip()
-            if not plan_text:
-                return "plan.txt is empty. Please run /plan first."
-            
-            # Update progress tracking
-            if hasattr(self.coordinator, 'progress_tracker'):
-                self.coordinator.progress_tracker.update_progress({
-                    "phase": "generate",
-                    "status": "started",
-                    "timestamp": datetime.now().isoformat()
-                })
-            
-            self._log("Executing code generation from plan.txt...")
-            print("Executing code generation and workflow from plan.txt...")
-            
-            # Execute code generation
-            if hasattr(self.coordinator, 'execute_generate'):
-                self.coordinator.execute_generate()
-            elif hasattr(self.coordinator, 'process_change_request'):
-                self.coordinator.process_change_request(plan_text, skip_planning=True)
-            else:
-                return "Code generation functionality not available."
-            
-            # Update progress tracking
-            if hasattr(self.coordinator, 'progress_tracker'):
-                self.coordinator.progress_tracker.update_progress({
-                    "phase": "generate",
-                    "status": "completed",
-                    "timestamp": datetime.now().isoformat()
-                })
-            
-            return "Code generation completed."
-        except Exception as e:
-            error_msg = f"Code generation failed: {e}"
-            self._log(error_msg, level="error")
-            
-            # Update progress tracking with failure
-            if hasattr(self.coordinator, 'progress_tracker'):
-                self.coordinator.progress_tracker.update_progress({
-                    "phase": "generate",
                     "status": "failed",
                     "error": str(e),
                     "timestamp": datetime.now().isoformat()
@@ -742,7 +680,6 @@ class CommandProcessor:
             help_msgs = {
                 "init": "Initialize workspace with essential files (personas.md, guidelines, etc.)",
                 "plan": "Generate a development plan from a request description",
-                "generate": "Generate code from plan.txt",
                 "test": "Run all tests in the codebase",
                 "debug": "Debug last test failure",
                 "terminal": "Execute a terminal command",
@@ -771,7 +708,6 @@ class CommandProcessor:
             help_text = """Available commands:
 /init: Initialize workspace
 /plan <description>: Generate a development plan
-/generate: Generate code from plan.txt
 /test [filter]: Run tests (optional filter)
 /debug: Debug last test failure
 /terminal <command>: Execute terminal command

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,12 +18,6 @@ class TestCliProcessCommand(unittest.TestCase):
         mock_print.assert_any_call("Plan written to plan.txt")
 
     @patch('builtins.print')
-    def test_generate_command(self, mock_print):
-        process_command(self.mock_coordinator, "/generate")
-        self.mock_coordinator.execute_generate.assert_called_once()
-        mock_print.assert_any_call("Executing /generate: running code generation and workflow from plan.txt...")
-
-    @patch('builtins.print')
     def test_test_command(self, mock_print):
         process_command(self.mock_coordinator, "/test")
         self.mock_coordinator.run_tests_all.assert_called_once()

--- a/tests/test_command_processor.py
+++ b/tests/test_command_processor.py
@@ -94,33 +94,6 @@ class TestCommandProcessor:
         # Verify
         assert "Please provide a plan description" in result
     
-    @patch('pathlib.Path.exists')
-    @patch('pathlib.Path.read_text')
-    def test_execute_generate_command(self, mock_read_text, mock_exists, command_processor, mock_coordinator):
-        """Test execute_generate_command."""
-        # Setup
-        mock_exists.return_value = True
-        mock_read_text.return_value = "Test plan content"
-        mock_coordinator.execute_generate = MagicMock()
-        
-        # Exercise
-        command_processor.execute_generate_command("")
-
-        # Verify
-        mock_coordinator.execute_generate.assert_called_once()
-        mock_coordinator.progress_tracker.update_progress.assert_called()
-    
-    @patch('pathlib.Path.exists')
-    def test_execute_generate_command_no_plan(self, mock_exists, command_processor):
-        """Test execute_generate_command with no plan file."""
-        # Setup
-        mock_exists.return_value = False
-        
-        # Exercise
-        result = command_processor.execute_generate_command("")
-        
-        # Verify
-        assert "plan.txt not found" in result
     
     def test_execute_test_command(self, command_processor, mock_coordinator):
         """Test execute_test_command."""
@@ -190,7 +163,6 @@ class TestCommandProcessor:
         assert "Available commands" in result
         assert "/init:" in result
         assert "/plan" in result
-        assert "/generate" in result
     
     def test_execute_help_command_specific(self, command_processor):
         """Test execute_help_command with a specific command."""
@@ -201,19 +173,6 @@ class TestCommandProcessor:
         assert "/init:" in result
         assert "Initialize workspace" in result
 
-    @patch('pathlib.Path.exists')
-    @patch('pathlib.Path.read_text')
-    def test_generate_command_fallback_to_process_change_request(self, mock_read_text, mock_exists, command_processor, mock_coordinator):
-        """Ensure generate command uses process_change_request when execute_generate is unavailable."""
-        mock_exists.return_value = True
-        mock_read_text.return_value = "Plan"
-        if hasattr(mock_coordinator, 'execute_generate'):
-            delattr(mock_coordinator, 'execute_generate')
-        mock_coordinator.process_change_request = MagicMock()
-
-        command_processor.execute_generate_command("")
-
-        mock_coordinator.process_change_request.assert_called_once_with("Plan", skip_planning=True)
 
     def test_execute_request_command(self, command_processor, mock_coordinator):
         """Test execute_request_command routes to process_change_request."""

--- a/tests/test_coordinator_facade_methods.py
+++ b/tests/test_coordinator_facade_methods.py
@@ -77,7 +77,6 @@ def coordinator():
     coordinator._get_llm_json_content = MagicMock(return_value='{"version":"1.0"}')
     coordinator._enhance_guidelines_with_tech_stack = MagicMock(return_value="Enhanced guidelines")
     coordinator.process_command = MagicMock(return_value="Command processed")
-    coordinator.execute_generate = MagicMock(return_value="Generated code")
     coordinator.execute_implementation = MagicMock(return_value={"success": True})
     coordinator.run_tests_all = MagicMock(return_value={"success": True})
     coordinator.execute_terminal_command = MagicMock(return_value=None)
@@ -419,26 +418,6 @@ class TestCoordinatorFacadeMethods:
         
         # Verify delegate was called
         coordinator.command_processor.process_command.assert_called_once_with("test", "arg1")
-        assert result == expected_result
-    
-    def test_execute_generate_facade(self, coordinator):
-        """Test that the execute_generate facade method delegates to CommandProcessor."""
-        # Set up return value
-        expected_result = "Generated code successfully"
-        coordinator.command_processor.execute_generate_command.return_value = expected_result
-        
-        # Define the function that will call the delegate
-        def delegate_to_command_processor():
-            return coordinator.command_processor.execute_generate_command("")
-        
-        # Replace the mock with our function that delegates to the delegate
-        coordinator.execute_generate.side_effect = delegate_to_command_processor
-        
-        # Call the method
-        result = coordinator.execute_generate()
-        
-        # Verify delegate was called
-        coordinator.command_processor.execute_generate_command.assert_called_once_with("")
         assert result == expected_result
     
     def test_execute_implementation_facade(self, coordinator):


### PR DESCRIPTION
## Summary
- delete all `/generate` entries from the CLI help
- drop `generate` command handling from `CommandProcessor`
- remove unused `execute_generate_command`
- clean up related tests

## Testing
- `pytest tests/test_cli.py tests/test_command_processor.py tests/test_coordinator_facade_methods.py -q` *(fails: `pytest` not found)*