### PR TITLE
Fix tool_user shell execution routing

### DIFF
--- a/agent_s3/cli.py
+++ b/agent_s3/cli.py
@@ -230,12 +230,12 @@ User input: ''' + repr(prompt)
         elif category == "tool_user":
             # Execute arbitrary shell command directly
             print("Routing to tool_user: executing shell command...")
-            # Use coordinator's CLI executor for bash commands, but confirm first
             confirmation = input(
                 f"Proceed to run '{prompt}' as a shell command? (y/n) "
             ).strip().lower()
             if confirmation == "y":
-                coordinator.execute_terminal_command(prompt)
+                # Run the command via CommandProcessor (lazy-loaded on access)
+                coordinator.command_processor.execute_terminal_command(prompt)
             else:
                 print("Command aborted.")
         elif category == "general_qa":

--- a/agent_s3/coordinator.py
+++ b/agent_s3/coordinator.py
@@ -130,6 +130,17 @@ class Coordinator:
                 level=logging.ERROR,
                 reraise=True
             )
+
+        # Lazy-initialized command processor
+        self._command_processor = None
+
+    @property
+    def command_processor(self):
+        """Lazily create and return the CommandProcessor instance."""
+        if self._command_processor is None:
+            from agent_s3.command_processor import CommandProcessor
+            self._command_processor = CommandProcessor(self)
+        return self._command_processor
     
     def _initialize_core_components(self) -> None:
         """Initialize core components and logging."""

--- a/tests/test_cli_tool_user_confirmation.py
+++ b/tests/test_cli_tool_user_confirmation.py
@@ -13,6 +13,7 @@ def run_main_with_prompt(prompt, user_input):
             with patch('agent_s3.cli.Config', return_value=dummy_config):
                 with patch('agent_s3.cli.Coordinator') as MockCoordinator:
                     coordinator_instance = MockCoordinator.return_value
+                    coordinator_instance.command_processor.execute_terminal_command = MagicMock()
                     with patch('agent_s3.cli.RouterAgent') as MockRouter:
                         router_instance = MockRouter.return_value
                         router_instance.call_llm_by_role.return_value = (
@@ -25,10 +26,10 @@ def run_main_with_prompt(prompt, user_input):
 
 def test_tool_user_executes_on_confirmation():
     coord = run_main_with_prompt('ls', 'y')
-    coord.execute_terminal_command.assert_called_once_with('ls')
+    coord.command_processor.execute_terminal_command.assert_called_once_with('ls')
 
 
 def test_tool_user_aborts_without_confirmation():
     coord = run_main_with_prompt('ls', 'n')
-    coord.execute_terminal_command.assert_not_called()
+    coord.command_processor.execute_terminal_command.assert_not_called()
 

--- a/tests/test_cli_tool_user_property.py
+++ b/tests/test_cli_tool_user_property.py
@@ -1,0 +1,36 @@
+import os
+import sys
+from unittest.mock import patch, MagicMock
+from agent_s3 import cli
+
+class MinimalCoordinator:
+    def __init__(self, *args, **kwargs):
+        self._command_processor = None
+
+    @property
+    def command_processor(self):
+        if self._command_processor is None:
+            self._command_processor = MagicMock()
+        return self._command_processor
+
+
+def test_tool_user_branch_without_preexisting_command_processor():
+    with patch.object(sys, 'argv', ['agent-s3', 'ls']):
+        with patch.dict(os.environ, {'GITHUB_TOKEN': 't'}):
+            dummy_config = MagicMock()
+            dummy_config.config = {}
+            with patch('agent_s3.cli.Config', return_value=dummy_config):
+                instance_holder = {}
+
+                def factory(*args, **kwargs):
+                    instance_holder['obj'] = MinimalCoordinator(*args, **kwargs)
+                    return instance_holder['obj']
+
+                with patch('agent_s3.cli.Coordinator', side_effect=factory):
+                    with patch('agent_s3.cli.RouterAgent') as MockRouter:
+                        MockRouter.return_value.call_llm_by_role.return_value = (
+                            '{"category": "tool_user", "rationale": "", "confidence": 0.99}'
+                        )
+                        with patch('builtins.input', return_value='y'):
+                            cli.main()
+                            assert instance_holder['obj'].command_processor.execute_terminal_command.called


### PR DESCRIPTION
## Summary
- run `tool_user` shell commands through `CommandProcessor`
- lazily create `CommandProcessor` in `Coordinator`
- update CLI tests for command processor usage
- add test ensuring `tool_user` branch runs without AttributeError

## Testing
- `pytest tests/test_cli_tool_user_confirmation.py::test_tool_user_executes_on_confirmation tests/test_cli_tool_user_confirmation.py::test_tool_user_aborts_without_confirmation tests/test_cli_tool_user_property.py::test_tool_user_branch_without_preexisting_command_processor -q`
- `pytest tests/test_cli_tool_user_property.py::test_tool_user_branch_without_preexisting_command_processor -q`
