### PR TITLE
Remove unused imports

### DIFF
--- a/agent_s3/tools/phase_validator.py
+++ b/agent_s3/tools/phase_validator.py
@@ -9,10 +9,8 @@ This module provides validation functions to check for consistency between:
 
 import os
 import logging
-from typing import Dict, List, Any, Tuple, Optional, Set
+from typing import Dict, List, Any, Tuple, Optional
 import re
-import difflib
-import json
 
 logger = logging.getLogger(__name__)
 

--- a/agent_s3/tools/static_plan_checker.py
+++ b/agent_s3/tools/static_plan_checker.py
@@ -11,7 +11,6 @@ from typing import Dict, Any, List, Tuple, Optional, Set
 from difflib import SequenceMatcher
 
 from agent_s3.tools.plan_validator import validate_pre_plan
-from agent_s3.tools.phase_validator import validate_user_modifications
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_phase_validation.py
+++ b/tests/test_phase_validation.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest.mock import MagicMock, patch
 import json
 import os
 import sys


### PR DESCRIPTION
## Summary
- clean up imports in `phase_validator.py`
- drop unused mocks from `test_phase_validation.py`
- remove extraneous import in `static_plan_checker.py`

## Testing
- `ruff check agent_s3`
- `mypy agent_s3`
- `pytest -q` *(fails: command not found)*