### PR TITLE
Add max_attempts param to pre-planning workflow

### DIFF
--- a/agent_s3/coordinator.py
+++ b/agent_s3/coordinator.py
@@ -823,7 +823,11 @@ class Coordinator:
             if mode == "enforced_json":
                 success, pre_plan = call_pre_planner_with_enforced_json(self.router_agent, task)
             else:  # "json"
-                success, pre_plan = pre_planning_workflow(self.router_agent, task)
+                success, pre_plan = pre_planning_workflow(
+                    self.router_agent,
+                    task,
+                    max_attempts=2,
+                )
             if not success:
                 self.scratchpad.log("Coordinator", "Pre-planning failed", level=LogLevel.ERROR)
                 return []

--- a/agent_s3/planning_helper.py
+++ b/agent_s3/planning_helper.py
@@ -6,7 +6,10 @@ from .feature_group_processor import FeatureGroupProcessor
 
 
 def generate_plan_via_workflow(
-    coordinator: Any, task_description: str, context: Optional[Dict[str, Any]] = None
+    coordinator: Any,
+    task_description: str,
+    context: Optional[Dict[str, Any]] = None,
+    max_attempts: int = 2,
 ) -> Dict[str, Any]:
     """Generate a consolidated plan via sequential pre-planning workflow.
 
@@ -19,13 +22,17 @@ def generate_plan_via_workflow(
             ``feature_group_processor``.
         task_description: Description of the task to plan.
         context: Optional context dictionary passed to the pre planner.
+        max_attempts: Maximum number of attempts for the pre-planning step.
 
     Returns:
         Dictionary with ``success`` flag and ``plan`` on success. On failure,
         ``error`` will describe the reason.
     """
     success, pre_plan = pre_planner_json_enforced.pre_planning_workflow(
-        coordinator.router_agent, task_description, context=context
+        coordinator.router_agent,
+        task_description,
+        context=context,
+        max_attempts=max_attempts,
     )
     if not success:
         return {"success": False, "error": "Pre-planning failed", "plan": None}

--- a/tests/integration/test_run_task_consolidated_plan.py
+++ b/tests/integration/test_run_task_consolidated_plan.py
@@ -91,7 +91,7 @@ def test_run_task_with_mocked_llm(monkeypatch):
     # Patch LLM-calling functions
     monkeypatch.setattr(
         'agent_s3.pre_planner_json_enforced.pre_planning_workflow',
-        lambda router, task, context=None: (True, PRE_PLAN_DATA)
+        lambda router, task, context=None, max_attempts=2: (True, PRE_PLAN_DATA)
     )
     monkeypatch.setattr(
         'agent_s3.tools.plan_validator.validate_pre_plan',

--- a/tests/test_integration_run_task.py
+++ b/tests/test_integration_run_task.py
@@ -35,7 +35,7 @@ def test_run_task_simple(monkeypatch):
     }
     monkeypatch.setattr(
         "agent_s3.pre_planner_json_enforced.pre_planning_workflow",
-        lambda router, task, context=None: (True, pre_plan_data),
+        lambda router, task, context=None, max_attempts=2: (True, pre_plan_data),
     )
     monkeypatch.setattr(
         "agent_s3.pre_planner_json_enforced.regenerate_pre_planning_with_modifications",

--- a/tests/test_pre_planner.py
+++ b/tests/test_pre_planner.py
@@ -79,11 +79,13 @@ class TestPrePlanner:
         # Setup mock
         mock_workflow.return_value = (True, {"feature_groups": []})
         
-        # Call method
-        result = pre_planner.generate_pre_planning_data("Test task")
+        # Call method with custom attempts
+        result = pre_planner.generate_pre_planning_data("Test task", max_attempts=3)
         
         # Verify JSON enforcement was used
         mock_workflow.assert_called_once()
+        args, kwargs = mock_workflow.call_args
+        assert kwargs.get("max_attempts") == 3
         assert result["success"] is True
         assert "pre_planning_data" in result
         assert "complexity_assessment" in result

--- a/tests/test_pre_planner_json_enforced.py
+++ b/tests/test_pre_planner_json_enforced.py
@@ -266,7 +266,7 @@ class TestPrePlannerJsonEnforced:
         mock_coordinator.get_current_timestamp.return_value = "2025-01-01T00:00:00"
         
         # Call the integration function
-        result = integrate_with_coordinator(mock_coordinator, task)
+        result = integrate_with_coordinator(mock_coordinator, task, max_attempts=4)
         
         # Verify results
         assert result["success"] is True
@@ -284,6 +284,7 @@ class TestPrePlannerJsonEnforced:
         args, kwargs = mock_workflow.call_args
         assert args[0] == mock_coordinator.router_agent
         assert args[1] == task
+        assert kwargs.get("max_attempts") == 4
 
     @patch('agent_s3.pre_planner_json_enforced.process_response')
     @patch('agent_s3.pre_planner_json_enforced.get_json_system_prompt')


### PR DESCRIPTION
## Summary
- add `max_attempts` argument to `pre_planning_workflow`
- allow `PrePlanner.generate_pre_planning_data` and helpers to pass attempts through
- propagate attempts in coordinator and planning helper
- verify attempts in unit tests
- adapt test patches for new argument

## Testing
- `pytest -q` *(fails: command not found)*