### PR TITLE
Implement planner validation utilities

### DIFF
--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -15,16 +15,12 @@ Key responsibilities:
 import json
 import logging
 import os
-import re
 import time  # Added for potential delays in retry
 from typing import Dict, Any, Optional, Tuple, List, Union
 
 from agent_s3.progress_tracker import progress_tracker
 
-from agent_s3.pre_planning_errors import (
-    AgentS3BaseError, PrePlanningError, ValidationError, SchemaError,
-    ComplexityError, RepairError, handle_pre_planning_errors
-)
+from agent_s3.pre_planning_errors import PrePlanningError
 
 from agent_s3.json_utils import (
     extract_json_from_text,
@@ -33,6 +29,7 @@ from agent_s3.json_utils import (
     repair_json_structure,
     sanitize_text,
 )
+from agent_s3.pre_planning_validator import PrePlanningValidator
 
 logger = logging.getLogger(__name__)
 
@@ -657,7 +654,7 @@ def process_response(response: str, original_request: str) -> Tuple[Union[bool, 
                 return True, repaired
             else:
                 return False, repaired
-        except Exception as repair_e:
+        except Exception:
             return False, data
 
 def ensure_element_id_consistency(pre_planning_data: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- add `validate_pre_planning_for_planner` and `regenerate_consolidated_plan_with_modifications`
- clean unused imports and fix lints in pre-planner
- expose `PrePlanningValidator`

## Testing
- `ruff check agent_s3/planner_json_enforced.py`
- `ruff check agent_s3/pre_planner_json_enforced.py`
- `ruff check agent_s3/coordinator.py`
- `mypy agent_s3`
- `pytest -q` *(fails: 83 errors during collection)*