### PR TITLE
Fix lint on next flagged files

### DIFF
--- a/agent_s3/communication/enhanced_websocket_server.py
+++ b/agent_s3/communication/enhanced_websocket_server.py
@@ -13,7 +13,7 @@ import socket
 import threading
 import time
 import uuid
-from typing import Dict, Any, Optional, Set, List, Callable
+from typing import Dict, Any, Optional, Set, List
 import websockets
 
 from .message_protocol import Message, MessageType, MessageBus, MessageQueue
@@ -289,7 +289,8 @@ class EnhancedWebSocketServer:
         # Extract stream ID and content
         content = message.content
         stream_id = content.get("stream_id", "")
-        text_content = content.get("content", "")
+        # Extract the raw text content if needed for future processing
+        # Currently, the server does not use the content directly
         
         # Ensure we're tracking this stream
         self._active_streams = getattr(self, "_active_streams", set())
@@ -507,7 +508,8 @@ class EnhancedWebSocketServer:
             message_dict: The message dictionary
         """
         # Get sync markers from client (timestamps, sequence IDs)
-        sync_markers = message_dict.get("content", {}).get("sync_markers", {})
+        # Extract client-provided synchronization markers if available
+        _ = message_dict.get("content", {}).get("sync_markers", {})
         
         # Determine what data needs to be sent
         # This is application-specific, but we'll send back some state for example
@@ -605,7 +607,8 @@ class EnhancedWebSocketServer:
                 # Fall back to direct send if no batching
                 payload = json.dumps(message.to_dict())
                 if len(payload) > 4096:
-                    import gzip, base64
+                    import gzip
+                    import base64
                     compressed = gzip.compress(payload.encode("utf-8"))
                     payload = json.dumps({
                         "encoding": "gzip",

--- a/agent_s3/communication/message_protocol.py
+++ b/agent_s3/communication/message_protocol.py
@@ -4,11 +4,10 @@ This module defines the message protocol used for communication between
 the Agent-S3 backend and the VS Code extension's WebView UI.
 """
 
-import json
 import uuid
 from datetime import datetime
 from enum import Enum
-from typing import Dict, Any, Optional, List, Union, Callable, Type, Set
+from typing import Dict, Any, Optional, List, Union, Callable, Set
 import logging
 import jsonschema
 from jsonschema import validate

--- a/agent_s3/communication/vscode_bridge.py
+++ b/agent_s3/communication/vscode_bridge.py
@@ -1,13 +1,11 @@
 """Simplified VS Code bridge used for unit tests."""
 from __future__ import annotations
 
-import json
 import logging
 import queue
 import threading
 import time
-from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from .message_protocol import Message, MessageBus, MessageType
 

--- a/agent_s3/complexity_analyzer.py
+++ b/agent_s3/complexity_analyzer.py
@@ -6,7 +6,7 @@ based on multiple weighted factors including feature count, impacted files,
 requirements complexity, security sensitivity, and external integrations.
 """
 
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, Optional
 import re
 import logging
 

--- a/agent_s3/deployment_manager.py
+++ b/agent_s3/deployment_manager.py
@@ -11,9 +11,8 @@ import json
 import re
 import secrets
 import string
-from pathlib import Path
-from typing import Dict, Any, List, Optional, Tuple, Union
-from urllib.parse import urlparse, quote_plus
+from typing import Dict, Any, List, Optional, Tuple
+from urllib.parse import quote_plus
 from datetime import datetime
 
 logger = logging.getLogger(__name__)
@@ -860,7 +859,7 @@ if __name__ == "__main__":
         elif config.app_type == "django":
             # For Django, we'd need to create a more complete structure,
             # so return a minimal manage.py and suggest running django-admin
-            return f"""#!/usr/bin/env python
+            return """#!/usr/bin/env python
 import os
 import sys
 from dotenv import load_dotenv

--- a/agent_s3/design_manager.py
+++ b/agent_s3/design_manager.py
@@ -10,16 +10,11 @@ This module provides functionality for:
 """
 
 import os
-import json
 import logging
-import time
-from typing import List, Dict, Any, Tuple, Optional
-from pathlib import Path
+from typing import Dict, Any, Tuple
 
 from agent_s3.tools.file_tool import FileTool
 from agent_s3.router_agent import RouterAgent
-from agent_s3.code_generator import CodeGenerator
-from agent_s3.deployment_manager import DeploymentManager
 
 logger = logging.getLogger(__name__)
 

--- a/agent_s3/enhanced_scratchpad_manager.py
+++ b/agent_s3/enhanced_scratchpad_manager.py
@@ -8,14 +8,12 @@ sections, session management, and utilities for extracting relevant debugging co
 import os
 import re
 import json
-import time
 import glob
-import shutil
 import logging
 from enum import Enum, auto
 from dataclasses import dataclass, field, asdict
 from datetime import datetime
-from typing import Optional, Dict, Any, List, Iterator, Set, Tuple, Union
+from typing import Optional, Dict, Any, List, Set, Union
 from pathlib import Path
 import hashlib
 
@@ -365,7 +363,7 @@ class EnhancedScratchpadManager:
                 
             return decrypted_bytes.decode()
         except Exception:
-            return f"[Error decrypting content]"
+            return "[Error decrypting content]"
     
     def _write_entry(self, entry: LogEntry) -> None:
         """Write a log entry to the current log file."""

--- a/agent_s3/error_handler.py
+++ b/agent_s3/error_handler.py
@@ -7,7 +7,6 @@ and recovery across all components of the agent_s3 system.
 
 import functools
 import logging
-import traceback
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union, cast
 
@@ -15,9 +14,7 @@ from agent_s3.errors import (
     AgentError, 
     ErrorCategory, 
     ErrorContext,
-    categorize_exception,
-    create_error_context,
-    log_exception
+    create_error_context
 )
 
 logger = logging.getLogger(__name__)

--- a/agent_s3/errors.py
+++ b/agent_s3/errors.py
@@ -5,15 +5,13 @@ This module defines a consistent hierarchy of exceptions, error categorization,
 and utilities for error handling across the entire agent_s3 system.
 """
 
-import enum
 import logging
-import os
 import re
 import traceback
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Optional, Pattern, Tuple, Union
+from typing import Any, Dict, Optional, Pattern, Tuple
 
 logger = logging.getLogger(__name__)
 

--- a/agent_s3/feature_group_processor.py
+++ b/agent_s3/feature_group_processor.py
@@ -5,11 +5,10 @@ This module processes pre-planning output into feature groups that can be implem
 
 import json
 import logging
-import os
 import uuid
 import traceback
 import difflib
-from typing import Dict, Any, List, Optional, Tuple, Union
+from typing import Dict, Any, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -376,7 +375,7 @@ class FeatureGroupProcessor:
                         content = self.coordinator.file_tool.read(file_path)
                         if content:
                             file_contents[file_path] = content
-                    except Exception as e:
+                    except Exception:
                         # Silently continue if file doesn't exist - it might be a new file
                         pass
             
@@ -600,7 +599,7 @@ class FeatureGroupProcessor:
         Returns:
             Updated consolidated plan
         """
-        self.coordinator.scratchpad.log("FeatureGroupProcessor", f"Updating plan with user modifications")
+        self.coordinator.scratchpad.log("FeatureGroupProcessor", "Updating plan with user modifications")
         
         try:
             # Import planner helper for modification regeneration
@@ -758,7 +757,6 @@ class FeatureGroupProcessor:
         overridden or patched in tests to verify that results are
         communicated correctly.
         """
-        results = updated_plan.get("revalidation_results", {})
         status = updated_plan.get("revalidation_status", {})
         self.coordinator.scratchpad.log(
             "FeatureGroupProcessor",


### PR DESCRIPTION
## Summary
- remove stray environment files accidentally committed
- clean unused imports in design_manager
- tidy scratchpad manager, error handler, errors module
- fix feature_group_processor logging and unused variables

## Testing
- `ruff check agent_s3/design_manager.py agent_s3/enhanced_scratchpad_manager.py agent_s3/error_handler.py agent_s3/errors.py agent_s3/feature_group_processor.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rank_bm25')*