### PR TITLE
Fix path resolution for workspace root and add symlink test

### DIFF
--- a/agent_s3/tools/file_tool.py
+++ b/agent_s3/tools/file_tool.py
@@ -21,8 +21,8 @@ class FileTool:
             allowed_extensions: List of allowed file extensions (e.g., ['.txt', '.py']). If None, all extensions allowed.
         """
         self.allowed_dirs = allowed_dirs or [os.getcwd()]
-        # Normalize paths to absolute paths
-        self.allowed_dirs = [os.path.abspath(dir_path) for dir_path in self.allowed_dirs]
+        # Normalize paths to absolute real paths to avoid symlink escapes
+        self.allowed_dirs = [os.path.realpath(dir_path) for dir_path in self.allowed_dirs]
         self.max_file_size = max_file_size
         self.allowed_extensions = allowed_extensions
         
@@ -49,7 +49,8 @@ class FileTool:
         """
         try:
             # Check for path traversal attacks
-            norm_path = os.path.normpath(os.path.abspath(file_path))
+            # Use realpath to resolve any symlinks before comparison
+            norm_path = os.path.normpath(os.path.realpath(file_path))
             
             # Check if path is within allowed directories
             allowed = False

--- a/tests/test_file_tool_symlinks.py
+++ b/tests/test_file_tool_symlinks.py
@@ -1,0 +1,18 @@
+import os
+from agent_s3.tools.file_tool import FileTool
+
+
+def test_symlink_outside_workspace_rejected(tmp_path):
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    secret = outside / "secret.txt"
+    secret.write_text("secret")
+    link = workspace / "link.txt"
+    link.symlink_to(secret)
+
+    ft = FileTool(allowed_dirs=[str(workspace)])
+    allowed, msg = ft._is_path_allowed(str(link))
+    assert not allowed
+    assert "outside allowed directories" in msg


### PR DESCRIPTION
## Summary
- use `os.path.realpath` instead of `os.path.abspath` when computing allowed directories
- resolve symlinks when validating paths
- test `FileTool` rejects symlinks escaping the workspace

## Testing
- `python -m pytest tests/test_file_tool_symlinks.py::test_symlink_outside_workspace_rejected -q` *(fails: No module named pytest)*