### PR TITLE
Fix command validation and QA performance

### DIFF
--- a/agent_s3/cli.py
+++ b/agent_s3/cli.py
@@ -243,13 +243,14 @@ User input: ''' + repr(prompt)
             print("Routing to general_qa: querying codebase context...")
             from pathlib import Path
             import glob
-            # Gather code files (e.g., .py) as context
+            import itertools
+            # Gather a limited set of code files to avoid excessive memory usage
             code_context = {}
-            for path in glob.glob("**/*.py", recursive=True):
+            for path in itertools.islice(glob.glob("**/*.py", recursive=True), 200):
                 try:
-                    content = Path(path).read_text(encoding="utf-8")
-                    code_context[path] = content[:5000]  # truncate large files
-                except Exception:
+                    with open(path, "r", encoding="utf-8") as f:
+                        code_context[path] = f.read(5000)
+                except OSError:
                     continue
             system_prompt = (
                 "You are a Q&A assistant. Use the provided codebase context to answer questions about the project."

--- a/agent_s3/tools/error_context_manager.py
+++ b/agent_s3/tools/error_context_manager.py
@@ -398,7 +398,7 @@ class ErrorContextManager:
         message = error_info.get("message", "")
         # ImportError: try pip install for missing package
         if error_type == "import":
-            match = re.search(r"No module named ['\"]([a-zA-Z0-9_\-]+)['\"]", message)
+            match = re.search(r"No module named ['\"]([^'\"]+)['\"]", message)
             if match:
                 package = match.group(1)
                 try:

--- a/tests/test_terminal_executor_paths.py
+++ b/tests/test_terminal_executor_paths.py
@@ -44,3 +44,32 @@ def test_symlink_outside_directory(tmp_path):
     is_valid, msg = executor._validate_command(f"cat {link}")
     assert not is_valid
     assert "restricted path" in msg
+
+
+def test_command_substitution_backticks(tmp_path):
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    executor = TerminalExecutor(DummyConfig([str(allowed)]))
+    is_valid, msg = executor._validate_command("echo `whoami`")
+    assert not is_valid
+    assert "substitution" in msg.lower()
+
+
+def test_command_substitution_dollar_parens(tmp_path):
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    executor = TerminalExecutor(DummyConfig([str(allowed)]))
+    is_valid, msg = executor._validate_command("echo $(whoami)")
+    assert not is_valid
+    assert "substitution" in msg.lower()
+
+
+def test_validate_path_with_spaces(tmp_path):
+    allowed = tmp_path / "allowed dir"
+    allowed.mkdir()
+    file_path = allowed / "file.txt"
+    file_path.write_text("data")
+    executor = TerminalExecutor(DummyConfig([str(tmp_path)]))
+    cmd = f'cat "{file_path}"'
+    is_valid, _ = executor._validate_command(cmd)
+    assert is_valid


### PR DESCRIPTION
## Summary
- tighten security checks in `TerminalExecutor`
- prevent command substitution attacks and improve path detection
- limit general QA file loading in CLI to 200 files
- fix package name parsing for automated recovery
- add regression tests for the terminal executor

## Testing
- `pytest tests/test_terminal_executor_paths.py tests/test_subprocess_security.py -q`