### PR TITLE
Add context checkpoint utilities and dependency

### DIFF
--- a/agent_s3/tools/context_management/checkpoint_manager.py
+++ b/agent_s3/tools/context_management/checkpoint_manager.py
@@ -8,8 +8,7 @@ import os
 import json
 import uuid
 from datetime import datetime
-from typing import Dict, List, Any, Tuple, Optional, Set
-import difflib
+from typing import Dict, List, Any, Tuple, Optional
 import logging
 
 logger = logging.getLogger(__name__)
@@ -296,3 +295,193 @@ def create_checkpoint_version(checkpoint_id: str, data: Dict[str, Any],
         data=data,
         metadata=new_metadata
     )
+
+
+class ContextCheckpoint:
+    """Represents a saved snapshot of context information."""
+
+    def __init__(
+        self,
+        context: Dict[str, Any],
+        checkpoint_id: Optional[str] = None,
+        description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        timestamp: Optional[str] = None,
+    ) -> None:
+        self.context = context
+        self.checkpoint_id = checkpoint_id or str(uuid.uuid4())
+        self.timestamp = timestamp or datetime.now().isoformat()
+        self.description = description or "checkpoint"
+        self.metadata = metadata or {}
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the checkpoint to a dictionary."""
+        return {
+            "checkpoint_id": self.checkpoint_id,
+            "timestamp": self.timestamp,
+            "description": self.description,
+            "metadata": self.metadata,
+            "context": self.context,
+        }
+
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> "ContextCheckpoint":
+        """Create a ContextCheckpoint from a dictionary."""
+        return ContextCheckpoint(
+            context=data.get("context", {}),
+            checkpoint_id=data.get("checkpoint_id"),
+            description=data.get("description"),
+            metadata=data.get("metadata"),
+            timestamp=data.get("timestamp"),
+        )
+
+    def compress(self) -> Dict[str, Any]:
+        """Return a compressed representation using zlib+base64."""
+        import base64
+        import zlib
+
+        data_bytes = json.dumps(self.to_dict()).encode("utf-8")
+        compressed = base64.b64encode(zlib.compress(data_bytes)).decode("utf-8")
+        return {
+            "checkpoint_id": self.checkpoint_id,
+            "timestamp": self.timestamp,
+            "description": self.description,
+            "compression": "zlib+base64",
+            "data": compressed,
+        }
+
+    @staticmethod
+    def decompress(data: Dict[str, Any]) -> "ContextCheckpoint":
+        """Create a checkpoint from compressed data."""
+        import base64
+        import zlib
+
+        if data.get("compression") != "zlib+base64":
+            raise ValueError("Unsupported compression format")
+        raw = zlib.decompress(base64.b64decode(data["data"]))
+        return ContextCheckpoint.from_dict(json.loads(raw.decode("utf-8")))
+
+    def diff(self, other: "ContextCheckpoint") -> Dict[str, Any]:
+        """Compute a diff between this checkpoint and another."""
+
+        differences: Dict[str, Any] = {}
+
+        def _diff(prefix: str, left: Any, right: Any) -> None:
+            if isinstance(left, dict) and isinstance(right, dict):
+                keys = set(left.keys()) | set(right.keys())
+                for key in keys:
+                    _diff(f"{prefix}.{key}" if prefix else key, left.get(key), right.get(key))
+            else:
+                if left != right:
+                    if left is None:
+                        differences[prefix] = {"status": "added", "value": right}
+                    elif right is None:
+                        differences[prefix] = {"status": "removed", "value": left}
+                    else:
+                        differences[prefix] = {
+                            "status": "changed",
+                            "old_value": left,
+                            "new_value": right,
+                        }
+
+        _diff("", self.context, other.context)
+
+        return {
+            "checkpoint_id_1": self.checkpoint_id,
+            "checkpoint_id_2": other.checkpoint_id,
+            "differences": differences,
+        }
+
+
+class CheckpointManager:
+    """Manage ContextCheckpoint instances on disk."""
+
+    def __init__(
+        self,
+        checkpoint_dir: Optional[str] = None,
+        max_checkpoints: int = 10,
+        auto_checkpoint_interval: Optional[int] = None,
+        compression: bool = True,
+    ) -> None:
+        self.checkpoint_dir = checkpoint_dir or get_checkpoints_dir()
+        os.makedirs(self.checkpoint_dir, exist_ok=True)
+        self.max_checkpoints = max_checkpoints
+        self.auto_checkpoint_interval = auto_checkpoint_interval
+        self.compression = compression
+        self.checkpoints: Dict[str, ContextCheckpoint] = {}
+        self._last_auto_checkpoint = datetime.now()
+
+    def _checkpoint_path(self, checkpoint_id: str) -> str:
+        return os.path.join(self.checkpoint_dir, f"{checkpoint_id}.json")
+
+    def _prune_checkpoints(self) -> None:
+        existing = self.list_checkpoints()
+        while len(existing) > self.max_checkpoints:
+            oldest = existing.pop(0)
+            self.delete_checkpoint(oldest["checkpoint_id"])
+
+    def create_checkpoint(
+        self,
+        context: Dict[str, Any],
+        description: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        checkpoint = ContextCheckpoint(context, description=description, metadata=metadata)
+        with open(self._checkpoint_path(checkpoint.checkpoint_id), "w") as f:
+            json.dump(checkpoint.to_dict(), f, indent=2)
+        self.checkpoints[checkpoint.checkpoint_id] = checkpoint
+        self._prune_checkpoints()
+        return checkpoint.checkpoint_id
+
+    def get_checkpoint(self, checkpoint_id: str) -> Optional[ContextCheckpoint]:
+        if checkpoint_id in self.checkpoints:
+            return self.checkpoints[checkpoint_id]
+        path = self._checkpoint_path(checkpoint_id)
+        if not os.path.exists(path):
+            return None
+        with open(path, "r") as f:
+            data = json.load(f)
+        checkpoint = ContextCheckpoint.from_dict(data)
+        self.checkpoints[checkpoint_id] = checkpoint
+        return checkpoint
+
+    def list_checkpoints(self) -> List[Dict[str, Any]]:
+        checkpoints = []
+        for filename in os.listdir(self.checkpoint_dir):
+            if not filename.endswith(".json"):
+                continue
+            cid = filename[:-5]
+            cp = self.get_checkpoint(cid)
+            if cp:
+                checkpoints.append(cp.to_dict())
+        checkpoints.sort(key=lambda x: x.get("timestamp", ""))
+        return checkpoints
+
+    def restore_checkpoint(self, checkpoint_id: str) -> Optional[Dict[str, Any]]:
+        checkpoint = self.get_checkpoint(checkpoint_id)
+        return checkpoint.context if checkpoint else None
+
+    def delete_checkpoint(self, checkpoint_id: str) -> bool:
+        self.checkpoints.pop(checkpoint_id, None)
+        path = self._checkpoint_path(checkpoint_id)
+        if os.path.exists(path):
+            os.remove(path)
+            return True
+        return False
+
+    def check_auto_checkpoint(self, context: Dict[str, Any]) -> Optional[str]:
+        if self.auto_checkpoint_interval is None:
+            return None
+        now = datetime.now()
+        elapsed = (now - self._last_auto_checkpoint).total_seconds()
+        if elapsed >= self.auto_checkpoint_interval:
+            self._last_auto_checkpoint = now
+            return self.create_checkpoint(context)
+        return None
+
+    def diff_checkpoints(self, checkpoint_id1: str, checkpoint_id2: str) -> Optional[Dict[str, Any]]:
+        cp1 = self.get_checkpoint(checkpoint_id1)
+        cp2 = self.get_checkpoint(checkpoint_id2)
+        if not cp1 or not cp2:
+            return None
+        return cp1.diff(cp2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "sqlalchemy>=2.0.0",
     "jsonschema>=4.0.0",
     "supabase-py>=2.0.0",
+    "rank-bm25>=0.2",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ pymysql>=1.0.0
 jsonschema>=4.0.0
 cryptography>=41.0.0
 supabase-py>=2.0.0
+rank-bm25>=0.2


### PR DESCRIPTION
## Summary
- add `ContextCheckpoint` and `CheckpointManager` utilities for managing serialized context
- declare `rank-bm25` as a core dependency
- remove accidentally committed installation logs

## Testing
- `ruff check agent_s3/tools/context_management/checkpoint_manager.py`
- `mypy agent_s3/tools/context_management/checkpoint_manager.py`
- `pytest tests/test_checkpoint_manager.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rank_bm25')*