### PR TITLE
Add npm install step before TypeScript tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
    - Open the `vscode` folder in VS Code
    - Press `F5` to launch the extension in Extension Development Host, or
    - Build and install the `.vsix` via `vsce package`/`Extensions: Install from VSIX...`
+   - Run `npm install` in the `vscode` directory before executing `npm run lint` or `npx tsc`
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- update `README` with instructions to run `npm install` in the `vscode` folder before linting or compiling the extension

## Testing
- `pytest -q`
- `mypy agent_s3`
- `ruff check agent_s3`
- `npm install` (fails due to missing network access)
- `npm run lint` *(fails: ESLint couldn't find plugin)*
- `npx tsc` *(fails: cannot find namespace 'vscode')*