### PR TITLE
Remove unused imports from pre_planner

### DIFF
--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -16,8 +16,6 @@ import json
 import logging
 import re
 import time # Added for potential delays in retry
-import sys
-import functools
 from typing import Dict, Any, Optional, Tuple, List, Union
 
 from agent_s3.pre_planning_errors import (


### PR DESCRIPTION
## Summary
- clean up unused imports in `pre_planner_json_enforced`

## Testing
- `ruff check agent_s3`
- `mypy agent_s3` *(fails: several type errors)*
- `pytest -q` *(fails: command not found)*