### PR TITLE
Enforce encrypted token storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
   - **GitHub App:** `GITHUB_APP_ID`, `GITHUB_PRIVATE_KEY`
   - `GITHUB_ORG` (optional membership filter)
   - `OPENROUTER_KEY` (or other LLM keys such as `OPENAI_KEY`)
-  - **Token Encryption:** `AGENT_S3_ENCRYPTION_KEY` (required for GitHub token storage)
+  - **Token Encryption:** `AGENT_S3_ENCRYPTION_KEY` (required for GitHub token storage; the CLI fails to save tokens when unset)
   - `DENYLIST_COMMANDS`, `COMMAND_TIMEOUT`, `CLI_COMMAND_WARNINGS` in config
   - `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` for Supabase integration
     (the service role key is only used by the Supabase function after

--- a/tests/test_auth_token_encryption.py
+++ b/tests/test_auth_token_encryption.py
@@ -1,4 +1,5 @@
 from cryptography.fernet import Fernet
+import pytest
 
 from agent_s3.auth import save_token, load_token, TOKEN_ENCRYPTION_KEY_ENV
 
@@ -13,6 +14,17 @@ def test_load_token_encrypted(tmp_path, monkeypatch):
 
     loaded = load_token()
     assert loaded == token_data
+
+
+def test_save_token_requires_key(tmp_path, monkeypatch):
+    token_data = {"access_token": "abc123"}
+    token_path = tmp_path / "token.json"
+    monkeypatch.setattr("agent_s3.auth.TOKEN_FILE", str(token_path))
+    monkeypatch.delenv(TOKEN_ENCRYPTION_KEY_ENV, raising=False)
+
+    with pytest.raises(RuntimeError):
+        save_token(token_data)
+    assert not token_path.exists()
 
 
 def test_load_token_missing_key(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- block plaintext token storage when `AGENT_S3_ENCRYPTION_KEY` is unset
- test error handling when saving tokens without encryption key
- document encryption key requirement

## Testing
- `ruff check agent_s3/auth.py tests/test_auth_token_encryption.py`
- `mypy agent_s3/auth.py tests/test_auth_token_encryption.py`
- `pytest tests/test_auth_token_encryption.py -q`