### PR TITLE
Switch to anon key for Supabase function calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,8 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
   - `OPENROUTER_KEY` (or other LLM keys such as `OPENAI_KEY`)
   - **Token Encryption:** `AGENT_S3_ENCRYPTION_KEY` (required for GitHub token storage)
   - `DENYLIST_COMMANDS`, `COMMAND_TIMEOUT`, `CLI_COMMAND_WARNINGS` in config
-  - `SUPABASE_URL`, `SUPABASE_SERVICE_KEY`, `SUPABASE_SERVICE_ROLE_KEY` for Supabase integration
+  - `SUPABASE_URL`, `SUPABASE_SERVICE_KEY` for Supabase integration
+  - `SUPABASE_ANON_KEY` (used for invoking edge functions)
   - `SUPABASE_EDGE_FUNCTION_PATH` (optional, defaults to the root function)
   - `USE_REMOTE_LLM` to toggle remote LLM usage
 
@@ -291,7 +292,7 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
   ```env
   SUPABASE_URL=https://your-project.supabase.co
   SUPABASE_SERVICE_KEY=your-service-key
-  SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+  SUPABASE_ANON_KEY=your-anon-key
   SUPABASE_EDGE_FUNCTION_PATH=/functions/v1/call-llm
   USE_REMOTE_LLM=true
   ```
@@ -376,12 +377,12 @@ python -m agent_s3.cli /db query <db_name> "SELECT * FROM users"
 ```
 
 ### Remote LLM via Supabase
-Set `USE_REMOTE_LLM=true` to forward prompts to a remote Supabase service. Ensure `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` (or `SUPABASE_SERVICE_KEY`) are set. `SUPABASE_EDGE_FUNCTION_PATH` is optional and defaults to the root function:
+Set `USE_REMOTE_LLM=true` to forward prompts to a remote Supabase service. Ensure `SUPABASE_URL` and `SUPABASE_ANON_KEY` (or `SUPABASE_SERVICE_KEY` for legacy setups) are set. `SUPABASE_EDGE_FUNCTION_PATH` is optional and defaults to the root function:
 
 ```bash
 USE_REMOTE_LLM=true \
 SUPABASE_URL=https://your-project.supabase.co \
-SUPABASE_SERVICE_ROLE_KEY=your-service-role-key \
+SUPABASE_ANON_KEY=your-anon-key \
 SUPABASE_EDGE_FUNCTION_PATH=/functions/v1/call-llm \
 python -m agent_s3.cli "Generate a README outline"
 ```

--- a/agent_s3/config.py
+++ b/agent_s3/config.py
@@ -198,6 +198,7 @@ class ConfigModel(BaseModel):
     summarizer_timeout: float = SUMMARIZER_TIMEOUT
     supabase_url: str = os.environ.get("SUPABASE_URL", "")
     supabase_service_key: str = os.environ.get("SUPABASE_SERVICE_KEY", "")
+    supabase_anon_key: str = os.environ.get("SUPABASE_ANON_KEY", "")
     use_remote_llm: bool = os.environ.get("USE_REMOTE_LLM", "false").lower() == "true"
     adaptive_config_enabled: bool = ADAPTIVE_CONFIG_ENABLED
     adaptive_config_repo_path: str = ADAPTIVE_CONFIG_REPO_PATH
@@ -206,6 +207,7 @@ class ConfigModel(BaseModel):
     adaptive_optimization_interval: int = ADAPTIVE_OPTIMIZATION_INTERVAL
     supabase_url: str = os.environ.get("SUPABASE_URL", "")
     supabase_service_role_key: str = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
+    supabase_anon_key: str = os.environ.get("SUPABASE_ANON_KEY", "")
     use_remote_llm: bool = os.getenv("USE_REMOTE_LLM", "false").lower() == "true"
 
     class Config:

--- a/agent_s3/llm_utils.py
+++ b/agent_s3/llm_utils.py
@@ -54,14 +54,21 @@ def call_llm_via_supabase(prompt: str, github_token: str, config: Dict[str, Any]
     Args:
         prompt: Prompt text to send to the remote LLM service.
         github_token: Authenticated GitHub token for authorization.
-        config: Configuration dictionary containing Supabase URL and key.
+        config: Configuration dictionary containing Supabase URL and
+            low-privilege token (anon key). Falls back to the service role
+            key for backward compatibility.
         timeout: Optional request timeout override.
 
     Returns:
         The text response from the remote service.
     """
     supabase_url = config.get("supabase_url") or os.getenv("SUPABASE_URL")
-    api_key = config.get("supabase_service_role_key") or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+    api_key = (
+        config.get("supabase_anon_key")
+        or os.getenv("SUPABASE_ANON_KEY")
+        or config.get("supabase_service_role_key")
+        or os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+    )
     if not supabase_url or not api_key:
         raise ValueError("Supabase configuration missing")
 

--- a/docs/supabase_llm_function.md
+++ b/docs/supabase_llm_function.md
@@ -4,6 +4,9 @@
 This serverless function provides secure access to large language model (LLM) services for Agent-S3. The function verifies the caller's GitHub organization membership before forwarding the request to the LLM provider. Only sanitized responses are returned to the client.
 
 ## Request Format
+- Include the low-privilege `SUPABASE_ANON_KEY` when creating the client that
+  calls this function. The function itself holds the `SUPABASE_SERVICE_ROLE_KEY`
+  and only uses it after verifying GitHub organization membership.
 - **Method:** `POST`
 - **Headers:**
   - `Content-Type: application/json`
@@ -29,6 +32,7 @@ This serverless function provides secure access to large language model (LLM) se
 3. Proceed only if the membership state is `active`.
 
 ## LLM Invocation
+- Verify the caller's organization membership before accessing the service role key.
 - Retrieve the LLM API key from the server's secure storage (environment variable or secret manager).
 - Forward the validated request to the LLM provider.
 - Sanitize the LLM output to remove any disallowed content before returning the JSON response.

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -44,7 +44,7 @@ def test_invalid_json_snippet(monkeypatch):
 
     cfg = {
         "supabase_url": "http://supabase",
-        "supabase_service_role_key": "key",
+        "supabase_anon_key": "key",
         "supabase_function_name": "func",
     }
 

--- a/tests/test_llm_utils_supabase.py
+++ b/tests/test_llm_utils_supabase.py
@@ -54,7 +54,7 @@ def test_call_llm_via_supabase(monkeypatch: pytest.MonkeyPatch) -> None:
         "gh",
         {
             "supabase_url": "https://example.com",
-            "supabase_service_role_key": "servicekey",
+            "supabase_anon_key": "servicekey",
             "supabase_function_name": "llm-func",
         },
         timeout=5.0,

--- a/tests/test_remote_llm.py
+++ b/tests/test_remote_llm.py
@@ -15,7 +15,7 @@ class DummyLLM:
         return "local"
 
 def test_remote_llm_invocation(monkeypatch):
-    cfg = ConfigModel(use_remote_llm=True, supabase_url="http://test", supabase_service_role_key="key")
+    cfg = ConfigModel(use_remote_llm=True, supabase_url="http://test", supabase_anon_key="key")
     dummy = DummyLLM()
     called = {}
 
@@ -33,7 +33,7 @@ def test_remote_llm_invocation(monkeypatch):
 
 
 def test_remote_llm_fallback(monkeypatch):
-    cfg = ConfigModel(use_remote_llm=True, supabase_url="http://test", supabase_service_role_key="key")
+    cfg = ConfigModel(use_remote_llm=True, supabase_url="http://test", supabase_anon_key="key")
     dummy = DummyLLM()
 
     def failing_remote(*_args, **_kwargs):


### PR DESCRIPTION
## Summary
- use low privilege `SUPABASE_ANON_KEY` when invoking Supabase edge functions
- document anon key usage in README and Supabase docs
- keep service role key fallback for backwards compatibility
- update tests for anon key

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*