### PR TITLE
Fix lint and typing issues in ast tools

### DIFF
--- a/agent_s3/ast_tools/parser.py
+++ b/agent_s3/ast_tools/parser.py
@@ -1,7 +1,9 @@
 """
 AST and CST parser wrappers for Python and JavaScript.
 """
-try:
+from typing import Any
+
+try:  # pragma: no cover - optional dependency
     import libcst
 except Exception:  # pragma: no cover - optional for minimal tests
     libcst = None
@@ -19,8 +21,10 @@ PY_PARSER.set_language(PY_LANGUAGE)
 JS_PARSER = Parser()
 JS_PARSER.set_language(JS_LANGUAGE)
 
-def parse_python(code: str):
+def parse_python(code: str) -> Any:
     """Parse Python code to a concrete syntax tree (CST) using LibCST."""
+    if libcst is None:
+        raise ImportError("libcst is required for parse_python")
     return libcst.parse_module(code)
 
 def parse_js(code: str):

--- a/agent_s3/ast_tools/python_units.py
+++ b/agent_s3/ast_tools/python_units.py
@@ -1,6 +1,8 @@
 """
 Extract logical units (functions, classes) from Python code using LibCST.
 """
+from typing import List, Tuple
+
 try:
     import libcst
 except Exception:  # pragma: no cover
@@ -8,15 +10,27 @@ except Exception:  # pragma: no cover
 import textwrap
 from .parser import parse_python
 
-class UnitCollector(libcst.CSTVisitor):
-    def __init__(self):
-        self.units = []
-    def visit_FunctionDef(self, node):
-        self.units.append(("function", node.name.value, textwrap.dedent(node.code)))
-    def visit_ClassDef(self, node):
-        self.units.append(("class", node.name.value, textwrap.dedent(node.code)))
+if libcst is not None:
+    class UnitCollector(libcst.CSTVisitor):
+        """Collect top-level function and class definitions."""
 
-def extract_units(code: str):
+        def __init__(self) -> None:
+            self.units: List[Tuple[str, str, str]] = []
+
+        def visit_FunctionDef(self, node: libcst.FunctionDef) -> None:  # type: ignore[name-defined]
+            self.units.append(("function", node.name.value, textwrap.dedent(node.code)))
+
+        def visit_ClassDef(self, node: libcst.ClassDef) -> None:  # type: ignore[name-defined]
+            self.units.append(("class", node.name.value, textwrap.dedent(node.code)))
+else:  # pragma: no cover - fallback when libcst is unavailable
+    class UnitCollector:  # type: ignore
+        """Fallback collector used when LibCST is not installed."""
+
+        def __init__(self) -> None:
+            self.units: List[Tuple[str, str, str]] = []
+
+def extract_units(code: str) -> List[Tuple[str, str, str]]:
+    """Return top-level classes and functions within the provided code."""
     if libcst is None:
         return []
     mod = parse_python(code)

--- a/agent_s3/ast_tools/summariser.py
+++ b/agent_s3/ast_tools/summariser.py
@@ -2,6 +2,8 @@
 LLM-based summarization for code units and file-level merging.
 """
 
+from typing import Any, Dict, List
+
 from agent_s3.tools.summarization.prompt_factory import SummarizationPromptFactory
 from agent_s3.tools.summarization.summary_validator import SummaryValidator
 from agent_s3.tools.summarization.validation_config import SummaryValidationConfig
@@ -10,7 +12,7 @@ from agent_s3.tools.summarization.refinement_manager import SummaryRefinementMan
 prompt_factory = SummarizationPromptFactory()
 validator = SummaryValidator(SummaryValidationConfig())
 
-def summarise_unit(code_unit, router_agent, config: dict = None) -> str:
+def summarise_unit(code_unit: Dict[str, Any], router_agent: Any, config: Dict[str, Any] | None = None) -> str:
     """
     Summarize a code unit with validation and refinement.
     """
@@ -33,7 +35,6 @@ def summarise_unit(code_unit, router_agent, config: dict = None) -> str:
         system_prompt=system_prompt,
         user_prompt=user_prompt
     )
-    validator = SummaryValidator()
     validation_result = validator.validate(code_text, summary, language)
     if not validation_result["passed"]:
         refinement_manager = SummaryRefinementManager(router_agent)
@@ -46,7 +47,7 @@ def summarise_unit(code_unit, router_agent, config: dict = None) -> str:
         summary = refinement_result["summary"]
     return summary
 
-def merge_summaries(summaries: list, language: str, router_agent) -> str:
+def merge_summaries(summaries: List[str], language: str, router_agent: Any) -> str:
     """
     Merge multiple summaries with validation.
     """


### PR DESCRIPTION
## Summary
- guard LibCST usage in python units collector
- enforce LibCST requirement in parser
- clean up summariser types and validator usage

## Testing
- `ruff check agent_s3/ast_tools`
- `mypy agent_s3/ast_tools`
- `python -m py_compile agent_s3/ast_tools/*.py`
- `pytest` *(fails: AttributeError: 'tree_sitter.Parser'...)*