### PR TITLE
Allow configurable clarification rounds

### DIFF
--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -14,9 +14,10 @@ Key responsibilities:
 
 import json
 import logging
+import os
 import re
-import time # Added for potential delays in retry
-from typing import Dict, Any, Optional, Tuple, List, Union
+import time  # Added for potential delays in retry
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from agent_s3.progress_tracker import progress_tracker
 
@@ -33,6 +34,11 @@ from agent_s3.json_utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+try:
+    MAX_CLARIFICATION_ROUNDS = int(os.getenv("MAX_CLARIFICATION_ROUNDS", "3"))
+except ValueError:
+    MAX_CLARIFICATION_ROUNDS = 3
 
 # Base system prompt for pre-planning
 def get_base_system_prompt() -> str:
@@ -524,7 +530,7 @@ def pre_planning_workflow(
     current_prompt = user_prompt
     attempts = 0
     clarification_attempts = 0
-    max_clarifications = 3
+    max_clarifications = MAX_CLARIFICATION_ROUNDS
 
     while attempts < max_attempts:
         response = router_agent.call_llm_by_role(


### PR DESCRIPTION
## Summary
- support MAX_CLARIFICATION_ROUNDS env var in pre_planning workflow
- use env var for clarification cap
- test environment variable handling

## Testing
- `ruff check agent_s3/pre_planner_json_enforced.py tests/test_pre_planner_json_enforced.py`
- `mypy agent_s3/pre_planner_json_enforced.py`
- `pytest tests/test_pre_planner_json_enforced.py::TestPrePlannerJsonEnforced::test_max_clarification_rounds_env_var -q` *(fails: command not found)*