### PR TITLE
Apply secure permissions to connection files

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ See `docs/summarization.md` for details.
 - Dedicated terminal panel for backend interactions
 - Real-time status updates via WebSocket; `progress_log.jsonl` is retained only as a log file
 - Server shuts down automatically on exit, removing the connection file
+- Connection file uses `0600` permissions on POSIX systems; default permissions
+  apply on Windows
 - Optional Copilot-style chat UI for input; terminal shows actual outputs
 - WebView panels for structured information display:
   - Code change plan reviews

--- a/agent_s3/communication/vscode_bridge.py
+++ b/agent_s3/communication/vscode_bridge.py
@@ -191,8 +191,15 @@ class VSCodeBridge:
             
             with open(connection_file, "w") as f:
                 json.dump(connection_info, f)
-                
-            logger.info(f"Created WebSocket connection file at {connection_file}")
+
+            # Restrict permissions on POSIX systems for security
+            if os.name == "posix":
+                import stat
+                os.chmod(connection_file, stat.S_IRUSR | stat.S_IWUSR)
+
+            logger.info(
+                f"Created WebSocket connection file at {connection_file}"
+            )
         except Exception as e:
             logger.error(f"Failed to create WebSocket connection file: {e}")
     

--- a/agent_s3/vscode_integration.py
+++ b/agent_s3/vscode_integration.py
@@ -280,8 +280,15 @@ class VSCodeIntegration:
             
             with open(self.connect_file_path, 'w') as f:
                 json.dump(connection_info, f)
-                
-            logger.info(f"Connection info written to {self.connect_file_path}")
+
+            # Restrict permissions on POSIX systems for security
+            if os.name == 'posix':
+                import stat
+                os.chmod(self.connect_file_path, stat.S_IRUSR | stat.S_IWUSR)
+
+            logger.info(
+                f"Connection info written to {self.connect_file_path}"
+            )
         except Exception as e:
             logger.error(f"Failed to write connection info: {e}")
             

--- a/docs/streaming_ui_implementation.md
+++ b/docs/streaming_ui_implementation.md
@@ -75,6 +75,7 @@ This document describes the implementation of a real-time streaming UI for Agent
    - Includes a `protocol` field (`ws` or `wss`) to indicate whether TLS should be used
    - Created during VS Code Bridge initialization
    - Removed automatically when the backend exits
+   - File permissions set to `0600` on POSIX systems; Windows uses default ACLs
 
 2. **Authentication Flow**
    - Client reads connection file to get authentication token


### PR DESCRIPTION
## Summary
- restrict connection file permissions to `0600` on POSIX systems
- document default Windows behavior for the connection file
- note secure permissions in README and streaming UI docs

## Testing
- `ruff check agent_s3`
- `mypy agent_s3`
- `pytest -q` *(fails: command not found)*