### PR TITLE
Validate Supabase URL scheme

### DIFF
--- a/agent_s3/llm_utils.py
+++ b/agent_s3/llm_utils.py
@@ -65,6 +65,9 @@ def call_llm_via_supabase(prompt: str, github_token: str, config: Dict[str, Any]
     if not supabase_url or not api_key:
         raise ValueError("Supabase configuration missing")
 
+    if not supabase_url.startswith("https://"):
+        raise ValueError("supabase_url must start with https://")
+
     if create_client is None:
         raise ImportError("supabase-py is required for remote LLM calls")
 

--- a/docs/supabase_llm_function.md
+++ b/docs/supabase_llm_function.md
@@ -35,6 +35,7 @@ This serverless function provides secure access to large language model (LLM) se
 
 ## Security Tips
 - Serve the function exclusively over **HTTPS**.
+- Ensure the `SUPABASE_URL` (or `supabase_url` config) begins with `https://`.
 - Use short-lived GitHub tokens with limited scopes (e.g., `read:org`).
 - Do not persist incoming tokens on disk.
 - Log only minimal metadata and avoid storing prompts or responses unless required.

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -44,7 +44,7 @@ def test_invalid_json_snippet(monkeypatch):
     monkeypatch.setattr("requests.post", fake_post)
 
     cfg = {
-        "supabase_url": "http://supabase",
+        "supabase_url": "https://supabase",
         "supabase_service_role_key": "key",
         "supabase_function_name": "func",
     }
@@ -63,10 +63,21 @@ def test_invalid_request_body(monkeypatch):
     monkeypatch.setattr("agent_s3.llm_utils.create_client", dummy_client)
 
     cfg = {
-        "supabase_url": "http://supabase",
+        "supabase_url": "https://supabase",
         "supabase_service_role_key": "key",
         "supabase_function_name": "func",
     }
 
     with pytest.raises(ValueError):
         call_llm_via_supabase(object(), "tok", cfg)
+
+
+def test_invalid_supabase_url_scheme(monkeypatch):
+    cfg = {
+        "supabase_url": "http://supabase",
+        "supabase_service_role_key": "key",
+        "supabase_function_name": "func",
+    }
+
+    with pytest.raises(ValueError):
+        call_llm_via_supabase("hi", "tok", cfg)


### PR DESCRIPTION
## Summary
- validate `supabase_url` begins with `https://` in `call_llm_via_supabase`
- document `SUPABASE_URL` security requirement
- update tests and add a unit test for invalid URLs

## Testing
- `ruff check agent_s3/llm_utils.py tests/test_llm_utils.py tests/test_llm_utils_supabase.py`
- `mypy agent_s3/llm_utils.py tests/test_llm_utils.py tests/test_llm_utils_supabase.py`
- `pytest -k llm_utils -q` *(fails: command not found)*