### PR TITLE
Implement design handoff to code workflow

### DIFF
--- a/agent_s3/design_manager.py
+++ b/agent_s3/design_manager.py
@@ -204,10 +204,11 @@ class DesignManager:
         
         impl_choice = impl_response in ["yes", "y", "true", "1"]
         deploy_choice = False
-        
+
         if impl_choice:
-            # User wants to implement; in this simplified version just acknowledge the choice
             print("Implementation phase selected.")
+            if self.coordinator and hasattr(self.coordinator, "start_pre_planning_from_design"):
+                self.coordinator.start_pre_planning_from_design("design.txt")
         else:
             # If user doesn't want implementation, ask about deployment
             deploy_message = (


### PR DESCRIPTION
## Summary
- start pre-planning automatically from `design.txt`
- call `start_pre_planning_from_design` when user accepts implementation
- add coordinator helpers for implementation management
- update design workflow loop logic

## Testing
- `pytest tests/test_design_to_implementation.py tests/test_coordinator_implementation_methods.py tests/test_coordinator_facade_methods.py -q`