### PR TITLE
Integrate router_agent in SummaryRefiner

### DIFF
--- a/agent_s3/tools/summarization/summary_refiner.py
+++ b/agent_s3/tools/summarization/summary_refiner.py
@@ -4,26 +4,27 @@ SummaryRefiner: Refines summaries that fail validation, using feedback from vali
 import time
 
 class SummaryRefiner:
-    def __init__(self, validator, prompt_factory, config):
+    def __init__(self, validator, prompt_factory, config, router_agent):
         self.validator = validator
         self.prompt_factory = prompt_factory
         self.config = config
+        self.router_agent = router_agent
 
     def refine(self, source, summary, language, task="summarize"):
         attempts = 0
         last_summary = summary
         while attempts < self.config.max_refinement_attempts:
-            passed, metrics = self.validator.validate(source, last_summary, language)
-            if passed:
-                return last_summary, metrics
+            validation = self.validator.validate(source, last_summary, language)
+            if validation["passed"]:
+                return last_summary, validation["metrics"]
             # Generate refinement instructions
-            feedback = self._generate_feedback(metrics)
+            feedback = self._generate_feedback(validation["metrics"])
             prompt = self.prompt_factory.get_prompt(language, source, task) + f"\n\nRefinement instructions: {feedback}"
             # Here, call the LLM with the new prompt (stubbed)
             last_summary = self._call_llm(prompt)
             attempts += 1
             time.sleep(2 ** attempts)  # Exponential backoff
-        return last_summary, metrics
+        return last_summary, validation.get("metrics", {})
 
     def _generate_feedback(self, metrics):
         feedback = []
@@ -35,6 +36,30 @@ class SummaryRefiner:
             feedback.append("Improve structural coherence.")
         return " ".join(feedback)
 
-    def _call_llm(self, prompt):
-        # TODO: Integrate with LLM API
-        return "[Refined summary based on feedback]"
+    def _call_llm(self, prompt: str) -> str:
+        """Call the LLM via ``router_agent`` and return the response.
+
+        Parameters
+        ----------
+        prompt : str
+            The user prompt containing the source code and refinement
+            instructions.
+
+        Returns
+        -------
+        str
+            The LLM generated summary or an empty string if the call fails.
+        """
+        try:
+            response = self.router_agent.call_llm_by_role(
+                role="summarizer",
+                system_prompt=(
+                    "You refine code summaries based on validation feedback. "
+                    "Return only the improved summary."
+                ),
+                user_prompt=prompt,
+            )
+            return response or ""
+        except Exception:
+            # In case of API failure, return empty string to allow retry logic
+            return ""

--- a/tests/test_summary_refiner.py
+++ b/tests/test_summary_refiner.py
@@ -1,15 +1,24 @@
+from unittest.mock import MagicMock
+
 from agent_s3.tools.summarization.summary_refiner import SummaryRefiner
 from agent_s3.tools.summarization.summary_validator import SummaryValidator
 from agent_s3.tools.summarization.validation_config import SummaryValidationConfig
-from agent_s3.tools.summarization.prompt_factory import SummarizationPromptFactory
+
+
+
+class DummyPromptFactory:
+    def get_prompt(self, language, source, task):
+        return "dummy prompt"
 
 def test_summary_refiner_refines():
     config = SummaryValidationConfig(faithfulness_threshold=0.9, detail_preservation_threshold=0.9, structural_coherence_threshold=0.9, max_refinement_attempts=2)
-    validator = SummaryValidator(config)
-    prompt_factory = SummarizationPromptFactory()
-    refiner = SummaryRefiner(validator, prompt_factory, config)
+    validator = SummaryValidator()
+    prompt_factory = DummyPromptFactory()
+    router_agent = MagicMock()
+    router_agent.call_llm_by_role.return_value = "Improved summary"
+    refiner = SummaryRefiner(validator, prompt_factory, config, router_agent)
     source = "def foo():\n    return 42"
     summary = "This function does something else."
     refined, metrics = refiner.refine(source, summary, language="python")
-    # Since _call_llm is stubbed, expect fallback output
-    assert "Refined summary" in refined or not metrics['faithfulness'] >= 0.9
+    router_agent.call_llm_by_role.assert_called()
+    assert refined == "Improved summary" or not metrics["faithfulness"] >= 0.9


### PR DESCRIPTION
## Summary
- hook up SummaryRefiner to the real router_agent
- update SummaryRefiner to work with SummaryValidator's return value
- update test to provide router agent and prompt factory stubs

## Testing
- `ruff check agent_s3/tools/summarization/summary_refiner.py tests/test_summary_refiner.py`
- `pytest tests/test_summary_refiner.py -q`
- `pytest -q` *(fails: ValueError, ProxyError, etc.)*