### PR TITLE
Fix design manager initialization

### DIFF
--- a/agent_s3/cli.py
+++ b/agent_s3/cli.py
@@ -241,7 +241,6 @@ User input: ''' + repr(prompt)
         elif category == "general_qa":
             # General Q&A: call the LLM with entire codebase as context
             print("Routing to general_qa: querying codebase context...")
-            from pathlib import Path
             import glob
             import itertools
             # Gather a limited set of code files to avoid excessive memory usage

--- a/agent_s3/coordinator.py
+++ b/agent_s3/coordinator.py
@@ -30,6 +30,7 @@ from agent_s3.pre_planner_json_enforced import (
 from agent_s3.progress_tracker import ProgressTracker
 from agent_s3.prompt_moderator import PromptModerator
 from agent_s3.router_agent import RouterAgent
+from agent_s3.design_manager import DesignManager
 from agent_s3.task_resumer import TaskResumer
 from agent_s3.task_state_manager import TaskStateManager
 from agent_s3.tech_stack_detector import TechStackDetector
@@ -268,6 +269,9 @@ class Coordinator:
 
         # Implementation manager handles step-by-step execution of design tasks
         self.implementation_manager = ImplementationManager(coordinator=self)
+
+        # Design manager for interactive design conversations
+        self.design_manager = DesignManager(coordinator=self)
 
         # Initialize core workflow components
         self._initialize_workflow_components()


### PR DESCRIPTION
## Summary
- import DesignManager in coordinator
- create a DesignManager instance when initializing specialized components
- remove stray Node.js files and clean up an unused import

## Testing
- `ruff check agent_s3`
- `mypy agent_s3`
- `pytest tests/test_design_to_implementation.py::test_design_manager_initialization -q`
- `pytest tests/test_coordinator_facade_methods.py::TestCoordinatorFacadeMethods::test_execute_design_facade_exists -q`

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.