### PR TITLE
Fix Supabase status check in LLM utils

### DIFF
--- a/agent_s3/llm_utils.py
+++ b/agent_s3/llm_utils.py
@@ -85,6 +85,13 @@ def call_llm_via_supabase(prompt: str, github_token: str, config: Dict[str, Any]
         headers=headers,
         timeout=timeout or config.get("llm_default_timeout", 60.0),
     )
+
+    status_code = getattr(response, "status_code", 200)
+    if status_code >= 400:
+        snippet = getattr(response, "text", "")[:200].replace("\n", " ")
+        raise RuntimeError(
+            f"Supabase function {function_name!r} returned status {status_code}: {snippet!r}"
+        )
     try:
         data = response.json()
     except json.JSONDecodeError as exc:  # pragma: no cover - network failure branch

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -6,8 +6,9 @@ from agent_s3.llm_utils import call_llm_via_supabase
 
 
 class DummyResponse:
-    def __init__(self, text: str) -> None:
+    def __init__(self, text: str, status_code: int = 200) -> None:
         self.text = text
+        self.status_code = status_code
 
     def json(self) -> dict:
         raise json.JSONDecodeError("error", self.text, 0)

--- a/tests/test_llm_utils_supabase.py
+++ b/tests/test_llm_utils_supabase.py
@@ -7,14 +7,17 @@ Supabase client and returns the expected response.
 from __future__ import annotations
 
 from typing import Any
+import json
 
 import pytest
 
 from agent_s3.llm_utils import call_llm_via_supabase
 
 class DummyResponse:
-    def __init__(self, data: dict[str, Any]) -> None:
+    def __init__(self, data: dict[str, Any], status_code: int = 200, text: str | None = None) -> None:
         self._data = data
+        self.status_code = status_code
+        self.text = text or json.dumps(data)
 
     def json(self) -> dict[str, Any]:
         return self._data
@@ -60,3 +63,25 @@ def test_call_llm_via_supabase(monkeypatch: pytest.MonkeyPatch) -> None:
         timeout=5.0,
     )
     assert result == "ok"
+
+
+def test_call_llm_via_supabase_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("agent_s3.llm_utils.create_client", fake_create_client)
+
+    def fake_post(url, **_kwargs):
+        assert "example.com" in url
+        return DummyResponse({"error": "bad"}, status_code=500, text="bad")
+
+    monkeypatch.setattr("agent_s3.llm_utils.requests.post", fake_post)
+
+    with pytest.raises(RuntimeError):
+        call_llm_via_supabase(
+            "hello",
+            "gh",
+            {
+                "supabase_url": "https://example.com",
+                "supabase_service_role_key": "servicekey",
+                "supabase_function_name": "llm-func",
+            },
+            timeout=5.0,
+        )


### PR DESCRIPTION
## Summary
- raise error when Supabase function returns non-success status
- update DummyResponse in tests
- test error handling for Supabase failures

## Testing
- `ruff check agent_s3` *(fails: F401 unused imports)*
- `mypy agent_s3` *(fails: several missing stubs and type errors)*
- `pytest -q` *(fails: command not found)*