### PR TITLE
Fix ruff lint issues

### DIFF
--- a/tests/test_design_manager.py
+++ b/tests/test_design_manager.py
@@ -1,5 +1,3 @@
-import pytest
-
 from agent_s3.design_manager import DesignManager
 
 


### PR DESCRIPTION
## Summary
- remove unused pytest import from design manager tests

## Testing
- `ruff check .`
