### PR TITLE
Add minimal vscode typings

### DIFF
--- a/vscode/stubs.d.ts
+++ b/vscode/stubs.d.ts
@@ -23,10 +23,16 @@ declare module "ws" {
     readyState: number;
     on(event: string, listener: (...args: any[]) => void): void;
     send(data: any): void;
+    close(code?: number, reason?: string): void;
   }
   type RawData = any;
 }
 interface Buffer {}
+declare const Buffer: {
+  new(...args: any[]): Buffer;
+  from(input: any): Buffer;
+  isBuffer(input: any): boolean;
+};
 namespace NodeJS {
   type Timeout = any;
 }

--- a/vscode/types/node/index.d.ts
+++ b/vscode/types/node/index.d.ts
@@ -11,6 +11,10 @@ declare module "path" {
 }
 
 interface Buffer {}
+declare const Buffer: {
+  new(...args: any[]): Buffer;
+  from(input: string | any[] | ArrayBuffer | SharedArrayBuffer): Buffer;
+};
 
 declare namespace NodeJS {
   interface Timeout {}

--- a/vscode/types/vscode/index.d.ts
+++ b/vscode/types/vscode/index.d.ts
@@ -1,4 +1,51 @@
+/**
+ * Minimal VS Code API typings for offline usage.
+ * Provides loose 'any'-typed definitions so the extension can compile
+ * without the full @types/vscode package.
+ */
+
+declare namespace vscode {
+  interface Disposable {
+    dispose(): void;
+  }
+
+  class EventEmitter<T> {
+    event: any;
+    fire(data: T): void;
+    dispose(): void;
+  }
+
+  interface Memento {
+    get(key: string, defaultValue?: any): any;
+    update(key: string, value: any): Thenable<void>;
+    [key: string]: any;
+  }
+
+  interface ExtensionContext {
+    subscriptions: Disposable[];
+    workspaceState: Memento;
+    globalState: Memento;
+    [key: string]: any;
+  }
+
+  type Thenable<T> = Promise<T>;
+
+  const window: any;
+  const workspace: any;
+  const commands: any;
+  const env: any;
+  const Uri: any;
+  const ViewColumn: any;
+
+  // Type placeholders used within the extension
+  type OutputChannel = any;
+  type Terminal = any;
+  type Webview = any;
+  type WebviewPanel = any;
+  type StatusBarItem = any;
+  enum StatusBarAlignment { Left, Right }
+}
+
 declare module "vscode" {
-  const x: any;
-  export = x;
+  export = vscode;
 }


### PR DESCRIPTION
## Summary
- add lightweight vscode namespace definition
- stub Node Buffer and WebSocket with minimal APIs

## Testing
- `npx tsc --noEmit -p vscode/tsconfig.json` *(fails: Parameter 't' implicitly has an 'any' type)*