### PR TITLE
Update test target linking for planner

### DIFF
--- a/agent_s3/planner_json_enforced.py
+++ b/agent_s3/planner_json_enforced.py
@@ -1640,6 +1640,30 @@ def validate_pre_planning_for_planner(pre_plan_data: Dict[str, Any]) -> Tuple[bo
                             f"Feature {feature_idx} in group {group_idx} has {tests_missing_ids} unit tests missing target_element_id links"
                         )
 
+                integration_tests = test_requirements.get("integration_tests")
+                if isinstance(integration_tests, list):
+                    tests_missing_ids = 0
+                    for test in integration_tests:
+                        if isinstance(test, dict):
+                            if test.get("target_element") and not test.get("target_element_id"):
+                                tests_missing_ids += 1
+                    if tests_missing_ids > 0:
+                        compatibility_issues.append(
+                            f"Feature {feature_idx} in group {group_idx} has {tests_missing_ids} integration tests missing target_element_id links"
+                        )
+
+                acceptance_tests = test_requirements.get("acceptance_tests")
+                if isinstance(acceptance_tests, list):
+                    tests_missing_ids = 0
+                    for test in acceptance_tests:
+                        if isinstance(test, dict):
+                            if test.get("target_element") and not test.get("target_element_id"):
+                                tests_missing_ids += 1
+                    if tests_missing_ids > 0:
+                        compatibility_issues.append(
+                            f"Feature {feature_idx} in group {group_idx} has {tests_missing_ids} acceptance tests missing target_element_id links"
+                        )
+
     if compatibility_issues:
         message = (
             f"Pre-planning data has {len(compatibility_issues)} compatibility issues for planner phase: "

--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -770,6 +770,48 @@ def ensure_element_id_consistency(pre_planning_data: Dict[str, Any]) -> Dict[str
                                         test["target_element_id"] = matched_element["element_id"]
                                         logger.info(f"Linked property test to element_id {matched_element['element_id']} based on target_element {target_element}")
 
+                        # Process integration tests
+                        if "integration_tests" in feature["test_requirements"] and isinstance(feature["test_requirements"]["integration_tests"], list):
+                            for test_idx, test in enumerate(feature["test_requirements"]["integration_tests"]):
+                                if not isinstance(test, dict):
+                                    continue
+
+                                if "target_element" in test and isinstance(test["target_element"], str):
+                                    target_element = test["target_element"]
+
+                                    matched_element = None
+                                    for element in code_elements:
+                                        if isinstance(element, dict) and element.get("name") == target_element:
+                                            matched_element = element
+                                            break
+
+                                    if matched_element and "element_id" in matched_element:
+                                        test["target_element_id"] = matched_element["element_id"]
+                                        logger.info(
+                                            f"Linked integration test to element_id {matched_element['element_id']} based on target_element {target_element}"
+                                        )
+
+                        # Process acceptance tests
+                        if "acceptance_tests" in feature["test_requirements"] and isinstance(feature["test_requirements"]["acceptance_tests"], list):
+                            for test_idx, test in enumerate(feature["test_requirements"]["acceptance_tests"]):
+                                if not isinstance(test, dict):
+                                    continue
+
+                                if "target_element" in test and isinstance(test["target_element"], str):
+                                    target_element = test["target_element"]
+
+                                    matched_element = None
+                                    for element in code_elements:
+                                        if isinstance(element, dict) and element.get("name") == target_element:
+                                            matched_element = element
+                                            break
+
+                                    if matched_element and "element_id" in matched_element:
+                                        test["target_element_id"] = matched_element["element_id"]
+                                        logger.info(
+                                            f"Linked acceptance test to element_id {matched_element['element_id']} based on target_element {target_element}"
+                                        )
+
     return pre_planning_data
 
 def get_json_system_prompt() -> str:


### PR DESCRIPTION
## Summary
- populate `target_element_id` for integration and acceptance tests
- report missing `target_element_id` links during planner validation

## Testing
- `ruff check agent_s3` *(fails: F811 redefinition errors)*
- `mypy agent_s3`
- `pytest tests/test_pre_planner_json_enforced.py::TestPrePlannerJsonEnforced::test_validate_json_schema_valid -q` *(fails: ValueError too many values to unpack)*
