### PR TITLE
Fix test failure handling

### DIFF
--- a/agent_s3/cli.py
+++ b/agent_s3/cli.py
@@ -241,7 +241,6 @@ User input: ''' + repr(prompt)
         elif category == "general_qa":
             # General Q&A: call the LLM with entire codebase as context
             print("Routing to general_qa: querying codebase context...")
-            from pathlib import Path
             import glob
             import itertools
             # Gather a limited set of code files to avoid excessive memory usage

--- a/agent_s3/implementation_manager.py
+++ b/agent_s3/implementation_manager.py
@@ -323,7 +323,14 @@ class ImplementationManager:
 
             # Run tests if implementation was successful
             if result.get("success", False):
-                self._run_tests()
+                test_result = self._run_tests()
+                result["tests"] = test_result
+
+                # Mark the implementation as failed if tests fail
+                if not test_result.get("success", False):
+                    result["success"] = False
+                    if "error" not in result:
+                        result["error"] = test_result.get("error", "Tests failed")
 
             return result
         else:

--- a/tests/test_implementation_manager.py
+++ b/tests/test_implementation_manager.py
@@ -243,6 +243,23 @@ class TestImplementationManager(unittest.TestCase):
         self.assertTrue(result["success"])
         self.assertEqual(result["message"], "All tasks are completed")
 
+    @patch.object(ImplementationManager, "_run_tests")
+    def test_execute_request_failed_tests(self, mock_run_tests: MagicMock) -> None:
+        """Verify failing tests mark the result as unsuccessful."""
+        task = {"description": "Implement feature"}
+
+        # Router agent reports success
+        self.implementation_manager.router_agent = MagicMock()
+        self.implementation_manager.router_agent.execute_request.return_value = {"success": True}
+
+        # Tests fail
+        mock_run_tests.return_value = {"success": False, "error": "Tests failed"}
+
+        result = self.implementation_manager._execute_implementation_request(task)
+
+        self.assertFalse(result["success"])
+        self.assertIn("tests", result)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- fail implementation when test run fails
- remove unused import from CLI
- test failing tests in ImplementationManager

## Testing
- `pytest -q tests/test_implementation_manager.py`
- `mypy agent_s3`
- `ruff check agent_s3`
