### PR TITLE
Fix path validation for FileTool

### DIFF
--- a/agent_s3/tools/file_tool.py
+++ b/agent_s3/tools/file_tool.py
@@ -51,10 +51,16 @@ class FileTool:
             # Use realpath to resolve any symlinks before comparison
             norm_path = os.path.normpath(os.path.realpath(file_path))
             
-            # Check if path is within allowed directories
+            # Check if path is within allowed directories using commonpath to
+            # avoid prefix-based bypasses like '/tmpfoo'
             allowed = False
             for dir_path in self.allowed_dirs:
-                if norm_path.startswith(dir_path):
+                real_allowed = os.path.realpath(dir_path)
+                try:
+                    common = os.path.commonpath([norm_path, real_allowed])
+                except ValueError:
+                    common = ""
+                if common == real_allowed:
                     allowed = True
                     break
             

--- a/tests/test_file_tool_paths.py
+++ b/tests/test_file_tool_paths.py
@@ -1,0 +1,21 @@
+from agent_s3.tools.file_tool import FileTool
+
+
+def test_prefix_path_rejected(tmp_path):
+    allowed_dir = tmp_path / "tmp"
+    allowed_dir.mkdir()
+    prefix_dir = tmp_path / "tmpfoo" / "bar"
+    prefix_dir.mkdir(parents=True)
+    ft = FileTool(allowed_dirs=[str(allowed_dir)])
+    allowed, msg = ft._is_path_allowed(str(prefix_dir))
+    assert not allowed
+    assert "outside allowed directories" in msg
+
+
+def test_subdirectory_allowed(tmp_path):
+    allowed_dir = tmp_path / "tmp"
+    sub_dir = allowed_dir / "foo" / "bar"
+    sub_dir.mkdir(parents=True)
+    ft = FileTool(allowed_dirs=[str(allowed_dir)])
+    allowed, _ = ft._is_path_allowed(str(sub_dir))
+    assert allowed


### PR DESCRIPTION
## Summary
- use `os.path.commonpath` in `FileTool._is_path_allowed`
- add regression tests for prefix directory case

## Testing
- `pytest -k "file_tool_paths or file_tool_symlinks" -q`
- `pytest tests/test_terminal_executor_paths.py::test_validate_absolute_path -q`
