### PR TITLE
Update Supabase variable names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Description: Release notes for Agent-S3.
 - `SUPABASE_URL` – base URL of the Supabase instance.
 - `SUPABASE_SERVICE_ROLE_KEY` – key used for privileged Supabase operations.
 - `SUPABASE_ANON_KEY` – optional key for anonymous access when applicable.
-- `SUPABASE_EDGE_FUNCTION_PATH` – optional path to the Supabase Edge function used for LLM calls.
+- `SUPABASE_FUNCTION_NAME` – optional name of the Supabase function used for LLM calls.
 
 ### Security
 - API keys are now stored remotely via Supabase, reducing local exposure risk.

--- a/README.md
+++ b/README.md
@@ -285,15 +285,19 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
   - **Token Encryption:** `AGENT_S3_ENCRYPTION_KEY` (required for GitHub token storage)
   - `DENYLIST_COMMANDS`, `COMMAND_TIMEOUT`, `CLI_COMMAND_WARNINGS` in config
   - `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` for Supabase integration
-  - `SUPABASE_EDGE_FUNCTION_PATH` (optional, defaults to the root function)
+    (the service role key is only used by the Supabase function after
+    validating organization membership)
+  - `SUPABASE_ANON_KEY` for client requests
+  - `SUPABASE_FUNCTION_NAME` (optional, defaults to `call-llm`)
   - `USE_REMOTE_LLM` to toggle remote LLM usage
 
   Example `.env`:
 
   ```env
   SUPABASE_URL=https://your-project.supabase.co
+  SUPABASE_ANON_KEY=your-anon-key
   SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
-  SUPABASE_EDGE_FUNCTION_PATH=/functions/v1/call-llm
+  SUPABASE_FUNCTION_NAME=call-llm
   USE_REMOTE_LLM=true
   ```
 
@@ -377,13 +381,14 @@ python -m agent_s3.cli /db query <db_name> "SELECT * FROM users"
 ```
 
 ### Remote LLM via Supabase
-Set `USE_REMOTE_LLM=true` to forward prompts to a remote Supabase service. Ensure `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are set. `SUPABASE_EDGE_FUNCTION_PATH` is optional and defaults to the root function:
+Set `USE_REMOTE_LLM=true` to forward prompts to a remote Supabase service. Ensure `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are set. `SUPABASE_FUNCTION_NAME` is optional and defaults to `call-llm`:
 
 ```bash
 USE_REMOTE_LLM=true \
 SUPABASE_URL=https://your-project.supabase.co \
+SUPABASE_ANON_KEY=your-anon-key \
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key \
-SUPABASE_EDGE_FUNCTION_PATH=/functions/v1/call-llm \
+SUPABASE_FUNCTION_NAME=call-llm \
 python -m agent_s3.cli "Generate a README outline"
 ```
 

--- a/docs/supabase_llm_function.md
+++ b/docs/supabase_llm_function.md
@@ -39,3 +39,13 @@ This serverless function provides secure access to large language model (LLM) se
 - Do not persist incoming tokens on disk.
 - Log only minimal metadata and avoid storing prompts or responses unless required.
 
+### Environment Variables
+The function relies on the following environment variables:
+
+- `SUPABASE_URL` – base URL of your Supabase instance.
+- `SUPABASE_FUNCTION_NAME` – name of the function to invoke (defaults to `call-llm`).
+- `SUPABASE_ANON_KEY` – used by the client for authenticated Supabase requests.
+- `SUPABASE_SERVICE_ROLE_KEY` – used internally by the function **after** verifying organization membership.
+
+The client never receives the service role key; it is only used server-side once the caller's GitHub organization has been validated.
+


### PR DESCRIPTION
## Summary
- rename `SUPABASE_EDGE_FUNCTION_PATH` references to `SUPABASE_FUNCTION_NAME`
- document `SUPABASE_ANON_KEY` usage in README
- clarify that the service role key is only used by the Supabase function
- add environment variable section to Supabase LLM function docs

## Testing
- `pytest -q` *(fails: `pytest` not found)*