### PR TITLE
Centralize chat history key

### DIFF
--- a/vscode/backend-connection.ts
+++ b/vscode/backend-connection.ts
@@ -9,6 +9,7 @@ import { InteractiveWebviewManager } from "./webview-ui-loader";
 import { ChatHistoryEntry } from "./types/message";
 import * as fs from "fs";
 import * as path from "path";
+import { CHAT_HISTORY_KEY } from "./constants";
 
 /**
  * Manages the connection to the Agent-S3 backend, integrating terminal and WebSocket communication
@@ -416,7 +417,7 @@ export class BackendConnection implements vscode.Disposable {
     }
 
     const history = this.workspaceState.get<ChatHistoryEntry[]>(
-      "agent-s3.chatHistory",
+      CHAT_HISTORY_KEY,
       [],
     );
 
@@ -429,7 +430,7 @@ export class BackendConnection implements vscode.Disposable {
     };
 
     history.push(serialized);
-    this.workspaceState.update("agent-s3.chatHistory", history);
+    this.workspaceState.update(CHAT_HISTORY_KEY, history);
 
     this.chatHistoryEmitter.fire(message);
   }

--- a/vscode/constants.ts
+++ b/vscode/constants.ts
@@ -1,0 +1,7 @@
+// constants.ts
+// Centralized constants for the VS Code extension.
+
+/**
+ * Workspace state key for storing chat history.
+ */
+export const CHAT_HISTORY_KEY = "agent-s3.chatHistory";

--- a/vscode/extension.ts
+++ b/vscode/extension.ts
@@ -6,6 +6,7 @@ import { initializeWebSocketTester } from "./websocket-tester";
 import { registerPerformanceTestCommand } from "./websocket-performance-test";
 import { quote } from "./shellQuote";
 import { ChatHistoryEntry } from "./types/message";
+import { CHAT_HISTORY_KEY } from "./constants";
 
 /**
  * Extension activation point
@@ -200,7 +201,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Load persisted chat history from workspace state
     const rawHistory: any[] = context.workspaceState.get(
-      "agent-s3.chatHistory",
+      CHAT_HISTORY_KEY,
       [],
     );
 
@@ -228,7 +229,7 @@ export function activate(context: vscode.ExtensionContext) {
             : msg.timestamp,
       }));
       context.workspaceState.update(
-        "agent-s3.chatHistory",
+        CHAT_HISTORY_KEY,
         serializedHistory,
       );
       historyListener.dispose();
@@ -288,7 +289,7 @@ export function activate(context: vscode.ExtensionContext) {
                 : msg.timestamp,
           }));
           context.workspaceState.update(
-            "agent-s3.chatHistory",
+            CHAT_HISTORY_KEY,
             serializedHistory,
           );
 


### PR DESCRIPTION
## Summary
- add a constants module for chat history key
- import constant in backend connection and extension

## Testing
- `npm --prefix vscode run lint`
- `npm --prefix vscode run compile`
- `pytest -k constants`