### PR TITLE
Fix lint issues in tools

### DIFF
--- a/agent_s3/tools/bash_tool.py
+++ b/agent_s3/tools/bash_tool.py
@@ -8,11 +8,9 @@ import subprocess
 import tempfile
 import time
 import shutil
-import json
 import uuid
 import platform
 import shlex
-from pathlib import Path
 from typing import Tuple, Optional, Dict, Any, List
 
 

--- a/agent_s3/tools/canonical_validator.py
+++ b/agent_s3/tools/canonical_validator.py
@@ -8,7 +8,7 @@ prevent duplication of functionality and promotes consistent implementation patt
 
 import json
 import logging
-from typing import Dict, Any, List, Set, Tuple, Optional
+from typing import Dict, Any, List, Set, Tuple
 from collections import defaultdict
 
 logger = logging.getLogger(__name__)

--- a/agent_s3/tools/code_analysis_tool.py
+++ b/agent_s3/tools/code_analysis_tool.py
@@ -4,9 +4,6 @@ This module provides embedding-based code search capabilities as specified in in
 """
 
 import os
-import subprocess
-import tempfile
-import json
 import re
 import time
 import logging
@@ -14,7 +11,7 @@ import traceback
 import hashlib
 import importlib.util
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Optional
 import numpy as np
 try:
     import tomllib as toml
@@ -615,7 +612,6 @@ class CodeAnalysisTool:
         Returns:
             Similarity score (0-1) or None if calculation fails
         """
-        import numpy as np
         
         try:
             # Convert to numpy arrays
@@ -668,7 +664,6 @@ class CodeAnalysisTool:
         Returns:
             Current timestamp
         """
-        import time
         return int(time.time())
     
     def _prune_cache_if_needed(self):


### PR DESCRIPTION
## Summary
- resolve unused imports in BashTool
- clean up imports in canonical_validator
- remove unnecessary imports in CodeAnalysisTool

## Testing
- `ruff check agent_s3/tools/__init__.py agent_s3/tools/ast_tool.py agent_s3/tools/bash_tool.py agent_s3/tools/canonical_validator.py agent_s3/tools/code_analysis_tool.py`
- `mypy --follow-imports=skip agent_s3/tools/__init__.py agent_s3/tools/ast_tool.py agent_s3/tools/bash_tool.py agent_s3/tools/canonical_validator.py agent_s3/tools/code_analysis_tool.py`
- `python -m py_compile agent_s3/tools/__init__.py agent_s3/tools/ast_tool.py agent_s3/tools/bash_tool.py agent_s3/tools/canonical_validator.py agent_s3/tools/code_analysis_tool.py`