### PR TITLE
Add MAX_CLARIFICATION_ROUNDS cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
   - `SUPABASE_ANON_KEY` for client requests
   - `SUPABASE_FUNCTION_NAME` (optional, defaults to `call-llm`)
   - `USE_REMOTE_LLM` to toggle remote LLM usage
-  - `MAX_CLARIFICATION_ROUNDS` (optional, defaults to `3`) limits pre-planning clarification exchanges
+  - `MAX_CLARIFICATION_ROUNDS` (optional, defaults to `3`, capped by `MAX_CLARIFICATION_ROUNDS_CAP` which is `10`) limits pre-planning clarification exchanges
   - `pre_planning_mode` selects `off`, `json`, or `enforced_json` workflow. See `docs/pre_planning_workflow.md` for details.
 
   Example `.env`:

--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -36,6 +36,9 @@ from agent_s3.json_utils import (
 
 logger = logging.getLogger(__name__)
 
+# Maximum clarification rounds allowed regardless of environment setting
+MAX_CLARIFICATION_ROUNDS_CAP = 10
+
 # Base system prompt for pre-planning
 def get_base_system_prompt() -> str:
     """
@@ -539,6 +542,7 @@ def pre_planning_workflow(
         max_clarifications = int(os.getenv("MAX_CLARIFICATION_ROUNDS", "3"))
     except ValueError:
         max_clarifications = 3
+    max_clarifications = min(max_clarifications, MAX_CLARIFICATION_ROUNDS_CAP)
 
     while attempts < max_attempts:
         response = router_agent.call_llm_by_role(

--- a/docs/pre_planning_workflow.md
+++ b/docs/pre_planning_workflow.md
@@ -18,7 +18,7 @@ The pre-planning workflow follows these steps:
 
 5. **Repair**: If validation issues are found, the system attempts to repair them automatically.
 
-6. **User Interaction**: The system may ask clarifying questions to the user if needed. The number of clarification rounds is capped by the `MAX_CLARIFICATION_ROUNDS` environment variable (default: `3`).
+6. **User Interaction**: The system may ask clarifying questions to the user if needed. The number of clarification rounds is capped by the `MAX_CLARIFICATION_ROUNDS` environment variable (default: `3`) and cannot exceed `MAX_CLARIFICATION_ROUNDS_CAP` (10).
 
 7. **Complexity Assessment**: The complexity of the task is assessed to determine if user confirmation is required.
 
@@ -32,7 +32,7 @@ The `pre_planner_json_enforced.py` module is the canonical implementation for pr
 
 - Strict JSON schema definition and enforcement
 - Robust error handling and recovery
-- User interaction for clarifications (limited by `MAX_CLARIFICATION_ROUNDS`)
+- User interaction for clarifications (limited by `MAX_CLARIFICATION_ROUNDS` and capped at `MAX_CLARIFICATION_ROUNDS_CAP`)
 - Automatic repair of validation issues
 
 ### Pre-Planner JSON Validator


### PR DESCRIPTION
## Summary
- introduce `MAX_CLARIFICATION_ROUNDS_CAP` constant in pre_planning
- cap env-driven clarification rounds in workflow
- document new cap in README and workflow docs
- test clarification cap

## Testing
- `python -m pytest tests/test_pre_planner_json_enforced.py::TestPrePlannerJsonEnforced::test_pre_planning_workflow_clarification_cap -q` *(fails: No module named pytest)*