### PR TITLE
Fix complexity metrics and fallback outputs

### DIFF
--- a/agent_s3/complexity_analyzer.py
+++ b/agent_s3/complexity_analyzer.py
@@ -165,4 +165,8 @@ class ComplexityAnalyzer:
         else:
             result["advice"] = "This task has manageable complexity and can proceed without special handling."
 
+        # Provide standardized key names for consumers
+        result["complexity_score"] = result["score"]
+        result["complexity_factors"] = result["factors"]
+
         return result

--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -125,26 +125,32 @@ def create_fallback_pre_planning_output(task_description: str) -> Dict[str, Any]
     Returns:
         Dictionary with basic pre-planning structure
     """
+    feature = {
+        "name": "Main Task Implementation",
+        "description": task_description,
+        "files_affected": [],
+        "test_requirements": {
+            "unit_tests": [],
+            "integration_tests": [],
+            "property_based_tests": [],
+            "acceptance_tests": [],
+            "test_strategy": {
+                "coverage_goal": "80%",
+                "ui_test_approach": "manual",
+            },
+        },
+        "dependencies": [],
+        "risks": [],
+        "acceptance_criteria": [],
+    }
+
     return {
         "original_request": task_description,
-        "features": [
+        "feature_groups": [
             {
-                "name": "Main Task Implementation",
-                "description": task_description,
-                "files_affected": [],
-                "test_requirements": {
-                    "unit_tests": [],
-                    "integration_tests": [],
-                    "property_based_tests": [],
-                    "acceptance_tests": [],
-                    "test_strategy": {
-                        "coverage_goal": "80%",
-                        "ui_test_approach": "manual"
-                    }
-                },
-                "dependencies": [],
-                "risks": [],
-                "acceptance_criteria": []
+                "group_name": "Default Group",
+                "group_description": "Automatically generated fallback group",
+                "features": [feature],
             }
         ],
         "dependencies": [],
@@ -152,8 +158,8 @@ def create_fallback_pre_planning_output(task_description: str) -> Dict[str, Any]
         "acceptance_tests": [],
         "test_strategy": {
             "coverage_goal": "80%",
-            "ui_test_approach": "manual"
-        }
+            "ui_test_approach": "manual",
+        },
     }
 
 # Alias used by tests

--- a/agent_s3/tests/integration_test_complexity.py
+++ b/agent_s3/tests/integration_test_complexity.py
@@ -68,11 +68,11 @@ def main():
 
     # Print the results
     print("===== Complexity Assessment Results =====")
-    print(f"Overall Complexity Score: {result['score']:.1f}/100")
+    print(f"Overall Complexity Score: {result['complexity_score']:.1f}/100")
     print(f"Complexity Level: {result['level']}/5")
     print(f"Is Complex Task: {result['is_complex']}")
     print("\nContributing Factors:")
-    for factor, score in result['factors'].items():
+    for factor, score in result['complexity_factors'].items():
         print(f"  - {factor}: {score:.1f}")
 
     print("\nJustification:")

--- a/agent_s3/tests/test_complexity_analyzer.py
+++ b/agent_s3/tests/test_complexity_analyzer.py
@@ -68,8 +68,10 @@ class TestComplexityAnalyzer(unittest.TestCase):
 
     def test_low_complexity_assessment(self):
         """Test that low complexity tasks are assessed correctly."""
-        result = self.analyzer.assess_complexity(self.low_complexity_data, "Update the button styling")
-        self.assertLess(result["score"], 40)
+        result = self.analyzer.assess_complexity(
+            self.low_complexity_data, "Update the button styling"
+        )
+        self.assertLess(result["complexity_score"], 40)
         self.assertLessEqual(result["level"], 2)
         self.assertFalse(result["is_complex"])
 
@@ -79,7 +81,7 @@ class TestComplexityAnalyzer(unittest.TestCase):
             self.high_complexity_data,
             "Implement secure authentication system with OAuth2 integration and database transaction support"
         )
-        self.assertGreater(result["score"], 40)
+        self.assertGreater(result["complexity_score"], 40)
         self.assertGreaterEqual(result["level"], 3)
         self.assertTrue(result["is_complex"])
 
@@ -90,8 +92,8 @@ class TestComplexityAnalyzer(unittest.TestCase):
         result = self.analyzer.assess_complexity(self.low_complexity_data, security_description)
 
         # Ensure security factor is present and non-zero
-        self.assertIn("security_sensitivity", result["factors"])
-        self.assertGreater(result["factors"]["security_sensitivity"], 0)
+        self.assertIn("security_sensitivity", result["complexity_factors"])
+        self.assertGreater(result["complexity_factors"]["security_sensitivity"], 0)
 
 if __name__ == "__main__":
     unittest.main()

--- a/agent_s3/tests/test_complexity_integration.py
+++ b/agent_s3/tests/test_complexity_integration.py
@@ -12,11 +12,13 @@ def assess_complexity_with_threshold(data, task_description, threshold=60):
     """Assess complexity and raise an error if it exceeds the threshold."""
     result = analyzer.assess_complexity(data, task_description)
 
-    if result["score"] > threshold:
+    if result["complexity_score"] > threshold:
         raise ComplexityError(
-            message=f"Task complexity exceeds threshold ({result['score']:.1f} > {threshold})",
-            complexity_score=result["score"],
-            complexity_factors=result["factors"]
+            message=(
+                f"Task complexity exceeds threshold ({result['complexity_score']:.1f} > {threshold})"
+            ),
+            complexity_score=result["complexity_score"],
+            complexity_factors=result["complexity_factors"]
         )
 
     return {"success": True, "complexity": result}
@@ -55,4 +57,6 @@ print(f"Success: {result['success']}")
 print(f"Error Type: {result.get('error_type')}")
 print(f"Message: {result['message']}")
 print(f"Complexity Score: {result['details'].get('complexity_score', 'N/A')}")
-print(f"Complexity Factors: {result['details'].get('complexity_factors', 'N/A')}")
+print(
+    f"Complexity Factors: {result['details'].get('complexity_factors', 'N/A')}"
+)

--- a/tests/legacy/test_pre_planner_json_enforced.py
+++ b/tests/legacy/test_pre_planner_json_enforced.py
@@ -196,9 +196,11 @@ class TestPrePlannerJsonEnforced:
         fallback = create_fallback_json(request)
 
         assert fallback["original_request"] == request
-        assert isinstance(fallback["features"], list)
-        assert len(fallback["features"]) > 0
-        assert "files_affected" in fallback["features"][0]
+        assert "feature_groups" in fallback
+        assert isinstance(fallback["feature_groups"], list)
+        assert len(fallback["feature_groups"]) > 0
+        assert "features" in fallback["feature_groups"][0]
+        assert len(fallback["feature_groups"][0]["features"]) > 0
 
         # Validate the fallback structure
         is_valid, _ = validate_json_schema(fallback)
@@ -765,7 +767,12 @@ def test_call_pre_planner_with_enforced_json_returns_fallback(mock_fallback, moc
      mock_process):    """Ensure fallback JSON is returned after all retries fail."""
     mock_params.return_value = {}
     mock_process.return_value = (False, None)
-    fallback = {"original_request": "Task", "features": []}
+    fallback = {
+        "original_request": "Task",
+        "feature_groups": [
+            {"group_name": "Default Group", "group_description": "", "features": []}
+        ],
+    }
     mock_fallback.return_value = fallback
 
     router = MagicMock()

--- a/tests/test_coordinator_json_preplanning.py
+++ b/tests/test_coordinator_json_preplanning.py
@@ -175,7 +175,8 @@ class TestCoordinatorJsonPrePlanning:
         coordinator.config = MagicMock()
         coordinator.config.config = {"pre_planning_mode": "enforced_json"}
         coordinator.pre_planner.assess_complexity.return_value = {
-            "score": 60,
+            "complexity_score": 60,
+            "complexity_factors": {},
             "is_complex": True,
         }
 

--- a/tests/test_coordinator_phases.py
+++ b/tests/test_coordinator_phases.py
@@ -161,7 +161,8 @@ def test_initialize_workspace_exception(coordinator):
 def test_pre_planning_phase_normal_flow(coordinator):
     """Test normal flow of pre-planning phase using the new workflow."""
     coordinator.pre_planner.assess_complexity.return_value = {
-        "score": 150.0,
+        "complexity_score": 150.0,
+        "complexity_factors": {},
         "is_complex": False,
     }
     with patch(
@@ -184,7 +185,8 @@ def test_pre_planning_phase_normal_flow(coordinator):
 def test_pre_planning_phase_high_complexity(coordinator):
     """Test pre-planning phase identifies complex tasks."""
     coordinator.pre_planner.assess_complexity.return_value = {
-        "score": 400.0,
+        "complexity_score": 400.0,
+        "complexity_factors": {},
         "is_complex": True,
     }
     with patch(
@@ -263,7 +265,11 @@ def test_pre_planning_complete_failure(coordinator):
 
 def test_pre_planning_phase_updated_requirements(coordinator):
     """Test pre-planning returns updated test requirements."""
-    coordinator.pre_planner.assess_complexity.return_value = {"score": 200.0, "is_complex": False}
+    coordinator.pre_planner.assess_complexity.return_value = {
+        "complexity_score": 200.0,
+        "complexity_factors": {},
+        "is_complex": False,
+    }
     with patch(
         "agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json"
     ) as mock_call:
@@ -287,7 +293,11 @@ def test_pre_planning_phase_updated_requirements(coordinator):
 
 def test_pre_planning_phase_updated_complexity(coordinator):
     """Test updated complexity scoring is returned."""
-    coordinator.pre_planner.assess_complexity.return_value = {"score": 55, "is_complex": True}
+    coordinator.pre_planner.assess_complexity.return_value = {
+        "complexity_score": 55,
+        "complexity_factors": {},
+        "is_complex": True,
+    }
     with patch(
         "agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json"
     ) as mock_call:
@@ -307,7 +317,11 @@ def test_pre_planning_phase_updated_complexity(coordinator):
 
 def test_pre_planning_phase_with_caching(coordinator):
     """Test pre-planning phase with caching applied."""
-    coordinator.pre_planner.assess_complexity.return_value = {"score": 55, "is_complex": True}
+    coordinator.pre_planner.assess_complexity.return_value = {
+        "complexity_score": 55,
+        "complexity_factors": {},
+        "is_complex": True,
+    }
     with patch(
         "agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json"
     ) as mock_call:


### PR DESCRIPTION
## Summary
- return `complexity_score` and `complexity_factors` from `ComplexityAnalyzer`
- update fallback JSON structure to include a default `feature_groups` entry
- adjust tests to use new complexity keys and updated fallback structure

## Testing
- `ruff check agent_s3` *(fails: many syntax errors in repository)*
- `mypy agent_s3` *(fails: unexpected indent in summariser.py)*
- `pytest -q` *(fails: 100 errors during collection)*