### PR TITLE
Fix lint on first flagged files

### DIFF
--- a/agent_s3/communication/enhanced_websocket_server.py
+++ b/agent_s3/communication/enhanced_websocket_server.py
@@ -13,7 +13,7 @@ import socket
 import threading
 import time
 import uuid
-from typing import Dict, Any, Optional, Set, List, Callable
+from typing import Dict, Any, Optional, Set, List
 import websockets
 
 from .message_protocol import Message, MessageType, MessageBus, MessageQueue
@@ -289,7 +289,8 @@ class EnhancedWebSocketServer:
         # Extract stream ID and content
         content = message.content
         stream_id = content.get("stream_id", "")
-        text_content = content.get("content", "")
+        # Extract the raw text content if needed for future processing
+        # Currently, the server does not use the content directly
         
         # Ensure we're tracking this stream
         self._active_streams = getattr(self, "_active_streams", set())
@@ -507,7 +508,8 @@ class EnhancedWebSocketServer:
             message_dict: The message dictionary
         """
         # Get sync markers from client (timestamps, sequence IDs)
-        sync_markers = message_dict.get("content", {}).get("sync_markers", {})
+        # Extract client-provided synchronization markers if available
+        _ = message_dict.get("content", {}).get("sync_markers", {})
         
         # Determine what data needs to be sent
         # This is application-specific, but we'll send back some state for example
@@ -605,7 +607,8 @@ class EnhancedWebSocketServer:
                 # Fall back to direct send if no batching
                 payload = json.dumps(message.to_dict())
                 if len(payload) > 4096:
-                    import gzip, base64
+                    import gzip
+                    import base64
                     compressed = gzip.compress(payload.encode("utf-8"))
                     payload = json.dumps({
                         "encoding": "gzip",

--- a/agent_s3/communication/message_protocol.py
+++ b/agent_s3/communication/message_protocol.py
@@ -4,11 +4,10 @@ This module defines the message protocol used for communication between
 the Agent-S3 backend and the VS Code extension's WebView UI.
 """
 
-import json
 import uuid
 from datetime import datetime
 from enum import Enum
-from typing import Dict, Any, Optional, List, Union, Callable, Type, Set
+from typing import Dict, Any, Optional, List, Union, Callable, Set
 import logging
 import jsonschema
 from jsonschema import validate

--- a/agent_s3/communication/vscode_bridge.py
+++ b/agent_s3/communication/vscode_bridge.py
@@ -1,13 +1,11 @@
 """Simplified VS Code bridge used for unit tests."""
 from __future__ import annotations
 
-import json
 import logging
 import queue
 import threading
 import time
-from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from .message_protocol import Message, MessageBus, MessageType
 

--- a/agent_s3/complexity_analyzer.py
+++ b/agent_s3/complexity_analyzer.py
@@ -6,7 +6,7 @@ based on multiple weighted factors including feature count, impacted files,
 requirements complexity, security sensitivity, and external integrations.
 """
 
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, Optional
 import re
 import logging
 

--- a/agent_s3/deployment_manager.py
+++ b/agent_s3/deployment_manager.py
@@ -11,9 +11,8 @@ import json
 import re
 import secrets
 import string
-from pathlib import Path
-from typing import Dict, Any, List, Optional, Tuple, Union
-from urllib.parse import urlparse, quote_plus
+from typing import Dict, Any, List, Optional, Tuple
+from urllib.parse import quote_plus
 from datetime import datetime
 
 logger = logging.getLogger(__name__)
@@ -860,7 +859,7 @@ if __name__ == "__main__":
         elif config.app_type == "django":
             # For Django, we'd need to create a more complete structure,
             # so return a minimal manage.py and suggest running django-admin
-            return f"""#!/usr/bin/env python
+            return """#!/usr/bin/env python
 import os
 import sys
 from dotenv import load_dotenv


### PR DESCRIPTION
## Summary
- run Ruff autofix on first five flagged files
- remove unused imports and variables
- split gzip/base64 import lines for clarity

## Testing
- `ruff check agent_s3/communication/enhanced_websocket_server.py agent_s3/communication/message_protocol.py agent_s3/communication/vscode_bridge.py agent_s3/complexity_analyzer.py agent_s3/deployment_manager.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rank_bm25')*