### PR TITLE
Fix lint issues in tool modules

### DIFF
--- a/agent_s3/tools/coherence_validator.py
+++ b/agent_s3/tools/coherence_validator.py
@@ -10,8 +10,7 @@ patterns across the entire codebase.
 import json
 import logging
 import re
-from typing import Dict, Any, List, Set, Tuple, Optional
-from collections import defaultdict
+from typing import Dict, Any, List
 
 logger = logging.getLogger(__name__)
 
@@ -285,7 +284,7 @@ def check_error_handling_consistency(implementation_plan: Dict[str, Any]) -> Lis
             issues.append({
                 "issue_type": "inconsistent_error_handling",
                 "severity": "medium",
-                "description": f"Inconsistent error handling approaches detected. " +
+                "description": "Inconsistent error handling approaches detected. " +
                               f"Dominant approach is {dominant_approach}, but found {len(inconsistent_functions)} exceptions.",
                 "dominant_approach": dominant_approach,
                 "error_consistency_score": error_consistency_score,
@@ -396,7 +395,7 @@ def check_api_design_consistency(implementation_plan: Dict[str, Any]) -> List[Di
             issues.append({
                 "issue_type": "inconsistent_api_design",
                 "severity": "medium",
-                "description": f"Inconsistent API design patterns detected. " +
+                "description": "Inconsistent API design patterns detected. " +
                               f"Dominant pattern is {dominant_pattern}, but found {len(inconsistent_functions)} exceptions.",
                 "dominant_pattern": dominant_pattern,
                 "api_consistency_score": api_consistency_score,
@@ -525,7 +524,7 @@ def check_data_flow_consistency(implementation_plan: Dict[str, Any]) -> List[Dic
             issues.append({
                 "issue_type": "inconsistent_data_flow",
                 "severity": "medium",
-                "description": f"Inconsistent data flow patterns detected. " +
+                "description": "Inconsistent data flow patterns detected. " +
                               f"Dominant pattern is {dominant_flow}, but found {len(inconsistent_functions)} exceptions.",
                 "dominant_flow": dominant_flow,
                 "flow_consistency_score": flow_consistency_score,

--- a/agent_s3/tools/dependency_impact_analyzer.py
+++ b/agent_s3/tools/dependency_impact_analyzer.py
@@ -8,7 +8,7 @@ are affected by changes to a particular file based on dependency relationships.
 import os
 import logging
 from collections import defaultdict, deque
-from typing import Dict, List, Set, Optional, Tuple, Any, Union
+from typing import Dict, List, Set, Any
 
 logger = logging.getLogger(__name__)
 

--- a/agent_s3/tools/embedding_client.py
+++ b/agent_s3/tools/embedding_client.py
@@ -1,4 +1,3 @@
-import os
 import hashlib
 import faiss
 import json
@@ -9,7 +8,7 @@ import time  # Adding missing import for time functions
 import gzip  # Adding import for gzip compression
 import textwrap  # Adding import for text formatting
 from pathlib import Path
-from typing import List, Dict, Any, Optional, Tuple
+from typing import List, Dict, Any, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/agent_s3/tools/env_tool.py
+++ b/agent_s3/tools/env_tool.py
@@ -3,7 +3,6 @@ EnvTool: Environment activation and package management utilities.
 Follows security and performance best practices (see Copilot instructions).
 """
 import os
-import subprocess
 from typing import Dict, Optional
 
 class EnvTool:

--- a/agent_s3/tools/error_context_manager.py
+++ b/agent_s3/tools/error_context_manager.py
@@ -1,7 +1,6 @@
 import os
 import re
 import time
-import json
 import logging
 import shlex
 
@@ -781,9 +780,6 @@ class ErrorContextManager:
         
         # If we have an error location, prioritize it
         if error_info.get("file_paths") and error_info.get("line_numbers"):
-            primary_file = error_info["file_paths"][0]
-            primary_line = error_info["line_numbers"][0]
-            
             # Allocate more tokens to error location if it exists
             budgets["error_location"] = int(max_token_count * 0.3)
         else:

--- a/agent_s3/tools/error_pattern_learner.py
+++ b/agent_s3/tools/error_pattern_learner.py
@@ -40,11 +40,7 @@ class ErrorPatternLearner:
 
     def _save(self) -> None:
         os.makedirs(os.path.dirname(PATTERN_DB_PATH), exist_ok=True)
-        data = {
-            "category_counts": self.category_counts,
-            "word_category_counts": self.word_category_counts,
-        }
-        # Convert Counters to regular dicts for JSON serialization
+        # Prepare data for JSON serialization
         serializable = {
             "category_counts": dict(self.category_counts),
             "word_category_counts": {

--- a/agent_s3/tools/feature_flags.py
+++ b/agent_s3/tools/feature_flags.py
@@ -12,7 +12,6 @@ import os
 from pathlib import Path
 from typing import Dict, Any, List, Optional, Union, Set
 import threading
-import time
 
 logger = logging.getLogger(__name__)
 

--- a/agent_s3/tools/file_change_tracker.py
+++ b/agent_s3/tools/file_change_tracker.py
@@ -11,8 +11,7 @@ import time
 import json
 import logging
 import hashlib
-from pathlib import Path
-from typing import Dict, List, Set, Optional, Tuple, Any, Union
+from typing import Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- clean up unused imports across tool modules
- correct description f-strings in coherence validator
- remove unused locals in error context manager and error pattern learner

## Testing
- `ruff check`
- `mypy`
- `python -m py_compile agent_s3/tools/coherence_validator.py agent_s3/tools/database_tool.py agent_s3/tools/dependency_analyzer.py agent_s3/tools/dependency_impact_analyzer.py agent_s3/tools/embedding_client.py agent_s3/tools/env_tool.py agent_s3/tools/error_context_manager.py agent_s3/tools/error_pattern_learner.py agent_s3/tools/feature_flags.py agent_s3/tools/file_change_tracker.py`
