### PR TITLE
Remove unused variable from JSON pre-planner

### DIFF
--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -1026,7 +1026,6 @@ def call_pre_planner_with_enforced_json(
     import traceback
     max_preplanning_attempts = 3
     last_error = None
-    pre_planning_data = None
     system_prompt = get_json_system_prompt()
     user_prompt = get_base_user_prompt(task_description)
     openrouter_params = get_openrouter_params()
@@ -1055,7 +1054,6 @@ def call_pre_planner_with_enforced_json(
                     return True, data
                 else:
                     last_error = f"Validation failed: {validation_msg}"
-                    pre_planning_data = data
             elif status == "question":
                 # LLM is asking for clarification, return as-is
                 return False, data
@@ -1068,7 +1066,8 @@ def call_pre_planner_with_enforced_json(
 
     # If all attempts failed, return fallback JSON
     logger.warning(
-        "Pre-planning attempts exhausted; returning fallback JSON output"
+        "Pre-planning attempts exhausted; returning fallback JSON output."
+        f" Last error: {last_error}"
     )
     fallback_data = create_fallback_pre_planning_output(task_description)
     return False, fallback_data


### PR DESCRIPTION
## Summary
- clean up unused variable in `call_pre_planner_with_enforced_json`
- include last error in fallback log message

## Testing
- `ruff check agent_s3/pre_planner_json_enforced.py`
- `pytest -k pre_planner_json_enforced -q` *(fails: AssertionError in tests)*