### PR TITLE
Add shell quoting utility for extension

### DIFF
--- a/tests/test_shell_quote.py
+++ b/tests/test_shell_quote.py
@@ -1,0 +1,27 @@
+import json
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+NODE_SCRIPT = (
+    "const { quote } = require('./vscode/shellQuote.js');"
+    "const args = JSON.parse(process.argv[1]);"
+    "console.log(quote(args));"
+)
+
+def run_quote(args):
+    result = subprocess.check_output(
+        ['node', '-e', NODE_SCRIPT, json.dumps(args)], cwd=REPO_ROOT
+    )
+    return result.decode().strip()
+
+def test_quote_simple():
+    assert run_quote(["simple"]) == "'simple'"
+
+def test_quote_spaces():
+    assert run_quote(["hello world"]) == "'hello world'"
+
+def test_quote_single_quote():
+    assert run_quote(["O'Reilly"]) == "'O'\\''Reilly'"
+

--- a/vscode/extension.ts
+++ b/vscode/extension.ts
@@ -4,6 +4,7 @@ import { InteractiveWebviewManager } from "./webview-ui-loader";
 import { BackendConnection } from "./backend-connection";
 import { initializeWebSocketTester } from "./websocket-tester";
 import { registerPerformanceTestCommand } from "./websocket-performance-test";
+import { quote } from "./shellQuote";
 
 /**
  * Extension activation point
@@ -178,11 +179,11 @@ export function activate(context: vscode.ExtensionContext) {
       // Show the terminal
       terminal.show();
 
-      // Escape quotes in the request
-      const safeRequest = request.replace(/"/g, '\\"');
+      // Quote the request to prevent shell injection
+      const safeRequest = quote([request]);
 
       // Send the request to the CLI
-      terminal.sendText(`python -m agent_s3.cli "${safeRequest}"`);
+      terminal.sendText(`python -m agent_s3.cli ${safeRequest}`);
 
       // Show notification
       vscode.window.showInformationMessage(`Processing request: ${request}`);

--- a/vscode/shellQuote.js
+++ b/vscode/shellQuote.js
@@ -1,0 +1,16 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.quote = quote;
+/**
+ * Utility to safely quote shell arguments.
+ */
+function quote(args) {
+    return args
+        .map((arg) => {
+        if (arg === '') {
+            return "''";
+        }
+        return `'${arg.replace(/'/g, `'\\''`)}'`;
+    })
+        .join(' ');
+}

--- a/vscode/shellQuote.ts
+++ b/vscode/shellQuote.ts
@@ -1,0 +1,13 @@
+/**
+ * Utility to safely quote shell arguments.
+ */
+export function quote(args: string[]): string {
+  return args
+    .map((arg) => {
+      if (arg === '') {
+        return "''";
+      }
+      return `'${arg.replace(/'/g, `'\\''`)}'`;
+    })
+    .join(' ');
+}


### PR DESCRIPTION
## Summary
- add new `shellQuote` utility to sanitize shell arguments
- use the new quoting in `makeChangeRequest`
- add tests to verify quoting with special characters

## Testing
- `pytest tests/test_shell_quote.py -q`
- `npm run typecheck` *(fails: tsc help output)*