### PR TITLE
Fix lint errors in tool and workspace init

### DIFF
--- a/agent_s3/tool_definitions.py
+++ b/agent_s3/tool_definitions.py
@@ -7,7 +7,6 @@ Implements secure tool registration, validation, and resource management.
 from typing import Dict, Any, Optional, List
 import os
 import logging
-import re
 import traceback
 
 from agent_s3.tools.file_tool import FileTool

--- a/agent_s3/workspace_initializer.py
+++ b/agent_s3/workspace_initializer.py
@@ -3,10 +3,9 @@
 Responsible for initializing, validating, and managing workspace files.
 """
 
-import os
 import logging
 from pathlib import Path
-from typing import Tuple, Dict, Any, Optional
+from typing import Tuple
 
 class WorkspaceInitializer:
     """Handles workspace initialization, validation, and essential file management."""


### PR DESCRIPTION
## Summary
- remove unused imports in `tool_definitions`
- clean imports in `workspace_initializer`

## Testing
- `ruff check agent_s3/*.py`
- `mypy --ignore-missing-imports agent_s3/*.py`
- `pytest -q` *(fails: ImportError: cannot import name 'Coordinator')*