### PR TITLE
Fix connection file error handling

### DIFF
--- a/agent_s3/communication/vscode_bridge.py
+++ b/agent_s3/communication/vscode_bridge.py
@@ -200,8 +200,9 @@ class VSCodeBridge:
             logger.info(
                 f"Created WebSocket connection file at {connection_file}"
             )
-        except Exception as e:
+        except (OSError, ValueError) as e:
             logger.error(f"Failed to create WebSocket connection file: {e}")
+            raise
     
     def _setup_message_handlers(self) -> None:
         """Set up handlers for extension messages."""


### PR DESCRIPTION
## Summary
- catch only `OSError` and `ValueError` when creating connection file
- re-raise after logging so callers can handle failures

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*