### PR TITLE
Add invalid plan schema tests for modifications

### DIFF
--- a/agent_s3/tools/phase_validator.py
+++ b/agent_s3/tools/phase_validator.py
@@ -80,7 +80,9 @@ def validate_phase_transition(pre_plan_data: Dict[str, Any], feature_group: Dict
     return is_valid, "; ".join(error_messages) if error_messages else "Valid"
 
 
-def validate_user_modifications(modification_text: str) -> Tuple[bool, str]:
+def validate_user_modifications(
+    modification_text: str, plan: Optional[Dict[str, Any]] = None
+) -> Tuple[bool, str]:
     """Validate user modifications to ensure they don't break the plan.
     
     Args:
@@ -111,6 +113,23 @@ def validate_user_modifications(modification_text: str) -> Tuple[bool, str]:
     if len(modification_text.strip()) < 5:
         error_messages.append("Modification text is too short or empty")
         is_valid = False
+
+    # Optionally validate plan structure if provided
+    if plan is not None:
+        if not isinstance(plan, dict) or not isinstance(plan.get("feature_groups"), list):
+            error_messages.append("Plan missing 'feature_groups' list")
+            is_valid = False
+        else:
+            for group in plan.get("feature_groups", []):
+                if not isinstance(group, dict) or not isinstance(group.get("features"), list):
+                    error_messages.append("Invalid feature group structure")
+                    is_valid = False
+                    break
+                for feature in group.get("features", []):
+                    if not isinstance(feature, dict) or "name" not in feature or "description" not in feature:
+                        error_messages.append("Invalid feature object in plan")
+                        is_valid = False
+                        break
     
     # Return validation result
     return is_valid, "; ".join(error_messages) if error_messages else "Valid"

--- a/tests/test_phase_validation.py
+++ b/tests/test_phase_validation.py
@@ -97,6 +97,18 @@ class TestPhaseValidation(unittest.TestCase):
         is_valid, message = validate_user_modifications(invalid_modification_2)
         self.assertFalse(is_valid)
         self.assertTrue(any(pattern in message for pattern in ["delete everything", "start over"]))
+
+        # Invalid plan - missing feature_groups
+        invalid_plan = {}
+        is_valid, message = validate_user_modifications(valid_modification, invalid_plan)
+        self.assertFalse(is_valid)
+        self.assertIn("feature_groups", message)
+
+        # Invalid plan - malformed feature object
+        malformed_plan = {"feature_groups": [{"group_name": "Group 1", "features": ["not a dict"]}]}
+        is_valid, message = validate_user_modifications(valid_modification, malformed_plan)
+        self.assertFalse(is_valid)
+        self.assertIn("invalid feature", message.lower())
     
     def test_validate_architecture_implementation(self):
         """Test validation of architecture-implementation consistency."""


### PR DESCRIPTION
## Summary
- extend validation for user modifications to check optional plan structure
- test for missing `feature_groups` and malformed feature data

## Testing
- `python -m pytest tests/test_phase_validation.py::TestPhaseValidation::test_validate_user_modifications -q` *(fails: No module named pytest)*