### PR TITLE
Fix fallback prompt handling and add unit test

### DIFF
--- a/agent_s3/llm_utils.py
+++ b/agent_s3/llm_utils.py
@@ -45,8 +45,13 @@ if cache:
     cache.init()
 
 
-def call_llm_via_supabase(prompt: str, github_token: str, config: Dict[str, Any],
-     timeout: Optional[float] = None) -> str:    """Call a remote LLM via Supabase edge function.
+def call_llm_via_supabase(
+    prompt: str,
+    github_token: str,
+    config: Dict[str, Any],
+    timeout: Optional[float] = None,
+) -> str:
+    """Call a remote LLM via Supabase edge function.
 
     Args:
         prompt: Prompt text to send to the remote LLM service.
@@ -309,8 +314,10 @@ def call_llm_with_retry(
     last_error_details = None
 
     for attempt in range(max_retries):
-        scratchpad_manager.log("LLM Utils", f"Attempt {attempt +
-             1}/{max_retries} - Calling LLM API via {method_name}")
+        scratchpad_manager.log(
+            "LLM Utils",
+            f"Attempt {attempt + 1}/{max_retries} - Calling LLM API via {method_name}"
+        )
         try:
             # Clone prompt_data and call LLM via GPTCache-wrapped method
             current_prompt_data = prompt_data.copy()
@@ -388,12 +395,14 @@ def call_llm_with_retry(
                     # Find the user message (typically the last one) and prepend our fallback text
                     for i, msg in enumerate(fallback_prompt_data['messages']):
                         if msg.get('role', '') == 'user':
-                            fallback_prompt_data['messages'][i]['content'] = fallback_prompt +
-                                 "\n\n" + msg['content']                            break
+                            fallback_prompt_data['messages'][i]['content'] = (
+                                fallback_prompt + "\n\n" + msg['content']
+                            )
+                            break
             elif 'prompt' in fallback_prompt_data:
                 # Simple prompt-based API
-                fallback_prompt_data['prompt'] = fallback_prompt + "\n\n" +
-                     fallback_prompt_data['prompt']            else:
+                fallback_prompt_data['prompt'] = fallback_prompt + "\n\n" + fallback_prompt_data['prompt']
+            else:
                 # If we can't find a standard key, just add our own
                 fallback_prompt_data['fallback_prefix'] = fallback_prompt
 

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -1,8 +1,17 @@
 import json
+import requests
+import sys
+import types
 
 import pytest
 
-from agent_s3.llm_utils import call_llm_via_supabase
+# Provide a minimal progress_tracker to satisfy llm_utils import
+sys.modules.setdefault(
+    "agent_s3.progress_tracker",
+    types.SimpleNamespace(progress_tracker=lambda *a, **k: None),
+)
+
+from agent_s3.llm_utils import call_llm_via_supabase, call_llm_with_retry
 
 
 class DummyResponse:
@@ -81,3 +90,38 @@ def test_invalid_supabase_url_scheme(monkeypatch):
 
     with pytest.raises(ValueError):
         call_llm_via_supabase("hi", "tok", cfg)
+
+
+def test_call_llm_with_retry_fallback_executes():
+    class DummyLLM:
+        def __init__(self):
+            self.calls = []
+
+        def generate(self, prompt_data):
+            self.calls.append(prompt_data)
+            # Return success only when the fallback prefix is present
+            prompt = prompt_data.get("prompt", "")
+            if prompt.startswith("Previous attempt failed"):
+                return {"response": "ok"}
+            raise requests.exceptions.Timeout("fail")
+
+    class DummyScratchpad:
+        def log(self, *_args, **_kwargs):
+            pass
+
+    client = DummyLLM()
+    scratch = DummyScratchpad()
+    config = {
+        "llm_default_timeout": 0,
+        "llm_max_retries": 1,
+        "llm_initial_backoff": 0,
+        "llm_backoff_factor": 1,
+        "llm_fallback_strategy": "retry_simplified",
+    }
+    prompt_data = {"prompt": "hello"}
+
+    result = call_llm_with_retry(client, "generate", prompt_data, config, scratch, "hello")
+
+    assert result["success"] is True
+    assert result.get("used_fallback") is True
+    assert len(client.calls) == 2


### PR DESCRIPTION
## Summary
- clean up fallback prompt injection logic and remove stray break
- update log statement formatting
- fix call_llm_via_supabase function layout for clarity
- add unit test covering fallback path for call_llm_with_retry

## Testing
- `pytest tests/test_llm_utils.py::test_call_llm_with_retry_fallback_executes -q`