### PR TITLE
Update docs for MAX_CLARIFICATION_ROUNDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
   - `SUPABASE_ANON_KEY` for client requests
   - `SUPABASE_FUNCTION_NAME` (optional, defaults to `call-llm`)
   - `USE_REMOTE_LLM` to toggle remote LLM usage
+  - `MAX_CLARIFICATION_ROUNDS` (optional, defaults to `3`) limits pre-planning clarification exchanges
 
   Example `.env`:
 
@@ -299,6 +300,7 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
   SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
   SUPABASE_FUNCTION_NAME=call-llm
   USE_REMOTE_LLM=true
+  MAX_CLARIFICATION_ROUNDS=3
   ```
 
 ## Coding Guidelines

--- a/docs/pre_planning_workflow.md
+++ b/docs/pre_planning_workflow.md
@@ -18,7 +18,7 @@ The pre-planning workflow follows these steps:
 
 5. **Repair**: If validation issues are found, the system attempts to repair them automatically.
 
-6. **User Interaction**: The system may ask clarifying questions to the user if needed.
+6. **User Interaction**: The system may ask clarifying questions to the user if needed. The number of clarification rounds is capped by the `MAX_CLARIFICATION_ROUNDS` environment variable (default: `3`).
 
 7. **Complexity Assessment**: The complexity of the task is assessed to determine if user confirmation is required.
 
@@ -32,7 +32,7 @@ The `pre_planner_json_enforced.py` module is the canonical implementation for pr
 
 - Strict JSON schema definition and enforcement
 - Robust error handling and recovery
-- User interaction for clarifications
+- User interaction for clarifications (limited by `MAX_CLARIFICATION_ROUNDS`)
 - Automatic repair of validation issues
 
 ### Pre-Planner JSON Validator


### PR DESCRIPTION
## Summary
- document `MAX_CLARIFICATION_ROUNDS` env variable and default
- show the variable in `.env` example
- mention clarification limit in pre-planning workflow docs

## Testing
- `pip install pytest` *(fails: no network access)*