### PR TITLE
feat(pre-planner): make clarification rounds configurable

### DIFF
--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -14,8 +14,9 @@ Key responsibilities:
 
 import json
 import logging
+import os
 import re
-import time # Added for potential delays in retry
+import time  # Added for potential delays in retry
 from typing import Dict, Any, Optional, Tuple, List, Union
 
 from agent_s3.progress_tracker import progress_tracker
@@ -517,7 +518,8 @@ def pre_planning_workflow(
     The workflow may prompt the user for additional clarification when the
     initial request lacks sufficient detail. Clarification exchanges are
     limited by the ``MAX_CLARIFICATION_ROUNDS`` environment variable
-    (default: ``3``).
+    (default: ``3``). Set this variable to control how many clarification
+    prompts are allowed.
     """
     system_prompt = get_json_system_prompt()
     user_prompt = get_json_user_prompt(task_description)
@@ -532,7 +534,10 @@ def pre_planning_workflow(
     current_prompt = user_prompt
     attempts = 0
     clarification_attempts = 0
-    max_clarifications = 3
+    try:
+        max_clarifications = int(os.getenv("MAX_CLARIFICATION_ROUNDS", "3"))
+    except ValueError:
+        max_clarifications = 3
 
     while attempts < max_attempts:
         response = router_agent.call_llm_by_role(

--- a/tests/test_pre_planner_json_enforced.py
+++ b/tests/test_pre_planner_json_enforced.py
@@ -8,6 +8,7 @@ module is the primary implementation used throughout the system for pre-planning
 
 import json
 import logging
+import os
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -564,6 +565,25 @@ DESCRIPTION: Add error handling for connection failures
         
         # Verify the result
         assert result == json_data
+
+    @patch('agent_s3.pre_planner_json_enforced.process_response')
+    def test_pre_planning_workflow_respects_env_max_clarifications(self, mock_process):
+        """Ensure MAX_CLARIFICATION_ROUNDS limits clarification prompts."""
+        router = MagicMock()
+        router.call_llm_by_role.return_value = "{}"
+
+        mock_process.side_effect = [
+            ("question", {"question": "Q1?"}),
+            ("question", {"question": "Q2?"}),
+            (True, {"original_request": "Task", "features": []})
+        ]
+
+        with patch.dict(os.environ, {"MAX_CLARIFICATION_ROUNDS": "1"}), patch('builtins.input', return_value='A1') as mock_input:
+            success, data = pre_planning_workflow(router, "Task")
+
+        assert success is True
+        assert data == {"original_request": "Task", "features": []}
+        assert mock_input.call_count == 1
 
     @patch('agent_s3.pre_planner_json_enforced.process_response')
     def test_pre_planning_workflow_appends_clarification_to_file(self, mock_process, tmp_path):


### PR DESCRIPTION
## Summary
- allow customizing the max number of pre-planning clarification prompts via `MAX_CLARIFICATION_ROUNDS`
- test that the env variable is honored

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
- `mypy agent_s3` *(fails: many errors)*
- `ruff check agent_s3` *(fails: found 433 errors)*