### PR TITLE
Add ESLint config to VSCode extension

### DIFF
--- a/vscode/.eslintrc.json
+++ b/vscode/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "env": {
+    "node": true,
+    "es2021": true
+  },
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "ignorePatterns": ["webview-ui/**"],
+  "rules": {}
+}

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -61,7 +61,7 @@
     "vscode:prepublish": "npm run compile && npm run build-webview",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "lint": "eslint src --ext ts",
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint . --ext ts",
     "build-webview": "cd webview-ui && npm install && npm run build",
     "watch-webview": "cd webview-ui && npm run start",
     "test-server": "node ../tests/node_servers/simple-test-server.js"


### PR DESCRIPTION
## Summary
- add `.eslintrc.json` with TypeScript rules for the VS Code extension
- update lint script to use the config with ESLint 9

## Testing
- `npm run lint` *(fails: plugin not installed)*