### PR TITLE
Add offline queue constant

### DIFF
--- a/vscode/backend-connection.ts
+++ b/vscode/backend-connection.ts
@@ -7,6 +7,7 @@ import * as vscode from "vscode";
 import { WebSocketClient } from "./websocket-client";
 import { InteractiveWebviewManager } from "./webview-ui-loader";
 import { ChatHistoryEntry } from "./types/message";
+import { OFFLINE_QUEUE_KEY } from "./constants";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -40,7 +41,7 @@ export class BackendConnection implements vscode.Disposable {
     this.setupMessageHandlers();
 
     if (this.workspaceState) {
-      this.offlineQueue = this.workspaceState.get("agent-s3.offlineQueue", []);
+      this.offlineQueue = this.workspaceState.get(OFFLINE_QUEUE_KEY, []);
     }
   }
 
@@ -403,7 +404,7 @@ export class BackendConnection implements vscode.Disposable {
    */
   private persistOfflineQueue(): void {
     if (this.workspaceState) {
-      this.workspaceState.update("agent-s3.offlineQueue", this.offlineQueue);
+      this.workspaceState.update(OFFLINE_QUEUE_KEY, this.offlineQueue);
     }
   }
 

--- a/vscode/constants.ts
+++ b/vscode/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * Common constants used across the Agent-S3 VS Code extension.
+ */
+export const OFFLINE_QUEUE_KEY = "agent-s3.offlineQueue";
+


### PR DESCRIPTION
## Summary
- create `OFFLINE_QUEUE_KEY` constant
- replace inline key usages in the backend connection with the constant

## Testing
- `npm run compile` *(fails: Cannot find namespace 'vscode')*
- `pytest` *(fails: 100 errors during collection)*