### PR TITLE
Refactor design handoff into ImplementationManager

### DIFF
--- a/agent_s3/enhanced_scratchpad_manager.py
+++ b/agent_s3/enhanced_scratchpad_manager.py
@@ -251,8 +251,11 @@ class EnhancedScratchpadManager:
                 sessions = {}
                 for file in session_files:
                     # Extract session ID from filename pattern scratchpad_YYYYMMDD_HHMMSS_part*.log
-                    match = re.search(r'scratchpad_(\d{8}_\d{6})_part\d+
-                        \.log', os.path.basename(file))                    if match:
+                    match = re.search(
+                        r"scratchpad_(\d{8}_\d{6})_part\d+\.log",
+                        os.path.basename(file),
+                    )
+                    if match:
                         session_id = match.group(1)
                         if session_id not in sessions:
                             sessions[session_id] = []
@@ -538,8 +541,9 @@ class EnhancedScratchpadManager:
 
         truncated_response = response[:response_max_len]
         if len(response) > response_max_len:
-            truncated_response +
-                = f"... [truncated, {len(response) - response_max_len} chars omitted]"
+            truncated_response += (
+                f"... [truncated, {len(response) - response_max_len} chars omitted]"
+            )
         # Determine status
         status = "success"
         if error:

--- a/agent_s3/error_handler.py
+++ b/agent_s3/error_handler.py
@@ -310,12 +310,12 @@ def retry(
                             attempt=attempt,
                             max_attempts=max_attempts,
                         )
-                        logger.warning("%s", {log_message}: {exc})
+                        logger.warning("%s: %s", log_message, exc)
                     else:
                         log_message = failure_message.format(
                             operation=operation, max_attempts=max_attempts
                         )
-                        logger.error("%s", {log_message}: {exc})
+                        logger.error("%s: %s", log_message, exc)
 
             # Re-raise the last exception
             if last_exception:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,5 +48,17 @@ class TestCliProcessCommand(unittest.TestCase):
         mock_print.assert_called_once_with("Unknown command: /unknown")
         self.mock_coordinator.execute_terminal_command.assert_not_called()
 
+    @patch('builtins.print')
+    def test_continue_command(self, mock_print):
+        self.mock_coordinator.execute_continue.return_value = {
+            "success": True,
+            "message": "All implementation tasks completed."
+        }
+
+        process_command(self.mock_coordinator, "/continue")
+
+        self.mock_coordinator.execute_continue.assert_called_once_with("implementation")
+        mock_print.assert_any_call("All implementation tasks completed.")
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_design_to_implementation.py
+++ b/tests/test_design_to_implementation.py
@@ -142,19 +142,20 @@ def test_execute_design_facade(coordinator):
 
 
 def test_start_pre_planning_from_design(tmp_path, coordinator):
-    """Verify tasks parsed from design trigger planning with from_design flag."""
+    """Verify design implementation delegates to ImplementationManager."""
     design_file = tmp_path / "design.txt"
     design_file.write_text(
         "1. Setup environment\n2. Build feature\n3. Write tests"
     )
 
-    coordinator.run_task = MagicMock()
+    coordinator.implementation_manager = MagicMock()
+    coordinator.implementation_manager.start_implementation.return_value = {
+        "success": True
+    }
 
-    coordinator.start_pre_planning_from_design(str(design_file))
+    result = coordinator.start_pre_planning_from_design(str(design_file))
 
-    expected_calls = [
-        call(task="Setup environment", from_design=True),
-        call(task="Build feature", from_design=True),
-        call(task="Write tests", from_design=True),
-    ]
-    coordinator.run_task.assert_has_calls(expected_calls)
+    coordinator.implementation_manager.start_implementation.assert_called_once_with(
+        str(design_file)
+    )
+    assert result["success"] is True


### PR DESCRIPTION
## Summary
- delegate design file execution to ImplementationManager
- extract structured tasks from design files
- fix logging format strings
- update CLI tests for /continue
- update design to implementation test

## Testing
- `pytest tests/test_design_to_implementation.py::test_start_pre_planning_from_design tests/test_cli.py::TestCliProcessCommand::test_continue_command -q` *(fails: SyntaxError in planner_json_enforced.py)*