### PR TITLE
Add text sanitization for pre-planning logs

### DIFF
--- a/agent_s3/json_utils.py
+++ b/agent_s3/json_utils.py
@@ -16,6 +16,35 @@ class JSONValidationError(Exception):
     """Exception raised when JSON validation fails."""
     pass
 
+
+def sanitize_text(text: str) -> str:
+    """Escape newlines and control characters in ``text``.
+
+    This helper ensures strings written to logs or JSON files do not contain
+    raw control characters that could break formatting or terminal output.
+
+    Args:
+        text: The text to sanitize.
+
+    Returns:
+        The sanitized text with newlines and other control characters escaped.
+    """
+
+    if not isinstance(text, str):
+        text = str(text)
+
+    # Escape backslashes first to avoid double escaping
+    text = text.replace("\\", "\\\\")
+    # Replace common whitespace control chars with escaped sequences
+    text = (
+        text.replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
+    # Remove remaining ASCII control characters
+    text = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f]", "", text)
+    return text
+
 def extract_json_from_text(text: str) -> Optional[str]:
     """
     Extract JSON from text that might contain markdown or other formatting.

--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -31,6 +31,7 @@ from agent_s3.json_utils import (
     get_openrouter_json_params,
     validate_json_schema,
     repair_json_structure,
+    sanitize_text,
 )
 
 logger = logging.getLogger(__name__)
@@ -559,7 +560,7 @@ def pre_planning_workflow(
                         {
                             "phase": "pre-planning clarification",
                             "question": question,
-                            "answer": answer,
+                            "answer": sanitize_text(answer),
                         }
                     )
                 )


### PR DESCRIPTION
## Summary
- add `sanitize_text` helper to escape newlines and control characters
- sanitize clarification answers logged in `pre_planning_workflow`

## Testing
- `ruff check agent_s3`
- `pytest tests/test_pre_planner_json_enforced.py::test_pre_planning_workflow_logs_single_clarification -q` *(fails: command not found)*