### PR TITLE
Initialize DatabaseManager in coordinator

### DIFF
--- a/agent_s3/coordinator.py
+++ b/agent_s3/coordinator.py
@@ -42,6 +42,7 @@ from agent_s3.tools.code_analysis_tool import CodeAnalysisTool
 from agent_s3.tools.context_management.context_manager import ContextManager
 from agent_s3.tools.context_management.context_registry import ContextRegistry
 from agent_s3.tools.database_tool import DatabaseTool
+from agent_s3.database_manager import DatabaseManager
 from agent_s3.tools.embedding_client import EmbeddingClient
 from agent_s3.tools.env_tool import EnvTool
 from agent_s3.tools.error_context_manager import ErrorContextManager
@@ -228,6 +229,7 @@ class Coordinator:
         """Initialize additional tools that depend on core tools."""
         # Database, environment, and AST tools
         self.database_tool = DatabaseTool(config=self.config, bash_tool=self.bash_tool)
+        self.database_manager = DatabaseManager(coordinator=self, database_tool=self.database_tool)
         self.env_tool = EnvTool(self.bash_tool)
         self.ast_tool = ASTTool()
 

--- a/tests/integration/test_enforced_json_coordinator_integration.py
+++ b/tests/integration/test_enforced_json_coordinator_integration.py
@@ -97,7 +97,8 @@ class TestEnforcedJsonCoordinatorIntegration:
              patch('agent_s3.coordinator.TechStackDetector'), \
              patch('agent_s3.coordinator.FileHistoryAnalyzer'), \
              patch('agent_s3.coordinator.DebuggingManager'), \
-             patch('agent_s3.coordinator.CommandProcessor'):
+             patch('agent_s3.coordinator.CommandProcessor'), \
+             patch('agent_s3.coordinator.DatabaseManager'):
             
             coordinator = Coordinator(config=mock_config)
             

--- a/tests/test_advanced_workflows.py
+++ b/tests/test_advanced_workflows.py
@@ -110,6 +110,7 @@ def mock_coordinator(setup_test_files):
          patch('agent_s3.coordinator.PromptModerator') as mock_prompt_moderator_cls, \
          patch('agent_s3.coordinator.TaskStateManager') as mock_task_state_manager_cls, \
          patch('agent_s3.coordinator.ErrorContextManager') as mock_error_context_cls, \
+         patch('agent_s3.coordinator.DatabaseManager'), \
          patch('os.path.dirname') as mock_dirname, \
          patch('builtins.open', new_callable=MagicMock):
         

--- a/tests/test_coordinator_debugging.py
+++ b/tests/test_coordinator_debugging.py
@@ -55,6 +55,7 @@ def mock_coordinator(mock_config, mock_file_tool, mock_bash_tool):
          patch('agent_s3.coordinator.ProgressTracker'), \
          patch('agent_s3.coordinator.ErrorContextManager'), \
          patch('agent_s3.coordinator.TaskStateManager'), \
+         patch('agent_s3.coordinator.DatabaseManager'), \
          patch('agent_s3.coordinator.BashTool', return_value=mock_bash_tool), \
          patch('agent_s3.coordinator.FileTool', return_value=mock_file_tool), \
          patch('agent_s3.coordinator.os.path.join', return_value="task_snapshots"):

--- a/tests/test_coordinator_phases.py
+++ b/tests/test_coordinator_phases.py
@@ -40,7 +40,8 @@ def coordinator(mock_config):
          patch('agent_s3.coordinator.CodeAnalysisTool'), \
          patch('agent_s3.coordinator.TaskStateManager'), \
          patch('agent_s3.coordinator.TaskResumer'), \
-         patch('agent_s3.coordinator.WorkspaceInitializer'):
+         patch('agent_s3.coordinator.WorkspaceInitializer'), \
+         patch('agent_s3.coordinator.DatabaseManager'):
         
         coordinator = Coordinator(config=mock_config)
         

--- a/tests/test_coordinator_plan_validation.py
+++ b/tests/test_coordinator_plan_validation.py
@@ -34,7 +34,8 @@ class TestCoordinatorPlanValidation:
              patch('agent_s3.coordinator.FileTool'), \
              patch('agent_s3.coordinator.GitTool'), \
              patch('agent_s3.coordinator.BashTool'), \
-             patch('agent_s3.coordinator.TaskResumer'):
+             patch('agent_s3.coordinator.TaskResumer'), \
+             patch('agent_s3.coordinator.DatabaseManager'):
         
             coordinator = Coordinator(config=mock_config)
             

--- a/tests/test_coordinator_validation.py
+++ b/tests/test_coordinator_validation.py
@@ -35,7 +35,8 @@ def coordinator(mock_config):
          patch('agent_s3.coordinator.GitTool'), \
          patch('agent_s3.coordinator.CodeAnalysisTool'), \
          patch('agent_s3.coordinator.TaskStateManager'), \
-         patch('agent_s3.coordinator.TaskResumer'):
+         patch('agent_s3.coordinator.TaskResumer'), \
+         patch('agent_s3.coordinator.DatabaseManager'):
         
         coordinator = Coordinator(config=mock_config)
         

--- a/tests/test_plan_approval_loop.py
+++ b/tests/test_plan_approval_loop.py
@@ -24,7 +24,8 @@ def coordinator():
          patch('agent_s3.coordinator.CodeAnalysisTool'), \
          patch('agent_s3.coordinator.TaskStateManager'), \
          patch('agent_s3.coordinator.TaskResumer'), \
-         patch('agent_s3.coordinator.WorkspaceInitializer'):
+         patch('agent_s3.coordinator.WorkspaceInitializer'), \
+         patch('agent_s3.coordinator.DatabaseManager'):
 
         coord = Coordinator(config=config)
         coord.prompt_moderator = MagicMock()

--- a/tests/test_run_task_exception.py
+++ b/tests/test_run_task_exception.py
@@ -32,7 +32,8 @@ def coordinator(mock_config):
          patch("agent_s3.coordinator.CodeAnalysisTool"), \
          patch("agent_s3.coordinator.TaskStateManager"), \
          patch("agent_s3.coordinator.TaskResumer"), \
-         patch("agent_s3.coordinator.WorkspaceInitializer"):
+         patch("agent_s3.coordinator.WorkspaceInitializer"), \
+         patch("agent_s3.coordinator.DatabaseManager"):
         coord = Coordinator(config=mock_config)
         coord.pre_planner = MagicMock()
         coord.planner = MagicMock()

--- a/tests/test_system_integration.py
+++ b/tests/test_system_integration.py
@@ -264,6 +264,7 @@ def mock_coordinator():
          patch('agent_s3.coordinator.TestPlanner') as mock_test_planner_cls, \
          patch('agent_s3.coordinator.CodeGenerator') as mock_code_generator_cls, \
          patch('agent_s3.coordinator.PromptModerator') as mock_prompt_moderator_cls, \
+         patch('agent_s3.coordinator.DatabaseManager'), \
          patch('agent_s3.coordinator.os.makedirs') as _mock_makedirs, \
          patch('builtins.open', new_callable=MagicMock), \
          patch('agent_s3.coordinator.BashTool') as mock_bash_tool_cls:


### PR DESCRIPTION
## Summary
- import and instantiate `DatabaseManager`
- patch tests to mock the new dependency

## Testing
- `pytest tests/test_coordinator_validation.py::test_validation_phase_all_pass -q` *(fails: ProxyError - no network)*