### PR TITLE
Fix trailing newline lint issues

### DIFF
--- a/agent_s3/coordinator.py
+++ b/agent_s3/coordinator.py
@@ -1018,4 +1018,3 @@ class Coordinator:
     def _finalize_task(self, changes: Dict[str, str]) -> None:
         """Finalize the task after successful validation."""
         self.scratchpad.log("Coordinator", "Task completed successfully")
-

--- a/agent_s3/database_manager.py
+++ b/agent_s3/database_manager.py
@@ -49,4 +49,3 @@ class DatabaseManager:
         except Exception as e:  # Catch unexpected errors
             self._log(f"Query execution failed: {e}")
             return {"success": False, "error": str(e)}
-


### PR DESCRIPTION
## Summary
- remove extra newline at the end of `coordinator.py`
- remove extra newline at the end of `database_manager.py`

## Testing
- `python -m py_compile agent_s3/complexity_analyzer.py agent_s3/config.py agent_s3/coordinator.py agent_s3/database_manager.py agent_s3/debugging_manager.py`
- `pytest -q` *(fails: ImportError circular import)*