### PR TITLE
fix(lint): clean up ruff violations

### DIFF
--- a/agent_s3/cache/gdsf.py
+++ b/agent_s3/cache/gdsf.py
@@ -3,6 +3,7 @@ Prefix-aware Greedy-Dual-Size-Frequency (GDSF) eviction policy for GPTCache.
 """
 import time
 from gptcache.manager.eviction.base import BaseEvictionPolicy
+from gptcache.manager.eviction import registry
 
 class PrefixGDSF(BaseEvictionPolicy):
     def __init__(self):
@@ -20,5 +21,4 @@ class PrefixGDSF(BaseEvictionPolicy):
         return victim["uuid"]
 
 # Register the policy at import time
-from gptcache.manager.eviction import registry
 registry.register("custom_gdsf", PrefixGDSF)

--- a/agent_s3/json_utils.py
+++ b/agent_s3/json_utils.py
@@ -8,7 +8,7 @@ eliminating duplication in pre_planner, planner, and other components.
 import json
 import re
 import logging
-from typing import Dict, Any, Optional, List, Tuple, Union, Callable
+from typing import Dict, Any, Optional, List, Tuple, Callable
 
 logger = logging.getLogger(__name__)
 
@@ -227,17 +227,17 @@ def repair_json_structure(
         default_generators = {}
 
     def _default_for_type(typ: Any) -> Any:
-        if typ == str:
+        if typ is str:
             return ""
-        if typ == int:
+        if typ is int:
             return 0
-        if typ == float:
+        if typ is float:
             return 0.0
-        if typ == bool:
+        if typ is bool:
             return False
-        if typ == list:
+        if typ is list:
             return []
-        if typ == dict:
+        if typ is dict:
             return {}
         return None
 

--- a/agent_s3/llm_utils.py
+++ b/agent_s3/llm_utils.py
@@ -5,7 +5,7 @@ backoff, and fallback strategies with advanced semantic caching.
 """
 
 import time
-from typing import Any, Dict, Optional, Callable, Type, List, Union, Tuple
+from typing import Any, Dict, Optional, List
 import requests
 
 # Optional Supabase client
@@ -14,10 +14,9 @@ try:
 except Exception:  # pragma: no cover - library optional
     create_client = None
 import json
-import os
-import threading
-import numpy as np
 import logging
+from agent_s3.cache.helpers import read_cache, write_cache
+from agent_s3.progress_tracker import progress_tracker
 
 # Import GPTCache
 try:
@@ -43,9 +42,6 @@ FALLBACK_PROMPT_TEMPLATE = "Previous attempt failed. Please re-evaluate the requ
 # Initialize GPTCache if available
 if cache:
     cache.init()
-
-from agent_s3.cache.helpers import read_cache, write_cache
-from agent_s3.progress_tracker import progress_tracker
 
 
 def call_llm_via_supabase(prompt: str, github_token: str, config: Dict[str, Any], timeout: Optional[float] = None) -> str:
@@ -432,7 +428,7 @@ def call_llm_with_retry(
     return {
         'success': False,
         'error': (f"LLM API call failed after {max_retries} attempts" +
-                 (f" and fallback" if fallback_strategy != 'none' else "")),
+                 (" and fallback" if fallback_strategy != 'none' else "")),
         'details': f"Last error: {last_error_details}: {last_error}"
     }
 

--- a/agent_s3/planner_json_enforced.py
+++ b/agent_s3/planner_json_enforced.py
@@ -13,9 +13,7 @@ import time
 import random
 from typing import Dict, Any, Optional, List, Tuple
 from datetime import datetime
-import os
 from pathlib import Path
-import warnings
 from collections import defaultdict
 
 from agent_s3.json_utils import extract_json_from_text
@@ -294,7 +292,6 @@ def get_openrouter_params() -> Dict[str, Any]:
     }
 
 # Add import for implementation validator
-from agent_s3.tools.implementation_validator import validate_implementation_plan, repair_implementation_plan
 
 logger = logging.getLogger(__name__)
 
@@ -1057,12 +1054,6 @@ def generate_refined_test_specifications(
                         system_design[key].extend(value)
     
     # Prepare input data for the LLM
-    input_data = {
-        "task_description": task_description,
-        "test_requirements": test_requirements,
-        "system_design": system_design,
-        "architecture_review": architecture_review
-    }
     
     # Create the user prompt
     user_prompt = f"""Please refine and enhance the test specifications for the following feature based on the system design and architecture review.
@@ -2479,12 +2470,9 @@ Focus on creating a comprehensive and detailed plan that a developer can follow 
             # Import validation tools with error handling
             try:
                 from .tools.implementation_validator import (
-                    validate_implementation_plan, 
-                    repair_implementation_plan, 
-                    _validate_implementation_quality,
-                    _validate_implementation_security,
-                    _validate_implementation_test_alignment,
-                    _calculate_implementation_metrics
+                    validate_implementation_plan,
+                    repair_implementation_plan,
+                    _calculate_implementation_metrics,
                 )
             except ImportError as import_error:
                 logger.error(f"Failed to import validation tools: {import_error}")
@@ -2661,7 +2649,7 @@ Focus on creating a comprehensive and detailed plan that a developer can follow 
                     # Add metrics improvement summary
                     if new_metrics["overall_score"] > metrics["overall_score"]:
                         improvement = (new_metrics["overall_score"] - metrics["overall_score"]) * 100
-                        repair_note += f"\n### Quality Improvement\n\n"
+                        repair_note += "\n### Quality Improvement\n\n"
                         repair_note += f"Overall quality score improved by {improvement:.1f}%.\n"
                         repair_note += f"- Element coverage: {metrics['element_coverage_score']:.2f} → {new_metrics['element_coverage_score']:.2f}\n"
                         repair_note += f"- Architecture issue addressal: {metrics['architecture_issue_addressal_score']:.2f} → {new_metrics['architecture_issue_addressal_score']:.2f}\n"
@@ -2714,7 +2702,7 @@ Focus on creating a comprehensive and detailed plan that a developer can follow 
                             response_data["discussion"] = ""
                         
                         coherence_note = "\n\n## Semantic Coherence Validation Results\n\n"
-                        coherence_note += f"The implementation plan was validated for semantic coherence across architecture review, test implementation, and system design.\n\n"
+                        coherence_note += "The implementation plan was validated for semantic coherence across architecture review, test implementation, and system design.\n\n"
                         
                         # Add scores
                         coherence_note += "### Validation Scores\n\n"
@@ -2790,7 +2778,7 @@ Focus on creating a comprehensive and detailed plan that a developer can follow 
                 logger.info("Attempting aggressive JSON structure repair")
                 
                 # Import required utilities
-                from .json_utils import extract_json_from_text, repair_json_structure
+                from .json_utils import repair_json_structure
                 
                 # Define a more tolerant JSON extraction regex pattern
                 json_pattern = r'({[\s\S]*?})'

--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -15,15 +15,15 @@ Key responsibilities:
 import json
 import logging
 import os
-import re
 import time  # Added for potential delays in retry
 from typing import Dict, Any, Optional, Tuple, List, Union
+
+from agent_s3.pre_planning_validator import PrePlanningValidator
 
 from agent_s3.progress_tracker import progress_tracker
 
 from agent_s3.pre_planning_errors import (
-    AgentS3BaseError, PrePlanningError, ValidationError, SchemaError,
-    ComplexityError, RepairError, handle_pre_planning_errors
+    PrePlanningError
 )
 
 from agent_s3.json_utils import (
@@ -657,7 +657,7 @@ def process_response(response: str, original_request: str) -> Tuple[Union[bool, 
                 return True, repaired
             else:
                 return False, repaired
-        except Exception as repair_e:
+        except Exception:
             return False, data
 
 def ensure_element_id_consistency(pre_planning_data: Dict[str, Any]) -> Dict[str, Any]:

--- a/agent_s3/pre_planner_json_validator.py
+++ b/agent_s3/pre_planner_json_validator.py
@@ -16,11 +16,9 @@ import json
 import logging
 import re
 import time
-from typing import Dict, Any, List, Tuple, Optional, Set
+from typing import Dict, Any, List, Tuple
 from dataclasses import dataclass, field
-from datetime import datetime
 
-from agent_s3.pre_planner_json_enforced import JSONValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -130,9 +128,9 @@ class PrePlannerJsonValidator:
         
         # Check for required top-level fields
         required_fields = ["original_request", "feature_groups"]
-        for field in required_fields:
-            if field not in data:
-                errors.append(f"Missing required top-level field: '{field}'")
+        for field_name in required_fields:
+            if field_name not in data:
+                errors.append(f"Missing required top-level field: '{field_name}'")
         
         # Validate feature_groups
         if "feature_groups" in data:
@@ -159,9 +157,11 @@ class PrePlannerJsonValidator:
         
         # Check for required fields in feature group
         required_fields = ["group_name", "group_description", "features"]
-        for field in required_fields:
-            if field not in group:
-                errors.append(f"Feature group at index {index} missing required field: '{field}'")
+        for field_name in required_fields:
+            if field_name not in group:
+                errors.append(
+                    f"Feature group at index {index} missing required field: '{field_name}'"
+                )
         
         # Validate features array
         if "features" in group:
@@ -185,11 +185,20 @@ class PrePlannerJsonValidator:
             return [f"Feature at index {feature_index} in feature group at index {group_index} is not a dictionary"]
         
         # Check for required fields in feature
-        required_fields = ["name", "description", "files_affected", "test_requirements", 
-                          "dependencies", "risk_assessment", "system_design"]
-        for field in required_fields:
-            if field not in feature:
-                errors.append(f"Feature '{feature.get('name', f'at index {feature_index}')}' missing required field: '{field}'")
+        required_fields = [
+            "name",
+            "description",
+            "files_affected",
+            "test_requirements",
+            "dependencies",
+            "risk_assessment",
+            "system_design",
+        ]
+        for field_name in required_fields:
+            if field_name not in feature:
+                errors.append(
+                    f"Feature '{feature.get('name', f'at index {feature_index}')}' missing required field: '{field_name}'"
+                )
         
         # Validate complexity_level if present
         if "complexity_level" in feature:
@@ -358,9 +367,9 @@ class PrePlannerJsonValidator:
                         )
                 
                 # Scan for dangerous commands
-                for field in ["description", "name"]:
-                    if field in feature:
-                        content = feature[field]
+                for field_name in ["description", "name"]:
+                    if field_name in feature:
+                        content = feature[field_name]
                         for cmd in blacklisted_commands:
                             if cmd in content:
                                 errors.append(
@@ -374,9 +383,9 @@ class PrePlannerJsonValidator:
                             continue
                             
                         # Check for dangerous operations in implementation steps
-                        for field in ["description", "code"]:
-                            if field in step:
-                                content = step[field]
+                        for field_name in ["description", "code"]:
+                            if field_name in step:
+                                content = step[field_name]
                                 for cmd in blacklisted_commands:
                                     if cmd in content:
                                         errors.append(
@@ -608,7 +617,7 @@ class PrePlannerJsonValidator:
                                         algorithms[i] = "Custom file processing algorithm (sanitized)"
                                         was_repaired = True
                                         repairs_made += 1
-                                        logger.info(f"Sanitized dangerous command in key_algorithms")
+                                        logger.info("Sanitized dangerous command in key_algorithms")
         
         # Record repair metrics
         self.validation_metrics.record_repair(was_repaired)

--- a/agent_s3/progress_tracker.py
+++ b/agent_s3/progress_tracker.py
@@ -10,6 +10,7 @@ from enum import Enum, auto
 from typing import Dict, Any, Optional, List
 
 from pydantic import BaseModel, Field, ValidationError
+from agent_s3.config import Config
 
 class Status(Enum):
     """Represents the status of a task."""
@@ -256,7 +257,6 @@ class ProgressTracker:
         ]
 
 # Create a default global progress_tracker instance
-from agent_s3.config import Config
 
 _default_config = Config()
 try:

--- a/agent_s3/prompt_moderator.py
+++ b/agent_s3/prompt_moderator.py
@@ -2,11 +2,11 @@
 
 import os
 import sys
-import re
 import tempfile
 import subprocess
 import shlex
-from typing import Dict, Optional, Union, List, Tuple, Any, Set, Literal
+import json
+from typing import Dict, Optional, List, Tuple, Any, Set, Literal
 
 from .communication.vscode_bridge import VSCodeBridge
 
@@ -398,7 +398,7 @@ class PromptModerator:
         
         # Format plan for display
         plan_display = "\n" + "="*80 + "\n"
-        plan_display += f"EXECUTION PLAN SUMMARY:\n"
+        plan_display += "EXECUTION PLAN SUMMARY:\n"
         plan_display += "-"*80 + "\n"
         plan_display += summary + "\n\n"
         plan_display += "="*80 + "\n"
@@ -413,7 +413,7 @@ class PromptModerator:
             self.vscode_bridge.send_terminal_output(plan_display)
             
             # Extract structured sections for better visualization
-            sections = self._extract_plan_sections(plan)
+            self._extract_plan_sections(plan)
             
             # Create enhanced interactive approval options
             approval_options = [
@@ -1124,7 +1124,7 @@ Focus on explaining the "why" behind the decisions, not just describing what's i
         print(f"\n{prompt_text}:")
         for i, file_path in enumerate(file_list):
             print(f"{i+1}. {file_path}")
-        print(f"0. Cancel")
+        print("0. Cancel")
         
         while True:
             try:

--- a/agent_s3/schema_validator.py
+++ b/agent_s3/schema_validator.py
@@ -1,3 +1,11 @@
+import json
+import logging
+import re
+from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
+
+from pydantic import BaseModel, Field, ValidationError
+
+
 def get_json_system_prompt() -> str:
     """
     Get the system prompt that enforces JSON output format.
@@ -124,11 +132,6 @@ This module defines Pydantic models for validating LLM responses and provides
 utility functions for robust parsing and validation of LLM responses.
 """
 
-import logging
-import json
-import re
-from typing import Dict, List, Any, Optional, Union, TypeVar, Type, Generic, Callable
-from pydantic import BaseModel, Field, ValidationError
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- move registry import to top and clean up gdsf
- use `is` for type checks in `json_utils`
- reorder imports in `llm_utils`
- drop unused validator imports
- inject pre-planning validator import
- rename loop vars in JSON validator
- move config import to top of progress tracker
- import json module in `prompt_moderator`
- reorganize imports in `schema_validator`

## Testing
- `ruff check agent_s3` *(fails: Found 365 errors)*