### PR TITLE
Update validation docstring

### DIFF
--- a/agent_s3/coordinator.py
+++ b/agent_s3/coordinator.py
@@ -919,7 +919,7 @@ class Coordinator:
 
         Returns a dictionary with the following keys:
             - ``success``: overall validation success
-            - ``step``: failing step (``"lint"``, ``"type_check"``, ``"tests"``) if any
+            - ``step``: failing step (``"lint"``, ``"type_check"``, ``"tests"``, ``"unknown_error"``) if any
             - ``lint_output``: output from the linting command
             - ``type_output``: output from the type checking command
             - ``test_output``: output from running the tests


### PR DESCRIPTION
## Summary
- document `unknown_error` as a possible `step` value when validation fails

## Testing
- `mypy agent_s3` *(fails: returning Any from function declared to return "str | None")*
- `ruff check agent_s3` *(fails: found 433 errors)*
- `pytest -q` *(fails: command not found)*