### PR TITLE
Fix lint on next set of modules

### DIFF
--- a/=0.2
+++ b/=0.2
@@ -1,0 +1,1 @@
+Requirement already satisfied: ruff in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (0.11.10)

--- a/=0.22.0
+++ b/=0.22.0
@@ -1,0 +1,6 @@
+Collecting tree-sitter
+  Downloading tree_sitter-0.24.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (9.8 kB)
+Downloading tree_sitter-0.24.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (575 kB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 575.6/575.6 kB 9.1 MB/s eta 0:00:00
+Installing collected packages: tree-sitter
+Successfully installed tree-sitter-0.24.0

--- a/=0.5.0
+++ b/=0.5.0
@@ -1,0 +1,16 @@
+Collecting tiktoken
+  Downloading tiktoken-0.9.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (6.7 kB)
+Collecting regex>=2022.1.18 (from tiktoken)
+  Downloading regex-2024.11.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (40 kB)
+Requirement already satisfied: requests>=2.26.0 in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from tiktoken) (2.32.3)
+Requirement already satisfied: charset-normalizer<4,>=2 in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from requests>=2.26.0->tiktoken) (3.4.2)
+Requirement already satisfied: idna<4,>=2.5 in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from requests>=2.26.0->tiktoken) (3.10)
+Requirement already satisfied: urllib3<3,>=1.21.1 in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from requests>=2.26.0->tiktoken) (2.4.0)
+Requirement already satisfied: certifi>=2017.4.17 in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from requests>=2.26.0->tiktoken) (2025.4.26)
+Downloading tiktoken-0.9.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.2 MB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.2/1.2 MB 17.8 MB/s eta 0:00:00
+Downloading regex-2024.11.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (792 kB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 792.7/792.7 kB 29.3 MB/s eta 0:00:00
+Installing collected packages: regex, tiktoken
+
+Successfully installed regex-2024.11.6 tiktoken-0.9.0

--- a/=0.9.1
+++ b/=0.9.1
@@ -1,0 +1,9 @@
+Collecting phply
+  Downloading phply-1.2.6-py2.py3-none-any.whl.metadata (801 bytes)
+Collecting ply (from phply)
+  Downloading ply-3.11-py2.py3-none-any.whl.metadata (844 bytes)
+Downloading phply-1.2.6-py2.py3-none-any.whl (74 kB)
+Downloading ply-3.11-py2.py3-none-any.whl (49 kB)
+Installing collected packages: ply, phply
+
+Successfully installed phply-1.2.6 ply-3.11

--- a/=1.0.0
+++ b/=1.0.0
@@ -1,0 +1,5 @@
+Collecting pymysql
+  Downloading PyMySQL-1.1.1-py3-none-any.whl.metadata (4.4 kB)
+Downloading PyMySQL-1.1.1-py3-none-any.whl (44 kB)
+Installing collected packages: pymysql
+Successfully installed pymysql-1.1.1

--- a/=1.24.0
+++ b/=1.24.0
@@ -1,0 +1,1 @@
+Requirement already satisfied: numpy in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (2.2.6)

--- a/=1.7.0
+++ b/=1.7.0
@@ -1,0 +1,8 @@
+Collecting faiss-cpu
+  Downloading faiss_cpu-1.11.0-cp311-cp311-manylinux_2_28_x86_64.whl.metadata (4.8 kB)
+Requirement already satisfied: numpy<3.0,>=1.25.0 in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from faiss-cpu) (2.2.6)
+Requirement already satisfied: packaging in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from faiss-cpu) (25.0)
+Downloading faiss_cpu-1.11.0-cp311-cp311-manylinux_2_28_x86_64.whl (31.3 MB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 31.3/31.3 MB 30.3 MB/s eta 0:00:00
+Installing collected packages: faiss-cpu
+Successfully installed faiss-cpu-1.11.0

--- a/=1.8
+++ b/=1.8
@@ -1,0 +1,3 @@
+Requirement already satisfied: mypy in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (1.15.0)
+Requirement already satisfied: typing_extensions>=4.6.0 in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from mypy) (4.13.2)
+Requirement already satisfied: mypy_extensions>=1.0.0 in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from mypy) (1.1.0)

--- a/=11.0
+++ b/=11.0
@@ -1,0 +1,1 @@
+Requirement already satisfied: websockets in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (14.2)

--- a/=2.0.0
+++ b/=2.0.0
@@ -1,0 +1,12 @@
+Collecting sqlalchemy
+  Downloading sqlalchemy-2.0.41-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (9.6 kB)
+Collecting greenlet>=1 (from sqlalchemy)
+  Downloading greenlet-3.2.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl.metadata (4.1 kB)
+Requirement already satisfied: typing-extensions>=4.6.0 in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from sqlalchemy) (4.13.2)
+Downloading sqlalchemy-2.0.41-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.3 MB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.3/3.3 MB 22.1 MB/s eta 0:00:00
+Downloading greenlet-3.2.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl (583 kB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 583.9/583.9 kB 32.2 MB/s eta 0:00:00
+Installing collected packages: greenlet, sqlalchemy
+
+Successfully installed greenlet-3.2.2 sqlalchemy-2.0.41

--- a/=2.25.0
+++ b/=2.25.0
@@ -1,0 +1,16 @@
+Collecting requests
+  Using cached requests-2.32.3-py3-none-any.whl.metadata (4.6 kB)
+Collecting charset-normalizer<4,>=2 (from requests)
+  Downloading charset_normalizer-3.4.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (35 kB)
+Requirement already satisfied: idna<4,>=2.5 in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from requests) (3.10)
+Collecting urllib3<3,>=1.21.1 (from requests)
+  Using cached urllib3-2.4.0-py3-none-any.whl.metadata (6.5 kB)
+Collecting certifi>=2017.4.17 (from requests)
+  Using cached certifi-2025.4.26-py3-none-any.whl.metadata (2.5 kB)
+Using cached requests-2.32.3-py3-none-any.whl (64 kB)
+Downloading charset_normalizer-3.4.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (147 kB)
+Using cached urllib3-2.4.0-py3-none-any.whl (128 kB)
+Using cached certifi-2025.4.26-py3-none-any.whl (159 kB)
+Installing collected packages: urllib3, charset-normalizer, certifi, requests
+
+Successfully installed certifi-2025.4.26 charset-normalizer-3.4.2 requests-2.32.3 urllib3-2.4.0

--- a/=2.9.0
+++ b/=2.9.0
@@ -1,0 +1,6 @@
+Collecting psycopg2-binary
+  Downloading psycopg2_binary-2.9.10-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (4.9 kB)
+Downloading psycopg2_binary-2.9.10-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.0 MB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.0/3.0 MB 29.2 MB/s eta 0:00:00
+Installing collected packages: psycopg2-binary
+Successfully installed psycopg2-binary-2.9.10

--- a/=4.0.0
+++ b/=4.0.0
@@ -1,0 +1,19 @@
+Collecting jsonschema
+  Downloading jsonschema-4.23.0-py3-none-any.whl.metadata (7.9 kB)
+Collecting attrs>=22.2.0 (from jsonschema)
+  Downloading attrs-25.3.0-py3-none-any.whl.metadata (10 kB)
+Collecting jsonschema-specifications>=2023.03.6 (from jsonschema)
+  Downloading jsonschema_specifications-2025.4.1-py3-none-any.whl.metadata (2.9 kB)
+Collecting referencing>=0.28.4 (from jsonschema)
+  Downloading referencing-0.36.2-py3-none-any.whl.metadata (2.8 kB)
+Collecting rpds-py>=0.7.1 (from jsonschema)
+  Downloading rpds_py-0.25.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (4.1 kB)
+Requirement already satisfied: typing-extensions>=4.4.0 in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from referencing>=0.28.4->jsonschema) (4.13.2)
+Downloading jsonschema-4.23.0-py3-none-any.whl (88 kB)
+Downloading attrs-25.3.0-py3-none-any.whl (63 kB)
+Downloading jsonschema_specifications-2025.4.1-py3-none-any.whl (18 kB)
+Downloading referencing-0.36.2-py3-none-any.whl (26 kB)
+Downloading rpds_py-0.25.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (386 kB)
+Installing collected packages: rpds-py, attrs, referencing, jsonschema-specifications, jsonschema
+
+Successfully installed attrs-25.3.0 jsonschema-4.23.0 jsonschema-specifications-2025.4.1 referencing-0.36.2 rpds-py-0.25.1

--- a/=41.0.0
+++ b/=41.0.0
@@ -1,0 +1,12 @@
+Collecting cryptography
+  Using cached cryptography-45.0.2-cp311-abi3-manylinux_2_34_x86_64.whl.metadata (5.7 kB)
+Collecting cffi>=1.14 (from cryptography)
+  Downloading cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (1.5 kB)
+Collecting pycparser (from cffi>=1.14->cryptography)
+  Using cached pycparser-2.22-py3-none-any.whl.metadata (943 bytes)
+Using cached cryptography-45.0.2-cp311-abi3-manylinux_2_34_x86_64.whl (4.5 MB)
+Downloading cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (467 kB)
+Using cached pycparser-2.22-py3-none-any.whl (117 kB)
+Installing collected packages: pycparser, cffi, cryptography
+
+Successfully installed cffi-1.17.1 cryptography-45.0.2 pycparser-2.22

--- a/=6.0
+++ b/=6.0
@@ -1,0 +1,6 @@
+Collecting pyyaml
+  Downloading PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (2.1 kB)
+Downloading PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (762 kB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 763.0/763.0 kB 13.8 MB/s eta 0:00:00
+Installing collected packages: pyyaml
+Successfully installed pyyaml-6.0.2

--- a/=8.0
+++ b/=8.0
@@ -1,0 +1,4 @@
+Requirement already satisfied: pytest in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (8.3.5)
+Requirement already satisfied: iniconfig in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from pytest) (2.1.0)
+Requirement already satisfied: packaging in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from pytest) (25.0)
+Requirement already satisfied: pluggy<2,>=1.5 in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from pytest) (1.6.0)

--- a/agent_s3/communication/enhanced_websocket_server.py
+++ b/agent_s3/communication/enhanced_websocket_server.py
@@ -13,7 +13,7 @@ import socket
 import threading
 import time
 import uuid
-from typing import Dict, Any, Optional, Set, List, Callable
+from typing import Dict, Any, Optional, Set, List
 import websockets
 
 from .message_protocol import Message, MessageType, MessageBus, MessageQueue
@@ -289,7 +289,8 @@ class EnhancedWebSocketServer:
         # Extract stream ID and content
         content = message.content
         stream_id = content.get("stream_id", "")
-        text_content = content.get("content", "")
+        # Extract the raw text content if needed for future processing
+        # Currently, the server does not use the content directly
         
         # Ensure we're tracking this stream
         self._active_streams = getattr(self, "_active_streams", set())
@@ -507,7 +508,8 @@ class EnhancedWebSocketServer:
             message_dict: The message dictionary
         """
         # Get sync markers from client (timestamps, sequence IDs)
-        sync_markers = message_dict.get("content", {}).get("sync_markers", {})
+        # Extract client-provided synchronization markers if available
+        _ = message_dict.get("content", {}).get("sync_markers", {})
         
         # Determine what data needs to be sent
         # This is application-specific, but we'll send back some state for example
@@ -605,7 +607,8 @@ class EnhancedWebSocketServer:
                 # Fall back to direct send if no batching
                 payload = json.dumps(message.to_dict())
                 if len(payload) > 4096:
-                    import gzip, base64
+                    import gzip
+                    import base64
                     compressed = gzip.compress(payload.encode("utf-8"))
                     payload = json.dumps({
                         "encoding": "gzip",

--- a/agent_s3/communication/message_protocol.py
+++ b/agent_s3/communication/message_protocol.py
@@ -4,11 +4,10 @@ This module defines the message protocol used for communication between
 the Agent-S3 backend and the VS Code extension's WebView UI.
 """
 
-import json
 import uuid
 from datetime import datetime
 from enum import Enum
-from typing import Dict, Any, Optional, List, Union, Callable, Type, Set
+from typing import Dict, Any, Optional, List, Union, Callable, Set
 import logging
 import jsonschema
 from jsonschema import validate

--- a/agent_s3/communication/vscode_bridge.py
+++ b/agent_s3/communication/vscode_bridge.py
@@ -1,13 +1,11 @@
 """Simplified VS Code bridge used for unit tests."""
 from __future__ import annotations
 
-import json
 import logging
 import queue
 import threading
 import time
-from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from .message_protocol import Message, MessageBus, MessageType
 

--- a/agent_s3/complexity_analyzer.py
+++ b/agent_s3/complexity_analyzer.py
@@ -6,7 +6,7 @@ based on multiple weighted factors including feature count, impacted files,
 requirements complexity, security sensitivity, and external integrations.
 """
 
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, Optional
 import re
 import logging
 

--- a/agent_s3/deployment_manager.py
+++ b/agent_s3/deployment_manager.py
@@ -11,9 +11,8 @@ import json
 import re
 import secrets
 import string
-from pathlib import Path
-from typing import Dict, Any, List, Optional, Tuple, Union
-from urllib.parse import urlparse, quote_plus
+from typing import Dict, Any, List, Optional, Tuple
+from urllib.parse import quote_plus
 from datetime import datetime
 
 logger = logging.getLogger(__name__)
@@ -860,7 +859,7 @@ if __name__ == "__main__":
         elif config.app_type == "django":
             # For Django, we'd need to create a more complete structure,
             # so return a minimal manage.py and suggest running django-admin
-            return f"""#!/usr/bin/env python
+            return """#!/usr/bin/env python
 import os
 import sys
 from dotenv import load_dotenv

--- a/agent_s3/design_manager.py
+++ b/agent_s3/design_manager.py
@@ -10,16 +10,11 @@ This module provides functionality for:
 """
 
 import os
-import json
 import logging
-import time
-from typing import List, Dict, Any, Tuple, Optional
-from pathlib import Path
+from typing import Dict, Any, Tuple
 
 from agent_s3.tools.file_tool import FileTool
 from agent_s3.router_agent import RouterAgent
-from agent_s3.code_generator import CodeGenerator
-from agent_s3.deployment_manager import DeploymentManager
 
 logger = logging.getLogger(__name__)
 

--- a/agent_s3/enhanced_scratchpad_manager.py
+++ b/agent_s3/enhanced_scratchpad_manager.py
@@ -8,14 +8,12 @@ sections, session management, and utilities for extracting relevant debugging co
 import os
 import re
 import json
-import time
 import glob
-import shutil
 import logging
 from enum import Enum, auto
 from dataclasses import dataclass, field, asdict
 from datetime import datetime
-from typing import Optional, Dict, Any, List, Iterator, Set, Tuple, Union
+from typing import Optional, Dict, Any, List, Set, Union
 from pathlib import Path
 import hashlib
 
@@ -365,7 +363,7 @@ class EnhancedScratchpadManager:
                 
             return decrypted_bytes.decode()
         except Exception:
-            return f"[Error decrypting content]"
+            return "[Error decrypting content]"
     
     def _write_entry(self, entry: LogEntry) -> None:
         """Write a log entry to the current log file."""

--- a/agent_s3/error_handler.py
+++ b/agent_s3/error_handler.py
@@ -7,7 +7,6 @@ and recovery across all components of the agent_s3 system.
 
 import functools
 import logging
-import traceback
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union, cast
 
@@ -15,9 +14,7 @@ from agent_s3.errors import (
     AgentError, 
     ErrorCategory, 
     ErrorContext,
-    categorize_exception,
-    create_error_context,
-    log_exception
+    create_error_context
 )
 
 logger = logging.getLogger(__name__)

--- a/agent_s3/errors.py
+++ b/agent_s3/errors.py
@@ -5,15 +5,13 @@ This module defines a consistent hierarchy of exceptions, error categorization,
 and utilities for error handling across the entire agent_s3 system.
 """
 
-import enum
 import logging
-import os
 import re
 import traceback
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Optional, Pattern, Tuple, Union
+from typing import Any, Dict, Optional, Pattern, Tuple
 
 logger = logging.getLogger(__name__)
 

--- a/agent_s3/feature_group_processor.py
+++ b/agent_s3/feature_group_processor.py
@@ -5,11 +5,10 @@ This module processes pre-planning output into feature groups that can be implem
 
 import json
 import logging
-import os
 import uuid
 import traceback
 import difflib
-from typing import Dict, Any, List, Optional, Tuple, Union
+from typing import Dict, Any, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -376,7 +375,7 @@ class FeatureGroupProcessor:
                         content = self.coordinator.file_tool.read(file_path)
                         if content:
                             file_contents[file_path] = content
-                    except Exception as e:
+                    except Exception:
                         # Silently continue if file doesn't exist - it might be a new file
                         pass
             
@@ -600,7 +599,7 @@ class FeatureGroupProcessor:
         Returns:
             Updated consolidated plan
         """
-        self.coordinator.scratchpad.log("FeatureGroupProcessor", f"Updating plan with user modifications")
+        self.coordinator.scratchpad.log("FeatureGroupProcessor", "Updating plan with user modifications")
         
         try:
             # Import planner helper for modification regeneration
@@ -758,7 +757,6 @@ class FeatureGroupProcessor:
         overridden or patched in tests to verify that results are
         communicated correctly.
         """
-        results = updated_plan.get("revalidation_results", {})
         status = updated_plan.get("revalidation_status", {})
         self.coordinator.scratchpad.log(
             "FeatureGroupProcessor",

--- a/agent_s3/file_history_analyzer.py
+++ b/agent_s3/file_history_analyzer.py
@@ -3,11 +3,10 @@
 Analyzes file modification history for context prioritization.
 """
 
-import os
 import logging
 from pathlib import Path
 from datetime import datetime, timedelta
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, List
 
 class FileHistoryAnalyzer:
     """Analyzes file modification history for context prioritization."""

--- a/agent_s3/implementation_manager.py
+++ b/agent_s3/implementation_manager.py
@@ -9,8 +9,7 @@ import json
 import os
 import logging
 import datetime
-from pathlib import Path
-from typing import Dict, List, Optional, Any, Tuple
+from typing import Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
 
@@ -175,7 +174,6 @@ class ImplementationManager:
             List of task dictionaries
         """
         tasks = []
-        current_section = None
         
         # Process each line
         for line in design_content.split('\n'):

--- a/agent_s3/json_utils.py
+++ b/agent_s3/json_utils.py
@@ -8,7 +8,7 @@ eliminating duplication in pre_planner, planner, and other components.
 import json
 import re
 import logging
-from typing import Dict, Any, Optional, List, Tuple, Union, Callable
+from typing import Dict, Any, Optional, List, Tuple, Callable
 
 logger = logging.getLogger(__name__)
 

--- a/agent_s3/llm_utils.py
+++ b/agent_s3/llm_utils.py
@@ -5,7 +5,7 @@ backoff, and fallback strategies with advanced semantic caching.
 """
 
 import time
-from typing import Any, Dict, Optional, Callable, Type, List, Union, Tuple
+from typing import Any, Dict, Optional, List
 import requests
 
 # Optional Supabase client
@@ -14,9 +14,6 @@ try:
 except Exception:  # pragma: no cover - library optional
     create_client = None
 import json
-import os
-import threading
-import numpy as np
 import logging
 
 # Import GPTCache
@@ -24,6 +21,9 @@ try:
     from gptcache import cache
 except ImportError:
     cache = None
+
+from agent_s3.cache.helpers import read_cache, write_cache
+from agent_s3.progress_tracker import progress_tracker
 
 # Type hint for ScratchpadManager to avoid circular imports
 ScratchpadManagerType = Any
@@ -41,9 +41,6 @@ FALLBACK_PROMPT_TEMPLATE = "Previous attempt failed. Please re-evaluate the requ
                           "Original request summary: {prompt_summary}"
 
 # Initialize GPTCache if available
-from agent_s3.cache.helpers import read_cache, write_cache
-from agent_s3.progress_tracker import progress_tracker
-
 if cache:
     cache.init()
 
@@ -432,7 +429,7 @@ def call_llm_with_retry(
     return {
         'success': False,
         'error': (f"LLM API call failed after {max_retries} attempts" +
-                 (f" and fallback" if fallback_strategy != 'none' else "")),
+                 (" and fallback" if fallback_strategy != 'none' else "")),
         'details': f"Last error: {last_error_details}: {last_error}"
     }
 

--- a/agent_s3/planner.py
+++ b/agent_s3/planner.py
@@ -690,7 +690,7 @@ Ensure your response strictly adheres to the JSON schema provided in the system 
                             if not isinstance(test, dict):
                                 continue
 
-                            if ("target_element" in test and not "target_element_id" in test) or not test.get("target_element_id"):
+                            if ("target_element" in test and "target_element_id" not in test) or not test.get("target_element_id"):
                                 tests_missing_element_ids += 1
 
                         if tests_missing_element_ids > 0:


### PR DESCRIPTION
## Summary
- run Ruff autofix on next ten flagged files
- drop unused imports and variables
- move GPTCache imports to top of module and clean f-string

## Testing
- `ruff check agent_s3/design_manager.py agent_s3/enhanced_scratchpad_manager.py agent_s3/error_handler.py agent_s3/errors.py agent_s3/feature_group_processor.py agent_s3/file_history_analyzer.py agent_s3/implementation_manager.py agent_s3/json_utils.py agent_s3/llm_utils.py agent_s3/planner.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rank_bm25')*