### PR TITLE
Unify validation results with dataclass

### DIFF
--- a/agent_s3/feature_group_processor.py
+++ b/agent_s3/feature_group_processor.py
@@ -763,15 +763,15 @@ class FeatureGroupProcessor:
                     )
 
                 # Perform implementation plan validation
-                validated_impl, validation_issues, needs_repair = (
-                    validate_implementation_plan(
-                        updated_plan.get("implementation_plan", {}),
-                        system_design,
-                        updated_plan.get("architecture_review", {}),
-                        updated_plan.get("tests", {}),
-                    )
+                validation_result = validate_implementation_plan(
+                    updated_plan.get("implementation_plan", {}),
+                    system_design,
+                    updated_plan.get("architecture_review", {}),
+                    updated_plan.get("tests", {}),
                 )
-                updated_plan["implementation_plan"] = validated_impl
+                updated_plan["implementation_plan"] = validation_result.data
+                validation_issues = validation_result.issues
+                needs_repair = validation_result.needs_repair
 
                 revalidation_results = {
                     "implementation_plan_validation": {

--- a/agent_s3/planner_json_enforced.py
+++ b/agent_s3/planner_json_enforced.py
@@ -1961,9 +1961,12 @@ def validate_planning_semantic_coherence(
     
     # Validate implementation plan against system design, architecture review, and test implementations
     if implementation_plan and system_design and architecture_review and test_implementations:
-        validated_plan, validation_issues, needs_repair = validate_implementation_plan(
+        validation_result = validate_implementation_plan(
             implementation_plan, system_design, architecture_review, test_implementations
         )
+        validated_plan = validation_result.data
+        validation_issues = validation_result.issues
+        needs_repair = validation_result.needs_repair
         
         # Calculate implementation metrics for deeper semantic analysis
         element_ids = set()
@@ -2661,12 +2664,15 @@ Focus on creating a comprehensive and detailed plan that a developer can follow 
                                 test_requirements[element_id].append(test_with_type)
             
             # Perform validation with detailed logging
-            validated_plan, validation_issues, needs_repair = validate_implementation_plan(
+            validation_result = validate_implementation_plan(
                 implementation_plan,
                 system_design,
                 architecture_review,
-                tests
+                tests,
             )
+            validated_plan = validation_result.data
+            validation_issues = validation_result.issues
+            needs_repair = validation_result.needs_repair
             
             # Log validation issues with structured categorization
             issue_types = defaultdict(lambda: defaultdict(int))

--- a/agent_s3/tools/coherence_validator.py
+++ b/agent_s3/tools/coherence_validator.py
@@ -12,12 +12,14 @@ import logging
 import re
 from typing import Dict, Any, List
 
+from .validation_result import ValidationResult
+
 logger = logging.getLogger(__name__)
 
 
 def validate_implementation_coherence(
     implementation_plan: Dict[str, Any]
-) -> List[Dict[str, Any]]:
+) -> ValidationResult:
     """
     Validate coherence across implementations, checking for consistency in naming,
     error handling, API design patterns, and data flow.
@@ -26,9 +28,9 @@ def validate_implementation_coherence(
         implementation_plan: The implementation plan to validate
         
     Returns:
-        List of validation issues related to coherence
+        ValidationResult with issues and coherence metrics
     """
-    issues = []
+    issues: List[Dict[str, Any]] = []
     
     # Extract implementation_plan dict if it's nested in a larger structure
     if "implementation_plan" in implementation_plan:
@@ -37,22 +39,25 @@ def validate_implementation_coherence(
         impl_plan = implementation_plan
     
     # Validate naming consistency
-    naming_issues = check_naming_consistency(impl_plan)
+    naming_issues, _ = check_naming_consistency(impl_plan)
     issues.extend(naming_issues)
     
     # Validate error handling approaches
-    error_handling_issues = check_error_handling_consistency(impl_plan)
+    error_handling_issues, _ = check_error_handling_consistency(impl_plan)
     issues.extend(error_handling_issues)
     
     # Validate API design patterns
-    api_design_issues = check_api_design_consistency(impl_plan)
+    api_design_issues, _ = check_api_design_consistency(impl_plan)
     issues.extend(api_design_issues)
     
     # Validate data flow patterns
-    data_flow_issues = check_data_flow_consistency(impl_plan)
+    data_flow_issues, _ = check_data_flow_consistency(impl_plan)
     issues.extend(data_flow_issues)
-    
-    return issues
+
+    metrics = calculate_coherence_metrics(impl_plan)
+    needs_repair = any(i.get("severity") in ["critical", "high"] for i in issues)
+
+    return ValidationResult(issues=issues, needs_repair=needs_repair, metrics=metrics)
 
 
 def check_naming_consistency(implementation_plan: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/agent_s3/tools/validation_result.py
+++ b/agent_s3/tools/validation_result.py
@@ -1,0 +1,18 @@
+"""Common validation result data structure used across validators."""
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class ValidationResult:
+    """Represents the result of a validation operation."""
+
+    data: Any = None
+    issues: List[Dict[str, Any]] = field(default_factory=list)
+    needs_repair: bool = False
+    metrics: Dict[str, float] = field(default_factory=dict)
+
+    @property
+    def is_valid(self) -> bool:
+        """Return ``True`` when no issues require repair."""
+        return not self.issues and not self.needs_repair

--- a/tests/test_implementation_validator.py
+++ b/tests/test_implementation_validator.py
@@ -144,30 +144,30 @@ class TestImplementationValidator(unittest.TestCase):
 
     def test_validate_valid_plan(self):
         """Test validation of a valid implementation plan."""
-        validated_plan, validation_issues, needs_repair = validate_implementation_plan(
+        result = validate_implementation_plan(
             self.valid_implementation_plan,
             self.system_design,
             self.architecture_review,
-            self.test_implementations
+            self.test_implementations,
         )
-        
-        self.assertFalse(needs_repair)
-        self.assertEqual(len(validation_issues), 0)
+
+        self.assertFalse(result.needs_repair)
+        self.assertEqual(len(result.issues), 0)
 
     def test_validate_invalid_plan(self):
         """Test validation of an invalid implementation plan."""
-        validated_plan, validation_issues, needs_repair = validate_implementation_plan(
+        result = validate_implementation_plan(
             self.invalid_implementation_plan,
             self.system_design,
             self.architecture_review,
-            self.test_implementations
+            self.test_implementations,
         )
-        
-        self.assertTrue(needs_repair)
-        self.assertGreater(len(validation_issues), 0)
+
+        self.assertTrue(result.needs_repair)
+        self.assertGreater(len(result.issues), 0)
         
         # Check for specific issues
-        issue_types = [issue["issue_type"] for issue in validation_issues]
+        issue_types = [issue["issue_type"] for issue in result.issues]
         self.assertIn("invalid_element_id", issue_types)
         self.assertIn("missing_steps", issue_types)
         self.assertIn("missing_element_implementation", issue_types)
@@ -175,12 +175,15 @@ class TestImplementationValidator(unittest.TestCase):
 
     def test_repair_plan(self):
         """Test repairing an invalid implementation plan."""
-        validated_plan, validation_issues, needs_repair = validate_implementation_plan(
+        result = validate_implementation_plan(
             self.invalid_implementation_plan,
             self.system_design,
             self.architecture_review,
-            self.test_implementations
+            self.test_implementations,
         )
+
+        validated_plan = result.data
+        validation_issues = result.issues
         
         repaired_plan = repair_implementation_plan(
             validated_plan,

--- a/tests/test_semantic_validation_workflow.py
+++ b/tests/test_semantic_validation_workflow.py
@@ -1,5 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
+
+from agent_s3.tools.validation_result import ValidationResult
 import json
 import tempfile
 import shutil
@@ -410,7 +412,11 @@ class TestSemanticValidationWorkflow(unittest.TestCase):
             'agent_s3.feature_group_processor.FeatureGroupProcessor._present_revalidation_results'
         ) as mock_present:
 
-            mock_validate.return_value = (invalid_plan["implementation_plan"], [validation_issue], True)
+            mock_validate.return_value = ValidationResult(
+                data=invalid_plan["implementation_plan"],
+                issues=[validation_issue],
+                needs_repair=True,
+            )
 
             result = self.processor.process_pre_planning_output(self.pre_planning_data, "Implement authentication")
             self.assertTrue(result["success"])
@@ -470,7 +476,11 @@ class TestSemanticValidationWorkflow(unittest.TestCase):
             'agent_s3.feature_group_processor.FeatureGroupProcessor._present_revalidation_results'
         ) as mock_present:
 
-            mock_validate.return_value = (invalid_plan["implementation_plan"], [], False)
+            mock_validate.return_value = ValidationResult(
+                data=invalid_plan["implementation_plan"],
+                issues=[],
+                needs_repair=False,
+            )
 
             result = self.processor.process_pre_planning_output(self.pre_planning_data, "Implement authentication")
             self.assertTrue(result["success"])


### PR DESCRIPTION
## Summary
- introduce `ValidationResult` dataclass
- refactor canonical, coherence and implementation validators to return `ValidationResult`
- update feature group processor and planner to handle new structure
- adjust tests for the new API

## Testing
- `pytest -q` *(fails: network access and environment issues)*