### PR TITLE
Add complexity confirmation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ Agent-S3 is not just a tool for automation; it is a partner in development that 
   - Automatic plan file generation with unique IDs for traceability
 - Complexity Management:
   - Explicit complexity assessment with numerical scoring
-  - User confirmation required for complex tasks
-  - Clear options to proceed, modify request, or cancel
-  - Removal of automatic workflow switching in favor of user control
+- User confirmation required for complex tasks
+- Clear options to proceed, modify request, or cancel
+- Removal of automatic workflow switching in favor of user control
+  - Final confirmation after reviewing pre-planning results when tasks are
+    flagged as complex
 - Design-to-Implementation Pipeline:
   - Conversational feature decomposition and architecture planning via `/design` command
   - Industry best practice analysis and recommendations during design

--- a/agent_s3/coordinator.py
+++ b/agent_s3/coordinator.py
@@ -581,7 +581,24 @@ class Coordinator:
                 "Do you want to proceed with this plan, modify it, or cancel?"
             )
             if decision == "yes":
-                self.scratchpad.log("Coordinator", "User approved pre-planning results.")
+                # Additional confirmation if the task was flagged as complex
+                is_complex = pre_planning_results.get("is_complex", False)
+                score = pre_planning_results.get("complexity_score", 0)
+                threshold = self.config.config.get("complexity_threshold", 0)
+                if is_complex or score >= threshold:
+                    confirm = self.prompt_moderator.ask_yes_no_question(
+                        "This plan is complex. Are you sure you want to continue?"
+                    )
+                    if not confirm:
+                        self.scratchpad.log(
+                            "Coordinator",
+                            "User cancelled after reviewing complex plan.",
+                        )
+                        return "no", None
+
+                self.scratchpad.log(
+                    "Coordinator", "User approved pre-planning results."
+                )
                 return decision, None
             elif decision == "no":
                 self.scratchpad.log("Coordinator", "User rejected pre-planning results.")

--- a/docs/pre_planning_workflow.md
+++ b/docs/pre_planning_workflow.md
@@ -24,7 +24,7 @@ The pre-planning workflow follows these steps:
 
 8. **Complexity Assessment**: The complexity of the task is assessed to determine if user confirmation is required.
 
-9. **User Confirmation**: The user reviews and approves, modifies, or rejects the pre-planning output.
+9. **User Confirmation**: The user reviews the pre-planning output. If the task was flagged as complex, a final confirmation is requested before proceeding. The user may approve, modify, or reject the output.
 
 ## Key Components
 

--- a/tests/test_coordinator_plan_validation.py
+++ b/tests/test_coordinator_plan_validation.py
@@ -372,3 +372,27 @@ class TestCoordinatorPlanValidation:
                 coordinator.feature_group_processor.process_pre_planning_output.assert_not_called()
 
 
+
+    def test_present_pre_planning_user_cancels_after_confirmation(self, coordinator):
+        """User cancels at the additional complexity confirmation step."""
+        pre_plan = {
+            "success": True,
+            "status": "completed",
+            "is_complex": True,
+            "complexity_score": 9.5,
+            "feature_groups": []
+        }
+
+        coordinator.prompt_moderator.ask_ternary_question.return_value = "yes"
+        coordinator.prompt_moderator.ask_yes_no_question.return_value = False
+
+        decision, modification = coordinator._present_pre_planning_results_to_user(pre_plan)
+
+        assert decision == "no"
+        assert modification is None
+        coordinator.prompt_moderator.ask_yes_no_question.assert_called_once()
+        coordinator.scratchpad.log.assert_any_call(
+            "Coordinator",
+            "User cancelled after reviewing complex plan.",
+        )
+


### PR DESCRIPTION
## Summary
- add follow-up confirmation in `_present_pre_planning_results_to_user`
- document the final confirmation in README and pre-planning docs
- test branch where user cancels at the new step

## Testing
- `pytest -q` *(fails: ProxyError during tiktoken download)*
- `pytest tests/test_coordinator_plan_validation.py::TestCoordinatorPlanValidation::test_present_pre_planning_user_cancels_after_confirmation -q` *(fails: ProxyError during initialization)*