### PR TITLE
Document pre_planning_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
   - `SUPABASE_FUNCTION_NAME` (optional, defaults to `call-llm`)
   - `USE_REMOTE_LLM` to toggle remote LLM usage
   - `MAX_CLARIFICATION_ROUNDS` (optional, defaults to `3`) limits pre-planning clarification exchanges
+  - `pre_planning_mode` selects `off`, `json`, or `enforced_json` workflow. See `docs/pre_planning_workflow.md` for details.
 
   Example `.env`:
 

--- a/docs/pre_planning_workflow.md
+++ b/docs/pre_planning_workflow.md
@@ -111,3 +111,14 @@ When working with the pre-planning phase:
 the context is serialized to JSON and appended to the user prompt before calling
 the language model. This enables the pre-planner to consider project specifics
 such as the tech stack or current project structure during analysis.
+
+## Pre-Planning Mode
+
+The `pre_planning_mode` configuration sets how the pre-planning workflow runs. Valid values are:
+
+- `off` – skip the pre-planning phase entirely.
+- `json` – execute `pre_planning_workflow` without strict schema enforcement.
+- `enforced_json` – run `call_pre_planner_with_enforced_json` with full validation (default).
+
+This option replaces the older `use_json_pre_planning` and `use_enforced_json_pre_planning` flags.
+Set `pre_planning_mode` to the desired value in your configuration to control the behavior.


### PR DESCRIPTION
## Summary
- add documentation for `pre_planning_mode` and its values
- note that this replaces the old boolean flags
- reference the new section from the README

## Testing
- `ruff check agent_s3`
- `mypy agent_s3`
- `pytest -q` *(fails: `pytest: command not found`)*