### PR TITLE
Fix lint and robustness issues

### DIFF
--- a/agent_s3/feature_group_processor.py
+++ b/agent_s3/feature_group_processor.py
@@ -153,10 +153,12 @@ class FeatureGroupProcessor:
                         "FeatureGroupProcessor",
                         f"Running Test Critic for {group_name}...",
                     )
-                    test_critic_results = self.test_critic.critique_tests(
-                        tests,
-                        feature_group.get("risk_assessment", {}),
-                    )
+                    test_critic_results = None
+                    if self.test_critic:
+                        test_critic_results = self.test_critic.critique_tests(
+                            tests,
+                            feature_group.get("risk_assessment", {}),
+                        )
                     
                     # STEP 4: Implementation Planning
                     self.coordinator.scratchpad.log(

--- a/agent_s3/json_utils.py
+++ b/agent_s3/json_utils.py
@@ -344,5 +344,8 @@ def get_openrouter_json_params() -> Dict[str, Any]:
 try:
     from agent_s3.planner_json_enforced import validate_json_schema
 except ImportError:
-    def validate_json_schema(data):
-        raise ImportError("validate_json_schema could not be imported from planner_json_enforced")
+    def validate_json_schema(data: Dict[str, Any]) -> None:
+        """Fallback stub when planner_json_enforced.validate_json_schema is unavailable."""
+        raise ImportError(
+            "validate_json_schema could not be imported from planner_json_enforced"
+        )


### PR DESCRIPTION
## Summary
- prevent crash if test critic is unavailable
- add generic logging helper in `ImplementationManager`
- clean up fallback schema validation helper

## Testing
- `ruff check agent_s3/feature_group_processor.py agent_s3/file_history_analyzer.py agent_s3/implementation_manager.py agent_s3/json_utils.py`
- `mypy agent_s3/feature_group_processor.py agent_s3/file_history_analyzer.py agent_s3/implementation_manager.py agent_s3/json_utils.py`
- `python -m py_compile agent_s3/feature_group_processor.py agent_s3/file_history_analyzer.py agent_s3/implementation_manager.py agent_s3/json_utils.py`
- `pytest -q` *(fails: ImportError and tree_sitter issues)*