### PR TITLE
Fix vscode bridge connection file permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,7 @@ See `docs/summarization.md` for details.
 - Dedicated terminal panel for backend interactions
 - Real-time status updates via WebSocket; `progress_log.jsonl` is retained only as a log file
 - Server shuts down automatically on exit, removing the connection file
-- Connection file uses `0600` permissions on POSIX systems; default permissions
-  apply on Windows
+- Connection file uses `0600` permissions on all platforms
 - Optional Copilot-style chat UI for input; terminal shows actual outputs
 - WebView panels for structured information display:
   - Code change plan reviews

--- a/agent_s3/communication/vscode_bridge.py
+++ b/agent_s3/communication/vscode_bridge.py
@@ -3,8 +3,9 @@ import asyncio
 import json
 import logging
 import os
+import stat
 import time
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, Optional
 
 try:
     from agent_s3.message_bus import Message, MessageBus, MessageType
@@ -192,10 +193,8 @@ class VSCodeBridge:
             with open(connection_file, "w") as f:
                 json.dump(connection_info, f)
 
-            # Restrict permissions on POSIX systems for security
-            if os.name == "posix":
-                import stat
-                os.chmod(connection_file, stat.S_IRUSR | stat.S_IWUSR)
+            # Set secure permissions (read/write for owner only)
+            os.chmod(connection_file, stat.S_IRUSR | stat.S_IWUSR)
 
             logger.info(
                 f"Created WebSocket connection file at {connection_file}"

--- a/docs/streaming_ui_implementation.md
+++ b/docs/streaming_ui_implementation.md
@@ -75,7 +75,7 @@ This document describes the implementation of a real-time streaming UI for Agent
    - Includes a `protocol` field (`ws` or `wss`) to indicate whether TLS should be used
    - Created during VS Code Bridge initialization
    - Removed automatically when the backend exits
-   - File permissions set to `0600` on POSIX systems; Windows uses default ACLs
+   - File permissions set to `0600` on all platforms
 
 2. **Authentication Flow**
    - Client reads connection file to get authentication token


### PR DESCRIPTION
## Summary
- import `stat` at the top of `vscode_bridge`
- chmod the connection file to `0o600` after it's written
- update docs to note that `0600` is used on all platforms

## Testing
- `ruff check agent_s3`
- `mypy agent_s3`
- `pytest -q` *(fails: `pytest` not installed)*