### PR TITLE
Unify pre-planning config

### DIFF
--- a/agent_s3/config.py
+++ b/agent_s3/config.py
@@ -209,6 +209,7 @@ class ConfigModel(BaseModel):
     adaptive_config_dir: str = ADAPTIVE_CONFIG_DIR
     adaptive_metrics_dir: str = ADAPTIVE_METRICS_DIR
     adaptive_optimization_interval: int = ADAPTIVE_OPTIMIZATION_INTERVAL
+    pre_planning_mode: str = "enforced_json"
     supabase_service_role_key: str = Field(
         default_factory=lambda: os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
     )

--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -292,9 +292,27 @@ def integrate_with_coordinator(coordinator, task_description: str, context: Dict
     """
     # Get the router agent from the coordinator
     router_agent = coordinator.router_agent
-    
-    # Call the pre-planning workflow using the new entry point
-    success, pre_planning_data = call_pre_planner_with_enforced_json(router_agent, task_description, context)
+
+    mode = getattr(coordinator, "config", None)
+    if mode:
+        mode = coordinator.config.config.get("pre_planning_mode", "enforced_json")
+    else:
+        mode = "enforced_json"
+
+    if mode == "off":
+        return {
+            "success": False,
+            "uses_enforced_json": False,
+            "status": "skipped",
+        }
+    if mode == "json":
+        success, pre_planning_data = pre_planning_workflow(
+            router_agent, task_description, context
+        )
+    else:
+        success, pre_planning_data = call_pre_planner_with_enforced_json(
+            router_agent, task_description, context
+        )
     
     if success:
         # Extract key information for the coordinator

--- a/tests/integration/test_enforced_json_coordinator_integration.py
+++ b/tests/integration/test_enforced_json_coordinator_integration.py
@@ -22,8 +22,7 @@ class TestEnforcedJsonCoordinatorIntegration:
         """Create a mock configuration with enforced JSON pre-planning enabled."""
         config = MagicMock(spec=Config)
         config.config = {
-            "use_enforced_json_pre_planning": True,
-            "use_json_pre_planning": False,  # Should prioritize enforced JSON
+            "pre_planning_mode": "enforced_json",
             "workspace_path": "/tmp/test",
             "log_file_path": "/tmp/test/logs",
             "sandbox_environment": True,

--- a/tests/test_coordinator_json_preplanning.py
+++ b/tests/test_coordinator_json_preplanning.py
@@ -19,10 +19,7 @@ class TestCoordinatorJsonPrePlanning:
         """Test that enforced JSON integration is used."""
         coordinator = MagicMock()
         coordinator.config = MagicMock()
-        coordinator.config.config = {
-            "use_enforced_json_pre_planning": True,
-            "use_json_pre_planning": True
-        }
+        coordinator.config.config = {"pre_planning_mode": "enforced_json"}
 
         mock_enforced_json.return_value = {
             "status": "completed",
@@ -43,10 +40,7 @@ class TestCoordinatorJsonPrePlanning:
         """Test that errors propagate when enforced JSON fails."""
         coordinator = MagicMock()
         coordinator.config = MagicMock()
-        coordinator.config.config = {
-            "use_enforced_json_pre_planning": True,
-            "use_json_pre_planning": True,
-        }
+        coordinator.config.config = {"pre_planning_mode": "enforced_json"}
 
         mock_enforced_json.side_effect = Exception("Enforced JSON failed")
 
@@ -180,10 +174,7 @@ class TestCoordinatorJsonPrePlanning:
         """Test that complexity scoring is reflected in results."""
         coordinator = MagicMock()
         coordinator.config = MagicMock()
-        coordinator.config.config = {
-            "use_enforced_json_pre_planning": True,
-            "use_json_pre_planning": True,
-        }
+        coordinator.config.config = {"pre_planning_mode": "enforced_json"}
         coordinator.pre_planner.assess_complexity.return_value = {
             "score": 60,
             "is_complex": True,
@@ -211,10 +202,7 @@ class TestCoordinatorJsonPrePlanning:
         """Test repeated integration calls."""
         coordinator = MagicMock()
         coordinator.config = MagicMock()
-        coordinator.config.config = {
-            "use_enforced_json_pre_planning": True,
-            "use_json_pre_planning": True,
-        }
+        coordinator.config.config = {"pre_planning_mode": "enforced_json"}
 
         with patch(
             'agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json'


### PR DESCRIPTION
## Summary
- introduce `pre_planning_mode` config option
- switch Coordinator and pre_planner_json_enforced to respect new setting
- update unit tests for revised configuration

## Testing
- `ruff check agent_s3` *(fails: E701 Multiple statements on one line and others)*
- `mypy agent_s3` *(fails: Found 1264 errors in 122 files)*
- `pytest -q` *(fails: command not found)*