### PR TITLE
Fix lint errors in key modules

### DIFF
--- a/agent_s3/cache/gdsf.py
+++ b/agent_s3/cache/gdsf.py
@@ -3,6 +3,7 @@ Prefix-aware Greedy-Dual-Size-Frequency (GDSF) eviction policy for GPTCache.
 """
 import time
 from gptcache.manager.eviction.base import BaseEvictionPolicy
+from gptcache.manager.eviction import registry
 
 class PrefixGDSF(BaseEvictionPolicy):
     def __init__(self):
@@ -20,5 +21,4 @@ class PrefixGDSF(BaseEvictionPolicy):
         return victim["uuid"]
 
 # Register the policy at import time
-from gptcache.manager.eviction import registry
 registry.register("custom_gdsf", PrefixGDSF)

--- a/agent_s3/cache/setup_cache.py
+++ b/agent_s3/cache/setup_cache.py
@@ -16,11 +16,10 @@ def init_semantic_cache():
         cache_cfg = config.get('semantic_cache', {})
         if not cache_cfg.get('enabled', True):
             return  # Skip if disabled
-        lambda_decay = cache_cfg.get('lambda_decay', 0.001)
-        prefix_tokens = cache_cfg.get('prefix_tokens', 50)
+        _ = cache_cfg.get('lambda_decay', 0.001)
+        _ = cache_cfg.get('prefix_tokens', 50)
     except Exception:
-        lambda_decay = 0.001
-        prefix_tokens = 50
+        pass
     # Register custom GDSF policy (import triggers registration)
     from .gdsf import PrefixGDSF  # noqa: F401
     cache.init(

--- a/agent_s3/command_processor.py
+++ b/agent_s3/command_processor.py
@@ -8,7 +8,7 @@ import logging
 import json
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, Any, Optional, Tuple, List, Union, Callable
+
 
 from .planning_helper import generate_plan_via_workflow
 

--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -15,16 +15,13 @@ Key responsibilities:
 import json
 import logging
 import os
-import re
 import time  # Added for potential delays in retry
 from typing import Dict, Any, Optional, Tuple, List, Union
 
 from agent_s3.progress_tracker import progress_tracker
+from agent_s3.pre_planning_validator import PrePlanningValidator
 
-from agent_s3.pre_planning_errors import (
-    AgentS3BaseError, PrePlanningError, ValidationError, SchemaError,
-    ComplexityError, RepairError, handle_pre_planning_errors
-)
+from agent_s3.pre_planning_errors import PrePlanningError
 
 from agent_s3.json_utils import (
     extract_json_from_text,
@@ -657,7 +654,7 @@ def process_response(response: str, original_request: str) -> Tuple[Union[bool, 
                 return True, repaired
             else:
                 return False, repaired
-        except Exception as repair_e:
+        except Exception:
             return False, data
 
 def ensure_element_id_consistency(pre_planning_data: Dict[str, Any]) -> Dict[str, Any]:

--- a/agent_s3/prompt_moderator.py
+++ b/agent_s3/prompt_moderator.py
@@ -2,11 +2,11 @@
 
 import os
 import sys
-import re
+import json
 import tempfile
 import subprocess
 import shlex
-from typing import Dict, Optional, Union, List, Tuple, Any, Set, Literal
+from typing import Dict, Optional, List, Tuple, Any, Set, Literal
 
 from .communication.vscode_bridge import VSCodeBridge
 
@@ -398,7 +398,7 @@ class PromptModerator:
         
         # Format plan for display
         plan_display = "\n" + "="*80 + "\n"
-        plan_display += f"EXECUTION PLAN SUMMARY:\n"
+        plan_display += "EXECUTION PLAN SUMMARY:\n"
         plan_display += "-"*80 + "\n"
         plan_display += summary + "\n\n"
         plan_display += "="*80 + "\n"
@@ -412,8 +412,7 @@ class PromptModerator:
             # Send to VS Code UI
             self.vscode_bridge.send_terminal_output(plan_display)
             
-            # Extract structured sections for better visualization
-            sections = self._extract_plan_sections(plan)
+
             
             # Create enhanced interactive approval options
             approval_options = [
@@ -1124,7 +1123,7 @@ Focus on explaining the "why" behind the decisions, not just describing what's i
         print(f"\n{prompt_text}:")
         for i, file_path in enumerate(file_list):
             print(f"{i+1}. {file_path}")
-        print(f"0. Cancel")
+        print("0. Cancel")
         
         while True:
             try:

--- a/agent_s3/tools/context_management/adaptive_config/config_explainer.py
+++ b/agent_s3/tools/context_management/adaptive_config/config_explainer.py
@@ -6,10 +6,9 @@ This module provides transparency and observability for adaptive configuration d
 
 import logging
 import json
-from typing import Dict, Any, List, Optional, Tuple, Set, Union
-import time
+import os
+from typing import Dict, Any, List
 from datetime import datetime
-import textwrap
 
 logger = logging.getLogger(__name__)
 

--- a/agent_s3/tools/dependency_analyzer.py
+++ b/agent_s3/tools/dependency_analyzer.py
@@ -6,12 +6,11 @@ This module provides utilities to:
 3. Check for transitive dependencies and conflicts
 """
 
-import ast
-import importlib
 import logging
 import os
+import re
 import sys
-from typing import Dict, List, Set, Tuple, Optional
+from typing import Dict, List, Set, Optional
 from pathlib import Path
 import pkg_resources
 import subprocess

--- a/agent_s3/tools/plan_validator.py
+++ b/agent_s3/tools/plan_validator.py
@@ -11,22 +11,19 @@ Implementation uses comprehensive AST parsing for multi-language code analysis.
 import json
 import re
 import os
-import glob
 import logging
 import keyword
 import ast
-import importlib.util
 import xml.etree.ElementTree as ET
 import datetime
-from typing import Dict, Any, List, Tuple, Set, Optional, Union, Callable
+from typing import Dict, Any, List, Tuple
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 
 # Import AST tools for multi-language support
-from agent_s3.ast_tools.python_units import extract_units
+from agent_s3.ast_tools.parser import parse_js
 from .parsing.parser_registry import ParserRegistry
-from .parsing.base_parser import LanguageParser
 
 logger = logging.getLogger(__name__)
 

--- a/agent_s3/tools/test_implementation_validator.py
+++ b/agent_s3/tools/test_implementation_validator.py
@@ -10,6 +10,7 @@ import json
 import logging
 import re
 import ast
+import difflib
 from typing import Dict, Any, List, Set, Tuple, Optional
 from collections import defaultdict
 

--- a/agent_s3/workflows/implementation_workflow.py
+++ b/agent_s3/workflows/implementation_workflow.py
@@ -1,12 +1,14 @@
 """Workflow helpers for implementation and debugging phases."""
 
+from __future__ import annotations
 from typing import Any, Dict, Tuple, List
+from agent_s3.coordinator import Coordinator
 
 
 class ImplementationWorkflow:
     """Execute code generation, validation and debugging for approved plans."""
 
-    def __init__(self, coordinator: "Coordinator") -> None:
+    def __init__(self, coordinator: Coordinator) -> None:
         self.coordinator = coordinator
 
     def execute(self, plans: List[Dict[str, Any]]) -> Tuple[Dict[str, str], bool]:

--- a/agent_s3/workflows/planning_workflow.py
+++ b/agent_s3/workflows/planning_workflow.py
@@ -1,12 +1,14 @@
 """Workflow helpers for task planning phases."""
 
+from __future__ import annotations
 from typing import Any, Dict, List
+from agent_s3.coordinator import Coordinator
 
 
 class PlanningWorkflow:
     """Handle pre-planning, validation and plan consolidation for a task."""
 
-    def __init__(self, coordinator: "Coordinator") -> None:
+    def __init__(self, coordinator: Coordinator) -> None:
         self.coordinator = coordinator
 
     def execute(self, task: str, pre_planning_input: Dict[str, Any] | None = None, from_design: bool = False) -> List[Dict[str, Any]]:

--- a/tests/test_code_generator.py
+++ b/tests/test_code_generator.py
@@ -3,12 +3,14 @@
 import unittest
 from unittest.mock import MagicMock, patch, mock_open
 import json
-import os
 import tempfile
 
 try:
     from agent_s3.code_generator import CodeGenerator
-    from agent_s3.enhanced_scratchpad_manager import EnhancedScratchpadManager, LogLevel
+    from agent_s3.enhanced_scratchpad_manager import (
+        EnhancedScratchpadManager,
+    )
+    ScratchpadManager = EnhancedScratchpadManager
 except ImportError:
     print("Warning: Could not import full agent_s3 modules for testing. Using stubs.")
     class CodeGenerator:
@@ -16,6 +18,7 @@ except ImportError:
     class EnhancedScratchpadManager:
         def log(self, *args, **kwargs):
             pass
+    ScratchpadManager = EnhancedScratchpadManager
 
 
 class TestCodeGenerator(unittest.TestCase):
@@ -141,7 +144,7 @@ class TestCodeGenerator(unittest.TestCase):
             self.code_generator.router = MagicMock()
             self.code_generator.router.call_llm_with_streaming.return_value = {'success': True, 'response': 'OK'}
         
-        result = self.code_generator.generate_code(task, plan)
+        _ = self.code_generator.generate_code(task, plan)
         
         # Verify cached_call_llm was called, which means _create_generation_prompt was used
         mock_cached_call_llm.assert_called_once()
@@ -172,7 +175,7 @@ class TestCodeGenerator(unittest.TestCase):
         
         # Call generate_code which will use _extract_files_from_plan
         task = "Update files according to plan"
-        result = self.code_generator.generate_code(task, plan)
+        _ = self.code_generator.generate_code(task, plan)
         
         # Verify that the task and prompt were set correctly
         args = mock_cached_call_llm.call_args[0]
@@ -199,7 +202,7 @@ class TestCodeGenerator(unittest.TestCase):
         self.code_generator._generation_attempts = {}
         
         # Call generate_code
-        result = self.code_generator.generate_code(task, plan)
+        _ = self.code_generator.generate_code(task, plan)
         
         # Check that the mock was called with the expected context
         args = mock_cached_call_llm.call_args[0]
@@ -274,7 +277,7 @@ class TestCodeGenerator(unittest.TestCase):
                 }
                 
                 # Call generate_code
-                result = self.code_generator.generate_code(task, plan)
+                _ = self.code_generator.generate_code(task, plan)
                 
                 # Check that the mock was called with the expected context
                 args = mock_cached_call_llm.call_args[0]


### PR DESCRIPTION
## Summary
- clean up unused imports and variables
- tighten type hints for ImplementationWorkflow
- update semantic cache setup
- adjust tests to avoid unused variables
- remove extraneous f-strings

## Testing
- `ruff check agent_s3/workflows/implementation_workflow.py agent_s3/workflows/planning_workflow.py`
- `ruff check tests/test_code_generator.py`
- `pytest tests/test_code_generator.py -q` *(fails: TypeError: CodeGenerator() takes no arguments)*