### PR TITLE
Fix import errors with optional dependencies

### DIFF
--- a/agent_s3/__init__.py
+++ b/agent_s3/__init__.py
@@ -1,42 +1,43 @@
 """Agent-S3: A fully functional, state-of-the-art AI coding agent."""
 
-# This package now includes ast_tools for AST-guided summarization
-# and has been refactored to use Single Responsibility Principle.
+# This package now includes ast_tools for AST-guided summarization and follows
+# the Single Responsibility Principle. Importing heavy modules at package import
+# time can lead to unnecessary dependency errors during test collection when
+# optional packages are missing. To mitigate this we expose a lazy import layer
+# so that components are loaded only when first accessed.
+
+from importlib import import_module
+from typing import Any
 
 __version__ = "0.2.0"
 
-# Core components
-from agent_s3.coordinator import Coordinator
-from agent_s3.workspace_initializer import WorkspaceInitializer
-from agent_s3.tech_stack_detector import TechStackDetector
-from agent_s3.file_history_analyzer import FileHistoryAnalyzer
-from agent_s3.task_resumer import TaskResumer
-from agent_s3.command_processor import CommandProcessor
-from agent_s3.pre_planning_validator import PrePlanningValidator
-from agent_s3.complexity_analyzer import ComplexityAnalyzer
-from agent_s3.database_manager import DatabaseManager
-from agent_s3.security_utils import strip_sensitive_headers
-from agent_s3.pre_planning_errors import (
-    AgentS3BaseError, PrePlanningError, ValidationError,
-    SchemaError, RepairError, ComplexityError, handle_pre_planning_errors
-)
+_MODULE_MAP = {
+    "Coordinator": "agent_s3.coordinator",
+    "WorkspaceInitializer": "agent_s3.workspace_initializer",
+    "TechStackDetector": "agent_s3.tech_stack_detector",
+    "FileHistoryAnalyzer": "agent_s3.file_history_analyzer",
+    "TaskResumer": "agent_s3.task_resumer",
+    "CommandProcessor": "agent_s3.command_processor",
+    "PrePlanningValidator": "agent_s3.pre_planning_validator",
+    "ComplexityAnalyzer": "agent_s3.complexity_analyzer",
+    "DatabaseManager": "agent_s3.database_manager",
+    "strip_sensitive_headers": "agent_s3.security_utils",
+    "AgentS3BaseError": "agent_s3.pre_planning_errors",
+    "PrePlanningError": "agent_s3.pre_planning_errors",
+    "ValidationError": "agent_s3.pre_planning_errors",
+    "SchemaError": "agent_s3.pre_planning_errors",
+    "RepairError": "agent_s3.pre_planning_errors",
+    "ComplexityError": "agent_s3.pre_planning_errors",
+    "handle_pre_planning_errors": "agent_s3.pre_planning_errors",
+}
 
-__all__ = [
-    'Coordinator',
-    'WorkspaceInitializer',
-    'TechStackDetector',
-    'FileHistoryAnalyzer',
-    'TaskResumer',
-    'PrePlanningValidator',
-    'ComplexityAnalyzer',
-    'AgentS3BaseError',
-    'PrePlanningError',
-    'ValidationError',
-    'SchemaError',
-    'RepairError',
-    'ComplexityError',
-    'handle_pre_planning_errors',
-    'CommandProcessor',
-    'DatabaseManager',
-    'strip_sensitive_headers',
-]
+__all__ = list(_MODULE_MAP.keys())
+
+
+def __getattr__(name: str) -> Any:
+    """Dynamically import objects on first access."""
+    module_path = _MODULE_MAP.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module = import_module(module_path)
+    return getattr(module, name)


### PR DESCRIPTION
## Summary
- add fallback classes when SQLAlchemy is missing
- avoid importing heavy modules at package import time by using lazy loading
- adjust database tool type hints for optional SQLAlchemy

## Testing
- `pytest -q tests/test_database_tool_query.py::test_execute_query_fallback_on_error -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*