### PR TITLE
Centralize Supabase defaults

### DIFF
--- a/agent_s3/config.py
+++ b/agent_s3/config.py
@@ -19,6 +19,13 @@ logger = logging.getLogger(__name__)
 # Default values
 _config_instance = None
 
+# Supabase configuration defaults
+SUPABASE_URL = os.getenv("SUPABASE_URL", "")
+SUPABASE_SERVICE_KEY = os.getenv("SUPABASE_SERVICE_KEY", "")
+SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "")
+SUPABASE_ANON_KEY = os.getenv("SUPABASE_ANON_KEY", "")
+USE_REMOTE_LLM = os.getenv("USE_REMOTE_LLM", "false").lower() == "true"
+
 # Adaptive Configuration settings
 ADAPTIVE_CONFIG_ENABLED = os.getenv('ADAPTIVE_CONFIG_ENABLED', 'true').lower() == 'true'
 ADAPTIVE_CONFIG_REPO_PATH = os.getenv('ADAPTIVE_CONFIG_REPO_PATH', os.getcwd())
@@ -199,14 +206,16 @@ class ConfigModel(BaseModel):
     summarizer_role_name: str = SUMMARIZER_ROLE_NAME
     summarizer_max_chunk_size: int = SUMMARIZER_MAX_CHUNK_SIZE
     summarizer_timeout: float = SUMMARIZER_TIMEOUT
-    supabase_url: str = os.environ.get("SUPABASE_URL", "")
-    use_remote_llm: bool = os.environ.get("USE_REMOTE_LLM", "false").lower() == "true"
+    supabase_url: str = SUPABASE_URL
+    supabase_service_key: str = SUPABASE_SERVICE_KEY
+    supabase_service_role_key: str = SUPABASE_SERVICE_ROLE_KEY
+    supabase_anon_key: str = SUPABASE_ANON_KEY
+    use_remote_llm: bool = USE_REMOTE_LLM
     adaptive_config_enabled: bool = ADAPTIVE_CONFIG_ENABLED
     adaptive_config_repo_path: str = ADAPTIVE_CONFIG_REPO_PATH
     adaptive_config_dir: str = ADAPTIVE_CONFIG_DIR
     adaptive_metrics_dir: str = ADAPTIVE_METRICS_DIR
     adaptive_optimization_interval: int = ADAPTIVE_OPTIMIZATION_INTERVAL
-    supabase_service_role_key: str = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
 
     class Config:
         extra = "allow"


### PR DESCRIPTION
## Summary
- centralize Supabase environment variable defaults
- reference centralized constants in `ConfigModel`
- expose service/anon keys

## Testing
- `ruff check agent_s3` *(fails: E701 etc.)*
- `mypy agent_s3` *(fails: various missing stubs and type errors)*
- `pytest -q` *(fails: command not found)*