### PR TITLE
Refactor validation result handling

### DIFF
--- a/tests/test_advanced_workflows.py
+++ b/tests/test_advanced_workflows.py
@@ -186,7 +186,14 @@ def mock_coordinator(setup_test_files):
         
         # Patch file operations
         coordinator._apply_changes_and_manage_dependencies = MagicMock(return_value=True)
-        coordinator._run_validation_phase = MagicMock(return_value=(True, "validation", "All checks passed"))
+        coordinator._run_validation_phase = MagicMock(return_value={
+            "success": True,
+            "step": None,
+            "lint_output": "No lint errors",
+            "type_output": "No type errors",
+            "test_output": "All checks passed",
+            "coverage": None,
+        })
         coordinator._finalize_task = MagicMock(return_value={"status": "completed"})
         
         # Return coordinator with its mocks
@@ -469,8 +476,22 @@ class TestMultiStepDebugging:
         
         # Set up to fail validation on first attempt, succeed on second
         coordinator._run_validation_phase = MagicMock(side_effect=[
-            (False, "tests", "Tests failed: Authentication still has security issues"),
-            (True, "validation", "All checks passed")
+            {
+                "success": False,
+                "step": "tests",
+                "lint_output": None,
+                "type_output": None,
+                "test_output": "Tests failed: Authentication still has security issues",
+                "coverage": None,
+            },
+            {
+                "success": True,
+                "step": None,
+                "lint_output": "No lint errors",
+                "type_output": "No type errors",
+                "test_output": "All checks passed",
+                "coverage": None,
+            },
         ])
         
         # Execute task

--- a/tests/test_coordinator_phases.py
+++ b/tests/test_coordinator_phases.py
@@ -461,8 +461,22 @@ def test_implementation_retry_requests_user_guidance(coordinator):
     coordinator.code_generator.generate_code.return_value = {"auth.py": "code"}
     coordinator._apply_changes_and_manage_dependencies = MagicMock(return_value=True)
     coordinator._run_validation_phase.side_effect = [
-        {"success": False, "output": "fail"},
-        {"success": True},
+        {
+            "success": False,
+            "step": "lint",
+            "lint_output": "fail",
+            "type_output": None,
+            "test_output": None,
+            "coverage": None,
+        },
+        {
+            "success": True,
+            "step": None,
+            "lint_output": "No lint errors",
+            "type_output": "No type errors",
+            "test_output": "All checks passed",
+            "coverage": None,
+        },
     ]
     coordinator.debugging_manager.handle_error.return_value = {"success": False}
     coordinator.prompt_moderator.request_debugging_guidance.return_value = "Fix plan"

--- a/tests/test_coordinator_validation.py
+++ b/tests/test_coordinator_validation.py
@@ -62,15 +62,18 @@ def test_validation_phase_all_pass(coordinator):
     # Set up mocks for successful validation
     coordinator.database_manager.setup_database.return_value = {"success": True}
     coordinator.bash_tool.run_command.side_effect = [(0, "No lint errors"), (0, "No type errors")]
-    coordinator.run_tests = MagicMock(return_value={"success": True, "output": "All tests passed"})
+    coordinator.run_tests = MagicMock(return_value={"success": True, "output": "All tests passed", "coverage": 80.0})
     
     # Execute
     result = coordinator._run_validation_phase()
     
     # Assert
-    assert result[0] is True  # Validation passed
-    assert result[1] is None  # No failing step
-    assert result[2] is None  # No info about failure
+    assert result["success"] is True  # Validation passed
+    assert result["step"] is None  # No failing step
+    assert result["lint_output"] == "No lint errors"
+    assert result["type_output"] == "No type errors"
+    assert result["test_output"] == "All tests passed"
+    assert result["coverage"] == 80.0
     
     # Verify all validations were performed
     coordinator.database_manager.setup_database.assert_called()
@@ -88,11 +91,11 @@ def test_validation_phase_database_failure(coordinator):
     
     # Execute
     result = coordinator._run_validation_phase()
-    
+
     # Assert
-    assert result[0] is False  # Validation failed
-    assert result[1] == "database"  # Failing step
-    assert result[2] == "Database connection failed"  # Error info
+    assert result["success"] is False  # Validation failed
+    assert result["step"] == "database"  # Failing step
+    assert result["test_output"] == "Database connection failed"  # Error info
     
     # Verify only database validation was performed
     coordinator.database_manager.setup_database.assert_called()
@@ -108,11 +111,11 @@ def test_validation_phase_lint_failure(coordinator):
     
     # Execute
     result = coordinator._run_validation_phase()
-    
+
     # Assert
-    assert result[0] is False  # Validation failed
-    assert result[1] == "lint"  # Failing step
-    assert result[2] == "Lint errors found"  # Error info
+    assert result["success"] is False  # Validation failed
+    assert result["step"] == "lint"  # Failing step
+    assert result["lint_output"] == "Lint errors found"  # Error info
     
     # Verify validations were performed up to the failing point
     coordinator.database_manager.setup_database.assert_called()
@@ -128,11 +131,11 @@ def test_validation_phase_type_check_failure(coordinator):
     
     # Execute
     result = coordinator._run_validation_phase()
-    
+
     # Assert
-    assert result[0] is False  # Validation failed
-    assert result[1] == "type_check"  # Failing step
-    assert result[2] == "Type errors found"  # Error info
+    assert result["success"] is False  # Validation failed
+    assert result["step"] == "type_check"  # Failing step
+    assert result["type_output"] == "Type errors found"  # Error info
     
     # Verify validations were performed up to the failing point
     coordinator.database_manager.setup_database.assert_called()
@@ -146,17 +149,19 @@ def test_validation_phase_test_failure(coordinator):
     coordinator.database_manager.setup_database.return_value = {"success": True}
     coordinator.bash_tool.run_command.side_effect = [(0, "No lint errors"), (0, "No type errors")]
     coordinator.run_tests = MagicMock(return_value={
-        "success": False, 
-        "output": "Test failures detected"
+        "success": False,
+        "output": "Test failures detected",
+        "coverage": 50.0,
     })
     
     # Execute
     result = coordinator._run_validation_phase()
-    
+
     # Assert
-    assert result[0] is False  # Validation failed
-    assert result[1] == "tests"  # Failing step
-    assert result[2] == "Test failures detected"  # Error info
+    assert result["success"] is False  # Validation failed
+    assert result["step"] == "tests"  # Failing step
+    assert result["test_output"] == "Test failures detected"  # Error info
+    assert result["coverage"] == 50.0
     
     # Verify all validations were performed up to the failing point
     coordinator.database_manager.setup_database.assert_called()
@@ -171,11 +176,11 @@ def test_validation_phase_database_exception(coordinator):
     
     # Execute
     result = coordinator._run_validation_phase()
-    
+
     # Assert
-    assert result[0] is True  # Validation continues despite db exception
-    assert result[1] is None  # No specific failing step
-    assert result[2] is None  # No specific error info
+    assert result["success"] is True  # Validation continues despite db exception
+    assert result["step"] is None  # No specific failing step
+    assert result["lint_output"] is not None  # Lint still executed
     
     # Verify db validation was attempted and other validations continued
     coordinator.database_manager.setup_database.assert_called()

--- a/tests/test_feature_based_workflow.py
+++ b/tests/test_feature_based_workflow.py
@@ -43,7 +43,14 @@ class TestFeatureBasedWorkflow:
         coordinator._regenerate_pre_planning_with_modifications = MagicMock()
         coordinator._present_pre_planning_results_to_user = MagicMock(return_value=("yes", None))
         coordinator._apply_changes_and_manage_dependencies = MagicMock(return_value=True)
-        coordinator._run_validation_phase = MagicMock(return_value=(True, "validation", "All checks passed"))
+        coordinator._run_validation_phase = MagicMock(return_value={
+            "success": True,
+            "step": None,
+            "lint_output": "No lint errors",
+            "type_output": "No type errors",
+            "test_output": "All checks passed",
+            "coverage": None,
+        })
         coordinator._finalize_task = MagicMock()
         coordinator.run_persona_debate = MagicMock()
         coordinator.code_generator = MagicMock()

--- a/tests/test_system_integration.py
+++ b/tests/test_system_integration.py
@@ -325,7 +325,14 @@ def mock_coordinator():
         
         # Patch internal methods that interact with the filesystem
         coordinator._apply_changes_and_manage_dependencies = MagicMock(return_value=True)
-        coordinator._run_validation_phase = MagicMock(return_value=(True, "validation", "All checks passed"))
+        coordinator._run_validation_phase = MagicMock(return_value={
+            "success": True,
+            "step": None,
+            "lint_output": "No lint errors",
+            "type_output": "No type errors",
+            "test_output": "All checks passed",
+            "coverage": None,
+        })
         coordinator._finalize_task = MagicMock(return_value={"status": "completed"})
         
         # Return the coordinator with all its mocks for testing
@@ -525,8 +532,22 @@ class TestErrorHandling:
         
         # First validation fails, second succeeds
         coordinator._run_validation_phase = MagicMock(side_effect=[
-            (False, "lint", "Linting error"), 
-            (True, "validation", "All checks passed")
+            {
+                "success": False,
+                "step": "lint",
+                "lint_output": "Linting error",
+                "type_output": None,
+                "test_output": None,
+                "coverage": None,
+            },
+            {
+                "success": True,
+                "step": None,
+                "lint_output": "No lint errors",
+                "type_output": "No type errors",
+                "test_output": "All checks passed",
+                "coverage": None,
+            },
         ])
         
         # Set up error context


### PR DESCRIPTION
## Summary
- extend `_run_validation_phase` to return a detailed dictionary instead of a tuple
- adapt tests to use named fields from the validation result

## Testing
- `pytest -q` *(fails: command not found)*