### PR TITLE
Improve context handling in pre-planner

### DIFF
--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -1036,11 +1036,11 @@ def call_pre_planner_with_enforced_json(
             # Compose the prompt for the LLM
             prompt = {
                 "system": system_prompt,
-                "user": user_prompt
+                "user": user_prompt,
             }
-            # Merge context if provided
+            # Attach context under dedicated key
             if context and isinstance(context, dict):
-                prompt = {**prompt, **context}
+                prompt["context"] = context
 
             # Call the router agent (assumed to have a .run() method)
             response = router_agent.run(prompt, **openrouter_params)


### PR DESCRIPTION
## Summary
- update `call_pre_planner_with_enforced_json` to store extra context under a `context` key
- add `RouterAgent.run` helper to merge context into user prompt before delegating to `call_llm_by_role`

## Testing
- `pytest -q` *(fails: 59 failed, 116 passed, 1 skipped, 14 warnings, 39 errors)*