### PR TITLE
Fix config duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
   - `OPENROUTER_KEY` (or other LLM keys such as `OPENAI_KEY`)
   - **Token Encryption:** `AGENT_S3_ENCRYPTION_KEY` (required for GitHub token storage)
   - `DENYLIST_COMMANDS`, `COMMAND_TIMEOUT`, `CLI_COMMAND_WARNINGS` in config
-  - `SUPABASE_URL`, `SUPABASE_SERVICE_KEY`, `SUPABASE_SERVICE_ROLE_KEY` for Supabase integration
+  - `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` for Supabase integration
   - `SUPABASE_EDGE_FUNCTION_PATH` (optional, defaults to the root function)
   - `USE_REMOTE_LLM` to toggle remote LLM usage
 
@@ -290,7 +290,6 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
 
   ```env
   SUPABASE_URL=https://your-project.supabase.co
-  SUPABASE_SERVICE_KEY=your-service-key
   SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
   SUPABASE_EDGE_FUNCTION_PATH=/functions/v1/call-llm
   USE_REMOTE_LLM=true
@@ -376,7 +375,7 @@ python -m agent_s3.cli /db query <db_name> "SELECT * FROM users"
 ```
 
 ### Remote LLM via Supabase
-Set `USE_REMOTE_LLM=true` to forward prompts to a remote Supabase service. Ensure `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` (or `SUPABASE_SERVICE_KEY`) are set. `SUPABASE_EDGE_FUNCTION_PATH` is optional and defaults to the root function:
+Set `USE_REMOTE_LLM=true` to forward prompts to a remote Supabase service. Ensure `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are set. `SUPABASE_EDGE_FUNCTION_PATH` is optional and defaults to the root function:
 
 ```bash
 USE_REMOTE_LLM=true \

--- a/agent_s3/config.py
+++ b/agent_s3/config.py
@@ -197,16 +197,13 @@ class ConfigModel(BaseModel):
     summarizer_max_chunk_size: int = SUMMARIZER_MAX_CHUNK_SIZE
     summarizer_timeout: float = SUMMARIZER_TIMEOUT
     supabase_url: str = os.environ.get("SUPABASE_URL", "")
-    supabase_service_key: str = os.environ.get("SUPABASE_SERVICE_KEY", "")
     use_remote_llm: bool = os.environ.get("USE_REMOTE_LLM", "false").lower() == "true"
     adaptive_config_enabled: bool = ADAPTIVE_CONFIG_ENABLED
     adaptive_config_repo_path: str = ADAPTIVE_CONFIG_REPO_PATH
     adaptive_config_dir: str = ADAPTIVE_CONFIG_DIR
     adaptive_metrics_dir: str = ADAPTIVE_METRICS_DIR
     adaptive_optimization_interval: int = ADAPTIVE_OPTIMIZATION_INTERVAL
-    supabase_url: str = os.environ.get("SUPABASE_URL", "")
     supabase_service_role_key: str = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
-    use_remote_llm: bool = os.getenv("USE_REMOTE_LLM", "false").lower() == "true"
 
     class Config:
         extra = "allow"


### PR DESCRIPTION
## Summary
- remove duplicate Supabase fields in ConfigModel
- clean docs referencing `SUPABASE_SERVICE_KEY`

## Testing
- `ruff check agent_s3`
- `mypy agent_s3`
- `pytest tests/test_config_pydantic.py::test_load_defaults tests/test_config_pydantic.py::test_invalid_config_file -q` *(fails: command not found)*