### PR TITLE
fix: validate supabase payload

### DIFF
--- a/agent_s3/llm_utils.py
+++ b/agent_s3/llm_utils.py
@@ -76,6 +76,14 @@ def call_llm_via_supabase(prompt: str, github_token: str, config: Dict[str, Any]
     }
     payload = {"prompt": prompt}
 
+    # Validate that the payload can be serialized to JSON before making the
+    # network request. This avoids sending malformed data to the remote
+    # service and surfaces a clear error to the caller.
+    try:
+        json.dumps(payload)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - input validation
+        raise ValueError("Invalid request payload; must be JSON serializable") from exc
+
     # Create client and invoke edge function
     supabase = create_client(supabase_url, api_key)
     function_name = config.get("supabase_function_name") or os.getenv("SUPABASE_FUNCTION_NAME", "call-llm")

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -52,3 +52,20 @@ def test_invalid_json_snippet(monkeypatch):
         call_llm_via_supabase("hi", "tok", cfg)
 
     assert "{bad" in str(exc.value)
+
+
+def test_invalid_request_body(monkeypatch):
+    """Error is raised for a payload that cannot be JSON serialized."""
+    def dummy_client(*_args, **_kwargs):
+        raise AssertionError("client should not be created for invalid payload")
+
+    monkeypatch.setattr("agent_s3.llm_utils.create_client", dummy_client)
+
+    cfg = {
+        "supabase_url": "http://supabase",
+        "supabase_service_role_key": "key",
+        "supabase_function_name": "func",
+    }
+
+    with pytest.raises(ValueError):
+        call_llm_via_supabase(object(), "tok", cfg)


### PR DESCRIPTION
## Summary
- raise `ValueError` if the request payload to Supabase cannot be JSON-encoded
- add regression test to ensure bad payloads are rejected

## Testing
- `pytest -q` *(fails: command not found)*