### PR TITLE
Fix design completion detection case-insensitivity

### DIFF
--- a/agent_s3/design_manager.py
+++ b/agent_s3/design_manager.py
@@ -126,7 +126,8 @@ class DesignManager:
                 "Here are the distinct features:", "The system can be decomposed into:"
             ]
             
-            if any(indicator in last_ai_message for indicator in feature_indicators):
+            last_ai_message_lower = last_ai_message.lower()
+            if any(indicator.lower() in last_ai_message_lower for indicator in feature_indicators):
                 self.features_identified = True
                 self.consecutive_feature_messages += 1
             elif self.features_identified:
@@ -137,7 +138,7 @@ class DesignManager:
                     "Would you like me to create", "Would you like to implement",
                     "Should I finalize", "Ready to finalize"
                 ]
-                if any(indicator in last_ai_message for indicator in conclusion_indicators):
+                if any(indicator.lower() in last_ai_message_lower for indicator in conclusion_indicators):
                     return True
             
             # If we've had consecutive messages with feature listings, likely finished

--- a/tests/test_design_manager.py
+++ b/tests/test_design_manager.py
@@ -1,0 +1,16 @@
+import pytest
+
+from agent_s3.design_manager import DesignManager
+
+
+def test_detect_design_completion_case_insensitive():
+    """Design completion detection should handle mixed-case indicators."""
+    manager = DesignManager()
+    manager.conversation_history = [
+        {"role": "system", "content": "init"},
+        {"role": "user", "content": "List features"},
+        {"role": "assistant", "content": "feature 1: login system"},
+        {"role": "user", "content": "Looks Good"},
+    ]
+
+    assert manager.detect_design_completion()


### PR DESCRIPTION
## Summary
- improve design completion detection by matching indicators in lowercase
- add regression test covering mixed-case assistant responses

## Testing
- `pytest -q` *(fails: 55 failed, 113 passed, 1 skipped, 24 errors)*