### PR TITLE
Default vscode websocket connections to wss

### DIFF
--- a/docs/streaming_ui_implementation.md
+++ b/docs/streaming_ui_implementation.md
@@ -72,7 +72,7 @@ This document describes the implementation of a real-time streaming UI for Agent
 1. **Connection File**
    - Connection information stored in `.agent_s3_ws_connection.json`
    - Contains authentication token for secure connection
-   - Includes a `protocol` field (`ws` or `wss`) to indicate whether TLS should be used
+   - Includes a `protocol` field (defaults to `wss`) to indicate whether TLS should be used
    - Created during VS Code Bridge initialization
    - Removed automatically when the backend exits
    - File permissions set to `0600` on POSIX systems; Windows uses default ACLs

--- a/tests/node_servers/simple-test-server.js
+++ b/tests/node_servers/simple-test-server.js
@@ -18,7 +18,7 @@ const createConnectionFile = () => {
     host: 'localhost',
     port: PORT,
     auth_token: AUTH_TOKEN,
-    protocol: 'ws'
+    protocol: 'wss'
   };
   
   const filePath = path.join(process.cwd(), '.agent_s3_ws_connection.json');

--- a/tests/node_servers/test-websocket-server.js
+++ b/tests/node_servers/test-websocket-server.js
@@ -19,7 +19,7 @@ const createConnectionFile = () => {
     host: 'localhost',
     port: PORT,
     auth_token: AUTH_TOKEN,
-    protocol: 'ws'
+    protocol: 'wss'
   };
   
   const filePath = path.join(process.cwd(), '.agent_s3_ws_connection.json');

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -38,8 +38,9 @@ AGENT_S3_ENCRYPTION_KEY="$(python -c 'from cryptography.fernet import Fernet; pr
 
 ### Configuration
 
-The extension provides a `agent-s3.websocketProtocol` setting to override the
-protocol specified in the connection file. Set it to `wss` to force TLS.
+The extension uses TLS (`wss`) for WebSocket connections by default. You may
+override this by setting `agent-s3.websocketProtocol` to `ws` if TLS must be
+disabled (not recommended).
 
 ## Usage
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -51,8 +51,8 @@
         "agent-s3.websocketProtocol": {
           "type": "string",
           "enum": ["ws", "wss"],
-          "default": "ws",
-          "description": "Protocol to use for WebSocket connections when not specified in the connection file."
+          "default": "wss",
+          "description": "Protocol to use for WebSocket connections when not specified in the connection file. Defaults to secure 'wss'. Set to 'ws' to disable TLS."
         }
       }
     }

--- a/vscode/websocket-client.ts
+++ b/vscode/websocket-client.ts
@@ -129,7 +129,7 @@ export class WebSocketClient implements vscode.Disposable {
         .getConfiguration('agent-s3')
         .get<string>('websocketProtocol');
       const protocol =
-        this.options.protocol || (configProtocol as 'ws' | 'wss' | undefined) || fileProtocol || 'ws';
+        this.options.protocol || (configProtocol as 'ws' | 'wss' | undefined) || fileProtocol || 'wss';
 
       // Create the WebSocket connection
       const url = `${protocol}://${host}:${port}`;


### PR DESCRIPTION
## Summary
- default `WebSocketClient` protocol to `wss`
- document that TLS is used unless `agent-s3.websocketProtocol` is set to `ws`
- change extension configuration default to `wss`
- update mock connection files to use `wss`
- clarify default protocol in streaming UI docs

## Testing
- `npm --prefix vscode run compile` *(fails: Cannot find namespace 'vscode')*
- `pytest -k vscode_integration -q` *(fails: ValueError: a coroutine was expected)*