### PR TITLE
Centralize chat history key constant

### DIFF
--- a/vscode/backend-connection.ts
+++ b/vscode/backend-connection.ts
@@ -11,6 +11,11 @@ import * as fs from "fs";
 import * as path from "path";
 
 /**
+ * Workspace state key used to persist chat history.
+ */
+export const CHAT_HISTORY_KEY = "agent-s3.chatHistory";
+
+/**
  * Manages the connection to the Agent-S3 backend, integrating terminal and WebSocket communication
  */
 export class BackendConnection implements vscode.Disposable {
@@ -416,7 +421,7 @@ export class BackendConnection implements vscode.Disposable {
     }
 
     const history = this.workspaceState.get<ChatHistoryEntry[]>(
-      "agent-s3.chatHistory",
+      CHAT_HISTORY_KEY,
       [],
     );
 
@@ -429,7 +434,7 @@ export class BackendConnection implements vscode.Disposable {
     };
 
     history.push(serialized);
-    this.workspaceState.update("agent-s3.chatHistory", history);
+    this.workspaceState.update(CHAT_HISTORY_KEY, history);
 
     this.chatHistoryEmitter.fire(message);
   }

--- a/vscode/extension.ts
+++ b/vscode/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import { InteractiveWebviewManager } from "./webview-ui-loader";
-import { BackendConnection } from "./backend-connection";
+import { BackendConnection, CHAT_HISTORY_KEY } from "./backend-connection";
 import { initializeWebSocketTester } from "./websocket-tester";
 import { registerPerformanceTestCommand } from "./websocket-performance-test";
 import { quote } from "./shellQuote";
@@ -200,7 +200,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Load persisted chat history from workspace state
     const rawHistory: any[] = context.workspaceState.get(
-      "agent-s3.chatHistory",
+      CHAT_HISTORY_KEY,
       [],
     );
 
@@ -227,10 +227,7 @@ export function activate(context: vscode.ExtensionContext) {
             ? msg.timestamp.toISOString()
             : msg.timestamp,
       }));
-      context.workspaceState.update(
-        "agent-s3.chatHistory",
-        serializedHistory,
-      );
+      context.workspaceState.update(CHAT_HISTORY_KEY, serializedHistory);
       historyListener.dispose();
     });
 
@@ -287,10 +284,7 @@ export function activate(context: vscode.ExtensionContext) {
                 ? msg.timestamp.toISOString()
                 : msg.timestamp,
           }));
-          context.workspaceState.update(
-            "agent-s3.chatHistory",
-            serializedHistory,
-          );
+          context.workspaceState.update(CHAT_HISTORY_KEY, serializedHistory);
 
           // Forward the message to the backend for processing
           backendConnection.sendMessage({


### PR DESCRIPTION
## Summary
- export `CHAT_HISTORY_KEY` from the backend connection
- import the constant in the extension
- use the constant instead of the hard-coded key

## Testing
- `npm run compile` *(fails: Cannot find namespace 'vscode' because the container lacks VS Code types)*
- `pytest tests/test_shell_quote.py`