### PR TITLE
Refactor design preplanning API

### DIFF
--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -1068,9 +1068,10 @@ def call_pre_planner_with_enforced_json(
 
     # If all attempts failed, return fallback JSON
     logger.warning(
-        "Pre-planning attempts exhausted; returning fallback JSON output"
+        "Pre-planning attempts exhausted; returning fallback JSON output. Last error: %s",
+        last_error,
     )
-    fallback_data = create_fallback_pre_planning_output(task_description)
+    fallback_data = pre_planning_data or create_fallback_pre_planning_output(task_description)
     return False, fallback_data
 
 

--- a/tests/test_design_to_implementation.py
+++ b/tests/test_design_to_implementation.py
@@ -149,7 +149,9 @@ def test_start_pre_planning_from_design(tmp_path, coordinator):
 
     coordinator.run_task = MagicMock()
 
-    coordinator.start_pre_planning_from_design(str(design_file))
+    result = coordinator.start_pre_planning_from_design(str(design_file))
+
+    assert result == {"success": True, "tasks_started": 3}
 
     expected_calls = [
         call(task="Setup environment", from_design=True),


### PR DESCRIPTION
## Summary
- clean up duplicate implementation helper functions
- ensure pre-planning tasks pass `from_design=True`
- log last pre-planning error and use fallback data if attempts fail
- remove leftover Node package files

## Testing
- `ruff check agent_s3`
- `mypy agent_s3`
- `pytest -q` *(fails: context integration tests)*