### PR TITLE
Handle invalid mutation score threshold

### DIFF
--- a/agent_s3/coordinator.py
+++ b/agent_s3/coordinator.py
@@ -970,7 +970,16 @@ class Coordinator:
             critic_data = self.test_critic.run_analysis()
             mutation_score = critic_data.get("details", {}).get("mutation_score")
             results["mutation_score"] = mutation_score
-            threshold = float(self.config.config.get("mutation_score_threshold", 70.0))
+            threshold_config = self.config.config.get("mutation_score_threshold", 70.0)
+            try:
+                threshold = float(threshold_config)
+            except (TypeError, ValueError):
+                self.scratchpad.log(
+                    "Coordinator",
+                    f"Invalid mutation_score_threshold '{threshold_config}', defaulting to 70.0",
+                    level=LogLevel.ERROR,
+                )
+                threshold = 70.0
             if mutation_score is not None and mutation_score < threshold:
                 results.update({"success": False, "step": "mutation"})
                 return results


### PR DESCRIPTION
## Summary
- log and fall back when invalid `mutation_score_threshold`
- test the fallback behaviour

## Testing
- `ruff check agent_s3` *(fails: E701, F401, F841, etc.)*
- `mypy agent_s3` *(fails: many errors)*
- `pytest tests/test_coordinator_validation.py::test_validation_phase_invalid_threshold -q` *(fails: pytest not installed)*