### PR TITLE
Add chat history events in VS Code extension

### DIFF
--- a/vscode/types/message.d.ts
+++ b/vscode/types/message.d.ts
@@ -221,6 +221,17 @@ export interface ChatMessage {
 }
 
 /**
+ * Entry representing a chat message persisted in history
+ */
+export interface ChatHistoryEntry {
+  id: string;
+  type: "user" | "agent" | "system";
+  content: string;
+  timestamp: Date | string;
+  isComplete: boolean;
+}
+
+/**
  * Stream state interface
  */
 export interface StreamState {


### PR DESCRIPTION
## Summary
- add `ChatHistoryEntry` type
- emit `onDidPersistChatMessage` from `BackendConnection`
- persist chat messages on stream end
- update chat window to listen for persisted messages

## Testing
- `npm run compile` *(fails: Cannot find namespace 'vscode')*
- `pytest -q` *(fails: 100 errors during collection)*