### PR TITLE
Update pre planning workflow context handling

### DIFF
--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -494,6 +494,12 @@ def pre_planning_workflow(
     """Run the JSON-enforced pre-planning workflow."""
     system_prompt = get_json_system_prompt()
     user_prompt = get_json_user_prompt(task_description)
+    if context:
+        try:
+            context_str = json.dumps(context, indent=2)
+        except TypeError:
+            context_str = str(context)
+        user_prompt += "\n\nContext:\n" + context_str
     openrouter_params = get_openrouter_params()
 
     current_prompt = user_prompt

--- a/docs/pre_planning_workflow.md
+++ b/docs/pre_planning_workflow.md
@@ -104,3 +104,10 @@ When working with the pre-planning phase:
 3. Pay attention to complexity assessments to determine if user confirmation is needed
 4. Use the repair capabilities to fix validation issues automatically when possible
 5. Provide clear, detailed feature descriptions to ensure accurate implementation
+
+## Context-Aware Prompts
+
+`pre_planning_workflow` accepts an optional `context` dictionary. When supplied,
+the context is serialized to JSON and appended to the user prompt before calling
+the language model. This enables the pre-planner to consider project specifics
+such as the tech stack or current project structure during analysis.

--- a/tests/test_pre_planner_function_tests.py
+++ b/tests/test_pre_planner_function_tests.py
@@ -205,6 +205,9 @@ def test_call_pre_planner_with_enforced_json(router_agent, mock_context):
     assert "original_request" in result
     assert "feature_groups" in result
     assert len(result["feature_groups"]) > 0
+    # Ensure context was included in the prompt
+    _, call_kwargs = router_agent.call_llm_by_role.call_args
+    assert "Context:" in call_kwargs.get("user_prompt", "")
 
 
 def test_regenerate_pre_planning_with_modifications(router_agent):


### PR DESCRIPTION
## Summary
- include context in prompts generated by `pre_planning_workflow`
- verify context passthrough in unit test
- document context-aware prompting

## Testing
- `ruff check agent_s3/pre_planner_json_enforced.py`
- `python -m pytest tests/test_pre_planner_function_tests.py::test_call_pre_planner_with_enforced_json -q` *(fails: No module named pytest)*