### PR TITLE
Implement modular planning helpers

### DIFF
--- a/agent_s3/coordinator.py
+++ b/agent_s3/coordinator.py
@@ -832,7 +832,13 @@ class Coordinator:
                 continue
             decision, modification = self.feature_group_processor.present_consolidated_plan_to_user(consolidated_plan)
             if decision == "modify":
-                consolidated_plan = self.feature_group_processor.update_plan_with_modifications(consolidated_plan, modification)
+                original_plan = json.loads(json.dumps(consolidated_plan))
+                consolidated_plan = self.feature_group_processor.update_plan_with_modifications(
+                    consolidated_plan, modification
+                )
+                decision, _ = self.feature_group_processor.present_consolidated_plan_to_user(
+                    consolidated_plan, original_plan
+                )
             if decision == "yes":
                 plans.append(consolidated_plan)
 


### PR DESCRIPTION
## Summary
- modularize `process_pre_planning_output` using helper methods
- add diff display for plan modifications
- show diff after updating plans in Coordinator

## Testing
- `mypy agent_s3` *(fails: 1258 errors)*
- `ruff check agent_s3` *(fails: 469 errors)*
- `pytest` *(fails: command not found)*
