### PR TITLE
Clean up leftover cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ Thumbs.db
 
 # Project-specific artifacts and cache
 .cache/
+.agent_s3/
 .claude/
 .hypothesis/
 .mypy_cache/


### PR DESCRIPTION
## Summary
- ignore `.agent_s3/` cache directory in `.gitignore`

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement gptcache>=1.0.0)*
- `pytest -q` *(fails: 59 failed, 116 passed, 1 skipped, 14 warnings, 46 errors)*