### PR TITLE
Fix pre-planning result handler return type

### DIFF
--- a/agent_s3/coordinator.py
+++ b/agent_s3/coordinator.py
@@ -533,8 +533,12 @@ class Coordinator:
     
     # _execute_pre_planning_phase method removed as it's redundant with inline implementation in run_task
     
-    def _present_pre_planning_results_to_user(self, pre_planning_results: Dict[str, Any]) -> Tuple[str, Optional[Dict[str, Any]]]:
-        """Present the pre-planning results to the user and get their decision (yes/no/modify)."""
+    def _present_pre_planning_results_to_user(self, pre_planning_results: Dict[str, Any]) -> Tuple[str, Optional[str]]:
+        """Present the pre-planning results to the user and get their decision.
+
+        The second return value contains the modification text when the user
+        chooses to refine the plan, otherwise ``None``.
+        """
         # Use error context manager for consistent error handling
         with self.error_handler.error_context(
             phase="pre_planning",
@@ -550,7 +554,7 @@ class Coordinator:
             )
             if decision == "yes":
                 self.scratchpad.log("Coordinator", "User approved pre-planning results.")
-                return decision, pre_planning_results
+                return decision, None
             elif decision == "no":
                 self.scratchpad.log("Coordinator", "User rejected pre-planning results.")
                 return decision, None

--- a/tests/test_coordinator_plan_validation.py
+++ b/tests/test_coordinator_plan_validation.py
@@ -139,7 +139,7 @@ class TestCoordinatorPlanValidation:
         
         # Configure mocks
         coordinator.prompt_moderator.ask_ternary_question.return_value = "yes"  # User proceeds
-        coordinator._present_pre_planning_results_to_user.return_value = ("yes", complex_task_data)
+        coordinator._present_pre_planning_results_to_user.return_value = ("yes", None)
         
         # Mock call_pre_planner_with_enforced_json
         with patch('agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json', 
@@ -180,7 +180,7 @@ class TestCoordinatorPlanValidation:
         
         # Configure mocks
         coordinator.prompt_moderator.ask_ternary_question.return_value = "yes"  # User proceeds
-        coordinator._present_pre_planning_results_to_user.return_value = ("yes", complex_task_data)
+        coordinator._present_pre_planning_results_to_user.return_value = ("yes", None)
         
         # Mock call_pre_planner_with_enforced_json
         with patch('agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json', 
@@ -312,7 +312,7 @@ class TestCoordinatorPlanValidation:
         }
         
         # Configure mocks
-        coordinator._present_pre_planning_results_to_user.return_value = ("yes", simple_task_data)
+        coordinator._present_pre_planning_results_to_user.return_value = ("yes", None)
         
         # Mock call_pre_planner_with_enforced_json
         with patch('agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json', 


### PR DESCRIPTION
## Summary
- ensure `_present_pre_planning_results_to_user` consistently returns a modification string or None
- update tests for the new return type

## Testing
- `ruff check agent_s3` *(fails: E701 etc.)*
- `mypy agent_s3` *(fails: found 1251 errors)*
- `pytest -q` *(fails: command not found)*