### PR TITLE
Fix Ruff issues in initial modules

### DIFF
--- a/agent_s3/planning_helper.py
+++ b/agent_s3/planning_helper.py
@@ -2,7 +2,6 @@
 from typing import Any, Dict, Optional
 
 from . import pre_planner_json_enforced
-from .feature_group_processor import FeatureGroupProcessor
 
 
 def generate_plan_via_workflow(

--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -19,7 +19,6 @@ import time  # Added for potential delays in retry
 from typing import Dict, Any, Optional, Tuple, List, Union
 
 from agent_s3.progress_tracker import progress_tracker
-from agent_s3.pre_planning_validator import PrePlanningValidator
 
 from agent_s3.pre_planning_errors import PrePlanningError
 

--- a/agent_s3/pre_planner_json_validator.py
+++ b/agent_s3/pre_planner_json_validator.py
@@ -16,11 +16,8 @@ import json
 import logging
 import re
 import time
-from typing import Dict, Any, List, Tuple, Optional, Set
+from typing import Any, Dict, List, Tuple
 from dataclasses import dataclass, field
-from datetime import datetime
-
-from agent_s3.pre_planner_json_enforced import JSONValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -619,7 +616,7 @@ class PrePlannerJsonValidator:
                                         algorithms[i] = "Custom file processing algorithm (sanitized)"
                                         was_repaired = True
                                         repairs_made += 1
-                                        logger.info(f"Sanitized dangerous command in key_algorithms")
+                                        logger.info("Sanitized dangerous command in key_algorithms")
         
         # Record repair metrics
         self.validation_metrics.record_repair(was_repaired)

--- a/agent_s3/pre_planning_validator.py
+++ b/agent_s3/pre_planning_validator.py
@@ -5,9 +5,8 @@ This module provides structured validation for feature-based pre-planning data.
 It validates structure, semantic coherence, and security aspects of pre-planning data.
 """
 
-from typing import Dict, Any, Tuple, List, Optional
+from typing import Any, Dict, List, Tuple
 import logging
-from agent_s3.pre_planning_errors import ValidationError
 
 logger = logging.getLogger(__name__)
 

--- a/agent_s3/schema_validator.py
+++ b/agent_s3/schema_validator.py
@@ -132,9 +132,6 @@ Only use information from the user request, provided instructions, and system me
 This module defines Pydantic models for validating LLM responses and provides
 utility functions for robust parsing and validation of LLM responses.
 """
-from typing import Dict, List, Any, Optional, Union, TypeVar, Type, Generic, Callable
-from pydantic import BaseModel, Field, ValidationError
-
 logger = logging.getLogger(__name__)
 
 # Type variable for generic type hints

--- a/agent_s3/signature_normalizer.py
+++ b/agent_s3/signature_normalizer.py
@@ -10,11 +10,10 @@ import os
 import re
 import ast
 import logging
-from typing import Dict, Any, List, Set, Tuple, Optional
+from typing import Any, Dict, Set
 from pathlib import Path
 
 # Import plan validator for path validation and code validation
-from agent_s3.tools.plan_validator import validate_code_syntax
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +65,6 @@ class SignatureNormalizer:
                     continue
                     
                 feature_name = feature.get("name", f"Feature {feature_idx}")
-                feature_log_prefix = f"Feature '{feature_name}' in group '{group_name}'"
                 
                 # Process system_design.code_elements
                 system_design = feature.get("system_design", {})
@@ -327,13 +325,13 @@ class SignatureNormalizer:
         
         elif language in ["javascript", "typescript"]:
             if element_type == "function":
-                return f"function {name}() {'{'}";
+                return f"function {name}() {'{'}"
             elif element_type == "class":
-                return f"class {name} {'{'}";
+                return f"class {name} {'{'}"
             elif element_type == "interface" and language == "typescript":
-                return f"interface {name} {'{'}";
+                return f"interface {name} {'{'}"
             else:
-                return f"function {name}() {'{'}";
+                return f"function {name}() {'{'}"
         
         # Default fallback
         return f"{element_type} {name}"

--- a/agent_s3/task_resumer.py
+++ b/agent_s3/task_resumer.py
@@ -3,12 +3,10 @@
 Handles the resumption of interrupted tasks.
 """
 
-import os
 import logging
 import traceback
-from pathlib import Path
 from datetime import datetime
-from typing import Dict, Any, Optional, Tuple, List, Union
+from typing import Optional, Tuple
 
 class TaskResumer:
     """Handles detection and resumption of interrupted tasks."""
@@ -195,7 +193,7 @@ class TaskResumer:
         # If we already have a plan, we can jump to prompt approval
         if plan:
             print("Found existing plan, resuming from prompt approval phase.")
-            self._update_development_status("resumed", f"Resumed task from planning phase", 
+            self._update_development_status("resumed", "Resumed task from planning phase",
                                           phase="planning", request=request_text)
             
             # Pass the existing plan to prompt approval
@@ -246,7 +244,7 @@ class TaskResumer:
         plan = getattr(task_state, 'plan', {})
         generated_changes = getattr(task_state, 'generated_changes', [])
         current_iteration = getattr(task_state, 'current_iteration', 0)
-        code_context = getattr(task_state, 'code_context', {})
+        _ = getattr(task_state, 'code_context', {})
         
         request_text = "Original request not available"
         if plan and isinstance(plan, dict):
@@ -284,7 +282,7 @@ class TaskResumer:
         # Extract state data
         changes = getattr(task_state, 'changes', [])
         iteration = getattr(task_state, 'iteration', 0)
-        test_results = getattr(task_state, 'test_results', {})
+        _ = getattr(task_state, 'test_results', {})
         is_applied = getattr(task_state, 'is_applied', False)
         errors = getattr(task_state, 'errors', [])
         
@@ -372,7 +370,6 @@ class TaskResumer:
         
         # Get sub-state for granular resumption
         sub_state = getattr(task_state, 'sub_state', 'PREPARING')
-        commit_sha = getattr(task_state, 'commit_sha', None)
         base_branch = getattr(task_state, 'base_branch', 'main')
         draft = getattr(task_state, 'draft', False)
         

--- a/agent_s3/tech_stack_detector.py
+++ b/agent_s3/tech_stack_detector.py
@@ -3,10 +3,9 @@
 Responsible for detecting the technologies, frameworks, and libraries in the workspace.
 """
 
-import os
 import logging
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Any, Dict
 
 class TechStackDetector:
     """Detects and analyzes the tech stack used in a project workspace."""

--- a/agent_s3/terminal_executor.py
+++ b/agent_s3/terminal_executor.py
@@ -3,7 +3,7 @@ import threading
 import os
 import re
 import shlex
-from typing import Tuple, List, Optional, Dict, Set, Any, Callable
+from typing import Callable, Dict, List, Optional, Tuple
 
 class TerminalExecutor:
     """Executes shell commands in a sandbox with denylist and timeout enforcement."""
@@ -242,8 +242,6 @@ class TerminalExecutor:
         Returns:
             Exit code of the process
         """
-        import time
-        
         # Validate output_callback is callable if provided
         if output_callback is not None and not callable(output_callback):
             if self.logger:

--- a/agent_s3/test_generator.py
+++ b/agent_s3/test_generator.py
@@ -9,11 +9,8 @@ proceeding to implementation planning.
 import json
 import logging
 import re
-from typing import Dict, Any, List, Optional, Tuple
-from datetime import datetime
-import uuid
+from typing import Any, Dict, Optional
 import traceback
-from collections import defaultdict
 
 from .pre_planner_json_enforced import get_openrouter_json_params
 


### PR DESCRIPTION
## Summary
- address Ruff lint errors in core modules
- remove unused imports
- clean up unused variables
- fix stray semicolons and logging calls

## Testing
- `ruff check agent_s3/planning_helper.py agent_s3/pre_planner_json_enforced.py agent_s3/pre_planner_json_validator.py agent_s3/pre_planning_validator.py agent_s3/schema_validator.py agent_s3/signature_normalizer.py agent_s3/task_resumer.py agent_s3/tech_stack_detector.py agent_s3/terminal_executor.py agent_s3/test_generator.py`
- `pytest -q` *(fails: AttributeError: 'tree_sitter.Parser' object has no attribute 'set_language')*