### PR TITLE
Fix chat history timestamp handling

### DIFF
--- a/vscode/extension.ts
+++ b/vscode/extension.ts
@@ -197,14 +197,34 @@ export function activate(context: vscode.ExtensionContext) {
     const panel = interactiveWebviewManager.createOrShowPanel();
 
     // Load persisted chat history from workspace state
-    const messageHistory: any[] = context.workspaceState.get(
+    const rawHistory: any[] = context.workspaceState.get(
       "agent-s3.chatHistory",
       [],
     );
 
+    const messageHistory: any[] = rawHistory.map((msg) => ({
+      ...msg,
+      timestamp:
+        msg.timestamp && typeof msg.timestamp === "string"
+          ? new Date(msg.timestamp)
+          : msg.timestamp instanceof Date
+          ? msg.timestamp
+          : new Date(),
+    }));
+
     // Save history when the panel is disposed
     panel.onDidDispose(() => {
-      context.workspaceState.update("agent-s3.chatHistory", messageHistory);
+      const serializedHistory = messageHistory.map((msg) => ({
+        ...msg,
+        timestamp:
+          msg.timestamp instanceof Date
+            ? msg.timestamp.toISOString()
+            : msg.timestamp,
+      }));
+      context.workspaceState.update(
+        "agent-s3.chatHistory",
+        serializedHistory,
+      );
     });
 
     // Set up message handler for chat and interactive messages
@@ -248,12 +268,22 @@ export function activate(context: vscode.ExtensionContext) {
             id: `user-${Date.now()}`,
             type: "user",
             content: message.text,
-            timestamp: new Date(),
+            timestamp: new Date().toISOString(),
             isComplete: true,
           });
 
           // Persist updated history
-          context.workspaceState.update("agent-s3.chatHistory", messageHistory);
+          const serializedHistory = messageHistory.map((msg) => ({
+            ...msg,
+            timestamp:
+              msg.timestamp instanceof Date
+                ? msg.timestamp.toISOString()
+                : msg.timestamp,
+          }));
+          context.workspaceState.update(
+            "agent-s3.chatHistory",
+            serializedHistory,
+          );
 
           // Forward the message to the backend for processing
           backendConnection.sendMessage({

--- a/vscode/types/message.d.ts
+++ b/vscode/types/message.d.ts
@@ -216,7 +216,7 @@ export interface ChatMessage {
   id: string;
   type: "user" | "agent" | "system";
   content: string;
-  timestamp: Date;
+  timestamp: Date | string;
   isComplete: boolean;
 }
 

--- a/vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -20,7 +20,7 @@ interface ChatMessage {
   id: string;
   type: 'user' | 'agent' | 'system';
   content: string;
-  timestamp: Date;
+  timestamp: Date | string;
   isComplete: boolean;
 }
 
@@ -368,7 +368,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ messages: externalMessages =
               {renderMessageContent(message.content)}
             </div>
             <div className="message-timestamp">
-              {message.timestamp.toLocaleTimeString()}
+              {new Date(message.timestamp).toLocaleTimeString()}
             </div>
           </div>
         ))}


### PR DESCRIPTION
## Summary
- parse chat history timestamps when opening the chat
- serialize timestamps on save
- store ISO timestamps in message history
- allow timestamps to be strings in the chat view
- render timestamps safely regardless of type

## Testing
- `npm run typecheck`
- `ruff check agent_s3` *(fails: SyntaxError)*
- `mypy agent_s3` *(fails: unexpected indent)*
- `pytest` *(fails: 54 errors)*