### PR TITLE
Refactor header redaction utilities

### DIFF
--- a/agent_s3/__init__.py
+++ b/agent_s3/__init__.py
@@ -20,6 +20,9 @@ _MODULE_MAP = {
     "PrePlanningValidator": "agent_s3.pre_planning_validator",
     "ComplexityAnalyzer": "agent_s3.complexity_analyzer",
     "DatabaseManager": "agent_s3.database_manager",
+    "redact_sensitive_headers": "agent_s3.security_utils",
+    "redact_auth_headers": "agent_s3.logging_utils",
+    # Backward compatibility for old import name
     "strip_sensitive_headers": "agent_s3.security_utils",
     "AgentS3BaseError": "agent_s3.pre_planning_errors",
     "PrePlanningError": "agent_s3.pre_planning_errors",

--- a/agent_s3/logging_utils.py
+++ b/agent_s3/logging_utils.py
@@ -7,10 +7,14 @@ _AUTH_HEADER_RE = re.compile(
 )
 
 
-def strip_sensitive_headers(message: str) -> str:
+def redact_auth_headers(message: str) -> str:
     """Redact Authorization header values in a log message.
 
     This prevents accidental exposure of secrets when logging exceptions
     that include HTTP headers.
     """
     return _AUTH_HEADER_RE.sub(lambda m: m.group(1) + "[REDACTED]" + m.group(3), message)
+
+
+# Backwards compatibility alias
+strip_sensitive_headers = redact_auth_headers

--- a/agent_s3/security_utils.py
+++ b/agent_s3/security_utils.py
@@ -5,7 +5,7 @@ from typing import MutableMapping
 SENSITIVE_HEADERS = {"authorization", "cookie", "set-cookie"}
 
 
-def strip_sensitive_headers(headers: MutableMapping[str, str]) -> Dict[str, str]:
+def redact_sensitive_headers(headers: MutableMapping[str, str]) -> Dict[str, str]:
     """Return a copy of ``headers`` with sensitive values redacted.
 
     This is useful when logging or debugging HTTP requests and responses.
@@ -25,3 +25,7 @@ def strip_sensitive_headers(headers: MutableMapping[str, str]) -> Dict[str, str]
         else:
             sanitized[name] = value
     return sanitized
+
+
+# Backwards compatibility alias
+strip_sensitive_headers = redact_sensitive_headers

--- a/tests/test_redaction_utils.py
+++ b/tests/test_redaction_utils.py
@@ -1,0 +1,23 @@
+from agent_s3.security_utils import redact_sensitive_headers
+from agent_s3.logging_utils import redact_auth_headers
+
+
+def test_redact_sensitive_headers():
+    headers = {
+        "Authorization": "token abc",
+        "Content-Type": "application/json",
+        "Cookie": "sessionid=1",
+    }
+    result = redact_sensitive_headers(headers)
+    assert result["Authorization"] == "[REDACTED]"
+    assert result["Cookie"] == "[REDACTED]"
+    assert result["Content-Type"] == "application/json"
+
+
+def test_redact_auth_headers():
+    token = "abc123"
+    msg = f"401 Unauthorized: Authorization: token {token}"
+    redacted = redact_auth_headers(msg)
+    assert token not in redacted
+    assert "[REDACTED]" in redacted
+


### PR DESCRIPTION
## Summary
- rename `strip_sensitive_headers` -> `redact_sensitive_headers`
- rename logging helper to `redact_auth_headers`
- export new utilities and alias old name for compatibility
- update auth module to use the new API
- test header redaction utilities

## Testing
- `pytest tests/test_redaction_utils.py tests/test_auth_redaction.py tests/test_auth_token_encryption.py -q`
- `mypy agent_s3` *(fails: agent_s3/ast_tools/summariser.py:20: error: unexpected indent)*
- `ruff check agent_s3` *(fails: 4156 errors in unrelated files)*