### PR TITLE
Fix ruff warnings in tests

### DIFF
--- a/agent_s3/tests/integration_test_complexity.py
+++ b/agent_s3/tests/integration_test_complexity.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Integration test for the ComplexityAnalyzer module."""
 
-import json
 import sys
 from agent_s3.complexity_analyzer import ComplexityAnalyzer
 

--- a/agent_s3/tests/test_architecture_validation.py
+++ b/agent_s3/tests/test_architecture_validation.py
@@ -2,9 +2,7 @@
 Test cases for the architecture review validation system.
 """
 
-import json
 import unittest
-from unittest.mock import patch, MagicMock
 
 from agent_s3.tools.phase_validator import validate_security_concerns
 from agent_s3.test_spec_validator import (

--- a/agent_s3/tests/test_complex_validator.py
+++ b/agent_s3/tests/test_complex_validator.py
@@ -2,7 +2,7 @@
 """Test the PrePlanningValidator with more complex and error-prone data."""
 
 import unittest
-from agent_s3.pre_planning_validator import PrePlanningValidator, ValidationError
+from agent_s3.pre_planning_validator import PrePlanningValidator
 
 class TestComplexValidation(unittest.TestCase):
     """Tests for complex validation scenarios."""

--- a/agent_s3/tests/test_pre_planning_validator.py
+++ b/agent_s3/tests/test_pre_planning_validator.py
@@ -2,7 +2,7 @@
 """Test for the PrePlanningValidator class."""
 
 import unittest
-from agent_s3.pre_planning_validator import PrePlanningValidator, ValidationError
+from agent_s3.pre_planning_validator import PrePlanningValidator
 
 class TestPrePlanningValidator(unittest.TestCase):
     """Tests for the PrePlanningValidator class."""


### PR DESCRIPTION
## Summary
- run `ruff --fix` on the test suite to remove unused imports

## Testing
- `ruff check agent_s3`
- `pytest -q` *(fails: ImportError from circular import)*