### PR TITLE
Implement WebSocket message size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Agent-S3 is not just a tool for automation; it is a partner in development that 
   - Message type-based routing and handlers
   - Fallback to file polling when WebSocket is unavailable
   - Authentication and secure message passing
+  - 64&nbsp;KiB message size limit enforced server-side
 - Advanced context management with:
   - Context registry with multiple providers that can be registered and queried
   - Framework-specific context adaptation for popular frameworks (React, Django, Flask, FastAPI, Express)
@@ -296,6 +297,7 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
   - `MAX_CLARIFICATION_ROUNDS` (optional, defaults to `3`) limits pre-planning clarification exchanges
   - `MAX_PREPLANNING_ATTEMPTS` (optional, defaults to `2`) sets the maximum number of retries when generating pre-planning data
   - `pre_planning_mode` selects `off`, `json`, or `enforced_json` workflow. See `docs/pre_planning_workflow.md` for details.
+  - `WEBSOCKET_MAX_MESSAGE_SIZE` (optional, defaults to `65536`) limits incoming WebSocket payloads
 
   Example `.env`:
 

--- a/agent_s3/communication/message_protocol.py
+++ b/agent_s3/communication/message_protocol.py
@@ -38,6 +38,7 @@ class MessageType(Enum):
     
     # Streaming message types
     THINKING = "thinking"
+    THINKING_INDICATOR = "thinking_indicator"
     STREAM_START = "stream_start"
     STREAM_CONTENT = "stream_content"
     STREAM_END = "stream_end"


### PR DESCRIPTION
## Summary
- enforce `max_size` limit when serving websocket connections
- reject oversized messages in `_handle_client`
- note websocket size limit in README
- add unit test for oversized messages
- support THINKING_INDICATOR message type

## Testing
- `pytest tests/test_enhanced_websocket_server.py::TestEnhancedWebSocketServer::test_oversized_message_rejected -q`
- `pytest -q` *(fails: requests.exceptions.ProxyError and other errors)*