### PR TITLE
Add chat history persistence

### DIFF
--- a/vscode/extension.ts
+++ b/vscode/extension.ts
@@ -202,10 +202,7 @@ export function activate(context: vscode.ExtensionContext) {
       [],
     );
 
-    // Save history when the panel is disposed
-    panel.onDidDispose(() => {
-      context.workspaceState.update("agent-s3.chatHistory", messageHistory);
-    });
+    // No explicit save on dispose; history is persisted as messages arrive
 
     // Set up message handler for chat and interactive messages
     interactiveWebviewManager.setMessageHandler((message: any) => {


### PR DESCRIPTION
## Summary
- update `BackendConnection` to store completed agent messages
- keep chat history when the webview closes

## Testing
- `npx tsc --noEmit -p vscode/tsconfig.json` *(fails: Cannot find namespace 'vscode')*
- `pytest -k VSCodeIntegrationShutdown -q` *(fails: multiple errors during collection)*