### PR TITLE
Fix workflow imports and parser

### DIFF
--- a/agent_s3/ast_tools/parser.py
+++ b/agent_s3/ast_tools/parser.py
@@ -17,9 +17,16 @@ JS_LANGUAGE = Language(tree_sitter_javascript.language())
 PY_LANGUAGE = Language(tree_sitter_python.language())
 
 PY_PARSER = Parser()
-PY_PARSER.set_language(PY_LANGUAGE)
+try:  # Support tree-sitter >=0.22 where 'language' is a property
+    PY_PARSER.language = PY_LANGUAGE
+except AttributeError:  # pragma: no cover - legacy API
+    PY_PARSER.set_language(PY_LANGUAGE)
+
 JS_PARSER = Parser()
-JS_PARSER.set_language(JS_LANGUAGE)
+try:
+    JS_PARSER.language = JS_LANGUAGE
+except AttributeError:  # pragma: no cover - legacy API
+    JS_PARSER.set_language(JS_LANGUAGE)
 
 def parse_python(code: str) -> Any:
     """Parse Python code to a concrete syntax tree (CST) using LibCST."""

--- a/agent_s3/workflows/implementation_workflow.py
+++ b/agent_s3/workflows/implementation_workflow.py
@@ -1,8 +1,10 @@
 """Workflow helpers for implementation and debugging phases."""
 
 from __future__ import annotations
-from typing import Any, Dict, Tuple, List
-from agent_s3.coordinator import Coordinator
+from typing import Any, Dict, Tuple, List, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from agent_s3.coordinator import Coordinator
 
 
 class ImplementationWorkflow:

--- a/agent_s3/workflows/planning_workflow.py
+++ b/agent_s3/workflows/planning_workflow.py
@@ -1,8 +1,10 @@
 """Workflow helpers for task planning phases."""
 
 from __future__ import annotations
-from typing import Any, Dict, List
-from agent_s3.coordinator import Coordinator
+from typing import Any, Dict, List, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from agent_s3.coordinator import Coordinator
 
 
 class PlanningWorkflow:


### PR DESCRIPTION
## Summary
- avoid circular imports by using `TYPE_CHECKING` for Coordinator references
- support new tree-sitter API when setting parser languages

## Testing
- `pytest -q` *(fails: ProxyError during download)*