### PR TITLE
Fix vscode bridge connection file permissions

### DIFF
--- a/agent_s3/communication/vscode_bridge.py
+++ b/agent_s3/communication/vscode_bridge.py
@@ -3,8 +3,9 @@ import asyncio
 import json
 import logging
 import os
+import stat
 import time
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, Optional
 
 try:
     from agent_s3.message_bus import Message, MessageBus, MessageType
@@ -192,10 +193,8 @@ class VSCodeBridge:
             with open(connection_file, "w") as f:
                 json.dump(connection_info, f)
 
-            # Restrict permissions on POSIX systems for security
-            if os.name == "posix":
-                import stat
-                os.chmod(connection_file, stat.S_IRUSR | stat.S_IWUSR)
+            # Set secure permissions (read/write for owner only)
+            os.chmod(connection_file, stat.S_IRUSR | stat.S_IWUSR)
 
             logger.info(
                 f"Created WebSocket connection file at {connection_file}"


### PR DESCRIPTION
## Summary
- import `stat` at the top of `vscode_bridge`
- chmod the connection file to `0o600` after it's written

## Testing
- `ruff check agent_s3`
- `mypy agent_s3`
- `pytest -q` *(fails: `pytest` not installed)*