### PR TITLE
Fix lint and syntax issues

### DIFF
--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -653,7 +653,11 @@ def process_response(
         return True, data # Fully valid
     else:
         # Try to repair structure only if validation failed completely
-        logger.warning("%s", JSON schema validation failed: {validation_msg}. Attempting repair.)
+        logger.warning(
+            "%s",
+            "JSON schema validation failed: %s. Attempting repair.",
+            validation_msg,
+        )
         try:
             repaired = repair_json_structure(data)
             is_valid2, validation_msg2 = validate_json_schema(repaired)

--- a/agent_s3/prompt_moderator.py
+++ b/agent_s3/prompt_moderator.py
@@ -707,8 +707,10 @@ class PromptModerator:
             else:
                 print("Invalid input. Please enter 'y' or 'n'.")
 
-    def explain_plan_section(self, section_data: Dict[str, Any], section_path: str)
-         -> Optional[str]:        """Request an explanation for a section of the generated plan.
+    def explain_plan_section(
+        self, section_data: Dict[str, Any], section_path: str
+    ) -> Optional[str]:
+        """Request an explanation for a section of the generated plan.
 
         Args:
             section_data: The data for the section to explain

--- a/agent_s3/router_agent.py
+++ b/agent_s3/router_agent.py
@@ -81,10 +81,18 @@ def _load_llm_config():
             if isinstance(roles, list):
                 for role in roles:
                     if role in models_by_role:
-                        logger.warning("%s", Duplicate role definition found for '{role}'. Using the last definition found in llm.json.)
+                        logger.warning(
+                            "%s",
+                            "Duplicate role definition found for %s. Using the last definition found in llm.json.",
+                            role,
+                        )
                     models_by_role[role] = model_info
             else:
-                logger.warning("%s", Skipping model entry due to invalid or missing 'role': {model_info.get('model)}")
+                logger.warning(
+                    "%s",
+                    "Skipping model entry due to invalid or missing 'role': %s",
+                    model_info.get("model"),
+                )
 
         logger.info("%s", Loaded LLM configuration for roles: {list(models_by_role.keys())})
         return models_by_role

--- a/agent_s3/signature_normalizer.py
+++ b/agent_s3/signature_normalizer.py
@@ -240,9 +240,14 @@ class SignatureNormalizer:
 
         return target_file
 
-    def _normalize_signature(self, signature: str, name: str, element_type: str, target_file: str)
-         -> str:        """
-        Normalize code signature for syntactic correctness.
+    def _normalize_signature(
+        self,
+        signature: str,
+        name: str,
+        element_type: str,
+        target_file: str,
+    ) -> str:
+        """Normalize code signature for syntactic correctness.
 
         Args:
             signature: Original code signature

--- a/agent_s3/terminal_executor.py
+++ b/agent_s3/terminal_executor.py
@@ -58,7 +58,11 @@ class TerminalExecutor:
         for forbidden in self.denylist:
             if forbidden in command:
                 if self.logger:
-                    self.logger.warning("%s", Command contains forbidden token: {forbidden})
+                    self.logger.warning(
+                        "%s",
+                        "Command contains forbidden token: %s",
+                        forbidden,
+                    )
                 return False, f"Error: Command contains forbidden token '{forbidden}'"
 
         # Detect command substitution using backticks or $( ) syntax

--- a/agent_s3/test_generator.py
+++ b/agent_s3/test_generator.py
@@ -385,7 +385,11 @@ Each test must include complete runnable code - not stubs or pseudocode.
             # Log validation results
             issue_count = len(validation_issues)
             if issue_count > 0:
-                logger.warning("%s", Found {issue_count} issues in test implementations)
+                logger.warning(
+                    "%s",
+                    "Found %d issues in test implementations",
+                    issue_count,
+                )
                 critical_issues = sum(1 for issue in validation_issues if issue.get('severity') == 'critical')
                 high_issues = sum(1 for issue in validation_issues if issue.get('severity') == 'high')
                 other_issues = issue_count - critical_issues - high_issues

--- a/agent_s3/test_spec_validator.py
+++ b/agent_s3/test_spec_validator.py
@@ -444,7 +444,7 @@ def generate_missing_tests_with_llm(
             data = json.loads(json_str)
             return data.get("refined_test_requirements", data)
     except Exception as e:  # pragma: no cover - best effort
-        logger.error("%s", LLM repair failed: {e})
+        logger.error("%s", "LLM repair failed: %s", e)
 
     return {}
 

--- a/agent_s3/tool_definitions.py
+++ b/agent_s3/tool_definitions.py
@@ -204,7 +204,12 @@ class ToolRegistry:
                 missing_params.append(param)
 
         if missing_params:
-            logger.warning("%s", Missing required configuration for {tool_name}: {', '.join(missing_params)})
+            logger.warning(
+                "%s",
+                "Missing required configuration for %s: %s",
+                tool_name,
+                ", ".join(missing_params),
+            )
             return False
 
         return True

--- a/agent_s3/tools/code_analysis_tool.py
+++ b/agent_s3/tools/code_analysis_tool.py
@@ -67,8 +67,21 @@ class CodeAnalysisTool:
     of code relationships, dependencies, and evolutionary coupling.
     """
 
-    def __init__(self, coordinator=None, config: Optional[Dict[str, Any]] = None, file_tool=None,
-         *args, **kwargs):        """Initialize the code analysis tool with a coordinator for access to other tools."""
+    def __init__(
+        self,
+        coordinator: Optional[Any] = None,
+        config: Optional[Dict[str, Any]] = None,
+        file_tool: Optional[Any] = None,
+        *args,
+        **kwargs,
+    ) -> None:
+        """Initialize the code analysis tool.
+
+        Args:
+            coordinator: Optional coordinator providing other tools
+            config: Optional configuration dictionary
+            file_tool: Optional file tool instance
+        """
         self.coordinator = coordinator
         self.embedding_client = coordinator.embedding_client if coordinator else EmbeddingClient(config)
         self.file_tool = file_tool if file_tool else (coordinator.file_tool if coordinator else None)

--- a/agent_s3/tools/coherence_validator.py
+++ b/agent_s3/tools/coherence_validator.py
@@ -671,6 +671,10 @@ def repair_inconsistent_patterns(
         repaired_plan["discussion"] += "\n\nIMPORTANT PATTERN GUIDELINES:\n"
         for pattern_type, guide in guidelines.items():
             repaired_plan["discussion"] += f"\n{pattern_type.upper()}: {guide['description']}\n"
-            repaired_plan["discussion"] +
-                = f"Dominant pattern: {guide.get('dominant_style') or guide.get('dominant_approach') or guide.get('dominant_pattern') or guide.get('dominant_flow')}\n"
+            repaired_plan[
+                "discussion"
+            ] += (
+                "Dominant pattern: "
+                f"{guide.get('dominant_style') or guide.get('dominant_approach') or guide.get('dominant_pattern') or guide.get('dominant_flow')}\n"
+            )
     return repaired_plan

--- a/agent_s3/tools/context_management/__init__.py
+++ b/agent_s3/tools/context_management/__init__.py
@@ -1,19 +1,13 @@
-"""Context management package for agent-s3.
+"""Context management utilities for agent-s3."""
 
-This package provides tools for managing context across different phases
-of the agent workflow, including checkpoint management, context loading,
-and cross-phase validation.
-"""
-
-# Expose key modules and functions
-
+from .checkpoint_manager import (
     save_checkpoint,
     load_checkpoint,
     list_checkpoints,
     get_checkpoint_diff,
     ensure_checkpoint_consistency,
     get_latest_checkpoint,
-    create_checkpoint_version
+    create_checkpoint_version,
 )
 
 __all__ = [

--- a/agent_s3/tools/context_management/adaptive_config/adaptive_config_manager.py
+++ b/agent_s3/tools/context_management/adaptive_config/adaptive_config_manager.py
@@ -121,10 +121,14 @@ class AdaptiveConfigManager:
             # Save configuration
             self._save_configuration()
 
-            logger.info("%s", Created initial configuration for {repo_metrics.get('project_type)} project")
+            logger.info(
+                "%s",
+                "Created initial configuration for %s project",
+                repo_metrics.get("project_type"),
+            )
 
         except Exception as e:
-            logger.error("%s", Error creating initial configuration: {e})
+            logger.error("%s", "Error creating initial configuration: %s", e)
             logger.info("Falling back to default configuration")
 
             # Fall back to default configuration

--- a/agent_s3/tools/context_management/adaptive_config/config_explainer.py
+++ b/agent_s3/tools/context_management/adaptive_config/config_explainer.py
@@ -242,7 +242,7 @@ class ConfigExplainer:
             return report
 
         except Exception as e:
-            logger.error("%s", Error generating configuration report: {e})
+            logger.error("%s", "Error generating configuration report: %s", e)
             return {"error": str(e)}
 
     def get_human_readable_report(self) -> str:

--- a/agent_s3/tools/context_management/adaptive_config/config_templates.py
+++ b/agent_s3/tools/context_management/adaptive_config/config_templates.py
@@ -417,7 +417,11 @@ class ConfigTemplateManager:
         # Validate merged config
         is_valid, errors = self.validate_config(config)
         if not is_valid:
-            logger.warning("%s", Generated configuration has validation errors: {errors})
+            logger.warning(
+                "%s",
+                "Generated configuration has validation errors: %s",
+                errors,
+            )
             # Fall back to default if invalid
             return self.get_default_config()
 

--- a/agent_s3/tools/context_management/adaptive_config/metrics_collector.py
+++ b/agent_s3/tools/context_management/adaptive_config/metrics_collector.py
@@ -54,7 +54,11 @@ class MetricsCollector:
         try:
             os.makedirs(self.storage_path, exist_ok=True)
         except OSError as e:
-            logger.error("%s", Failed to create metrics storage directory: {e})
+            logger.error(
+                "%s",
+                "Failed to create metrics storage directory: %s",
+                e,
+            )
 
     def log_token_usage(
         self,

--- a/agent_s3/tools/context_management/adaptive_config/project_profiler.py
+++ b/agent_s3/tools/context_management/adaptive_config/project_profiler.py
@@ -101,7 +101,7 @@ class ProjectProfiler:
         Returns:
             Dictionary containing repository metrics and characteristics
         """
-        logger.info("%s", Analyzing repository at {self.repo_path})
+        logger.info("%s", "Analyzing repository at %s", self.repo_path)
 
         # Gather basic repository metrics
         self._gather_file_statistics()

--- a/agent_s3/tools/context_management/compression.py
+++ b/agent_s3/tools/context_management/compression.py
@@ -471,8 +471,11 @@ class SemanticSummarizer(CompressionStrategy):
                     summary_lines.append(line)
                 else:
                     # Just add the class signature with a comment
-                    class_match = re.search(r'(?:public|private|protected|internal)?\s*class\s+(\w+
-                        )', line)                    if class_match:
+                    class_match = re.search(
+                        r"(?:public|private|protected|internal)?\s*class\s+(\w+)",
+                        line,
+                    )
+                    if class_match:
                         class_name = class_match.group(1)
                         summary_lines.append(f"public class {class_name} {{ // Summarized")
 

--- a/agent_s3/tools/context_management/context_adapter.py
+++ b/agent_s3/tools/context_management/context_adapter.py
@@ -149,8 +149,8 @@ class ContextAdapter:
             # Django URLs
             r'path\s*\(\s*[\'"`]([^\'"`]+)[\'"`],\s*([a-zA-Z0-9_\.]+)',
             # Controllers with routing decorators
-            r'@(?:RequestMapping|GetMapping|PostMapping|PutMapping)\s*\(\s*[\'"`]?([^\'"`\)]+
-                )[\'"`]?'        ]
+            r'@(?:RequestMapping|GetMapping|PostMapping|PutMapping)\s*\(\s*[\'"`]?([^\'"`\)]+)[\'"`]?'
+        ]
 
         # Process each file
         for file_path, content in file_contents.items():

--- a/agent_s3/tools/context_management/context_manager.py
+++ b/agent_s3/tools/context_management/context_manager.py
@@ -675,7 +675,13 @@ class ContextManager:
                                 if keys[-1] in parent_dict:
                                     del parent_dict[keys[-1]]
                     pruned_tokens += token_count
-                    logger.debug("%s", Pruned {token_count} tokens from {key_path} (value score: {value_score:.2f}))
+                    logger.debug(
+                        "%s",
+                        "Pruned %d tokens from %s (value score: %.2f)",
+                        token_count,
+                        key_path,
+                        value_score,
+                    )
             compressed_context = {}
             for key, value in context_copy.items():
                 if isinstance(value, str) and len(value) > 1000:

--- a/agent_s3/tools/context_management/context_registry.py
+++ b/agent_s3/tools/context_management/context_registry.py
@@ -21,7 +21,7 @@ class ContextRegistry:
         self._providers = {}
     def register_provider(self, name: str, provider: ContextProvider) -> None:
         self._providers[name] = provider
-        logger.info("%s", Registered context provider: {name})
+        logger.info("%s", "Registered context provider: %s", name)
     def get_provider(self, name: str) -> Optional[ContextProvider]:
         return self._providers.get(name)
     def get_tech_stack(self) -> Dict[str, Any]:

--- a/agent_s3/tools/context_management/coordinator_integration.py
+++ b/agent_s3/tools/context_management/coordinator_integration.py
@@ -132,9 +132,13 @@ class CoordinatorContextIntegration:
             # Initialize config explainer
             self.config_explainer = ConfigExplainer(self.adaptive_config_manager)
 
-            logger.info("%s", Initialized adaptive configuration system in {config_dir})
+            logger.info(
+                "%s",
+                "Initialized adaptive configuration system in %s",
+                config_dir,
+            )
         except Exception as e:
-            logger.error("%s", Failed to set up adaptive configuration: {e})
+            logger.error("%s", "Failed to set up adaptive configuration: %s", e)
             logger.debug(traceback.format_exc())
 
     def integrate(self) -> bool:

--- a/agent_s3/tools/context_management/llm_integration.py
+++ b/agent_s3/tools/context_management/llm_integration.py
@@ -93,9 +93,10 @@ class LLMContextIntegration:
         return context
 
 
-    def _update_prompt_with_context(self, prompt_data: Dict[str, Any], context: Dict[str, Any])
-         -> Dict[str, Any]:        """
-        Update prompt data with optimized context.
+    def _update_prompt_with_context(
+        self, prompt_data: Dict[str, Any], context: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Update prompt data with optimized context.
 
         Args:
             prompt_data: Original prompt data

--- a/agent_s3/tools/context_management/token_budget.py
+++ b/agent_s3/tools/context_management/token_budget.py
@@ -165,7 +165,12 @@ class TokenEstimator:
                     content = f.read()
                 return self.estimate_tokens_for_text(content, language)
             except Exception as e:
-                logger.warning("%s", Failed to read file {file_path}: {e})
+                logger.warning(
+                    "%s",
+                    "Failed to read file %s: %s",
+                    file_path,
+                    e,
+                )
 
         # Fallback: estimate based on typical file sizes for that language
         avg_tokens_per_file = {

--- a/agent_s3/tools/file_tool.py
+++ b/agent_s3/tools/file_tool.py
@@ -66,7 +66,11 @@ class FileTool:
 
             if not allowed:
                 if self.logger:
-                    self.logger.warning("%s", Attempted access to restricted path: {norm_path})
+                    self.logger.warning(
+                        "%s",
+                        "Attempted access to restricted path: %s",
+                        norm_path,
+                    )
                 return False, f"Access to path outside allowed directories: {file_path}"
 
             # Check file extension if restricted

--- a/agent_s3/tools/git_tool.py
+++ b/agent_s3/tools/git_tool.py
@@ -56,8 +56,13 @@ class GitTool:
         self.max_retries = 3
         self.retry_delay = 2  # Initial delay in seconds
 
-    def run_git_command(self, command: str, max_retries: int = None, retry_delay: int = None)
-         -> Tuple[int, str]:        """Run a Git command securely with improved error handling and retry logic.
+    def run_git_command(
+        self,
+        command: str,
+        max_retries: Optional[int] = None,
+        retry_delay: Optional[int] = None,
+    ) -> Tuple[int, str]:
+        """Run a Git command securely with improved error handling and retry logic.
 
         Args:
             command: The Git command to run (without 'git' prefix)

--- a/agent_s3/tools/incremental_indexer.py
+++ b/agent_s3/tools/incremental_indexer.py
@@ -222,7 +222,13 @@ class IncrementalIndexer:
                 "timestamp": end_time
             }
 
-            logger.info("%s", Indexed {files_indexed} files ({files_skipped} skipped) in {duration:.2f} seconds)
+            logger.info(
+                "%s",
+                "Indexed %d files (%d skipped) in %.2f seconds",
+                files_indexed,
+                files_skipped,
+                duration,
+            )
 
             return stats
         except Exception as e:

--- a/agent_s3/tools/incremental_indexing_adapter.py
+++ b/agent_s3/tools/incremental_indexing_adapter.py
@@ -74,7 +74,7 @@ class IncrementalIndexingAdapter:
                 if cache_dir:
                     return os.path.join(cache_dir, "incremental_index")
         except Exception as e:
-            logger.error("%s", Error accessing cache directory: {e})
+            logger.error("%s", "Error accessing cache directory: %s", e)
 
         # Default to a hidden directory in the user's home
         home = os.path.expanduser("~")

--- a/agent_s3/tools/index_partition_manager.py
+++ b/agent_s3/tools/index_partition_manager.py
@@ -78,7 +78,7 @@ class IndexPartition:
                 with open(metadata_path, 'r') as f:
                     self.metadata = json.load(f)
             except Exception as e:
-                logger.error("%s", Error loading partition metadata: {e})
+                logger.error("%s", "Error loading partition metadata: %s", e)
 
         # Load file metadata
         file_metadata_path = os.path.join(self.storage_path, "file_metadata.json")

--- a/agent_s3/tools/memory_manager.py
+++ b/agent_s3/tools/memory_manager.py
@@ -136,9 +136,18 @@ class MemoryManager:
                     state = json.load(f)
                 self.context_history = state.get('context_history', [])
                 self.summaries = state.get('summaries', {})
-                logger.info("%s", Loaded memory state from {self.memory_state_path})
+                logger.info(
+                    "%s",
+                    "Loaded memory state from %s",
+                    self.memory_state_path,
+                )
             except (json.JSONDecodeError, OSError) as e:
-                logger.error("%s", Error loading memory state from {self.memory_state_path}: {e}. Initializing empty state.)
+                logger.error(
+                    "%s",
+                    "Error loading memory state from %s: %s. Initializing empty state.",
+                    self.memory_state_path,
+                    e,
+                )
                 self.context_history = []
                 self.summaries = {}
         else:


### PR DESCRIPTION
## Summary
- fix logging format strings and unify function signatures
- address minor syntax errors and restructure context management exports
- tidy up message formatting across various adaptive config utilities

## Testing
- `python3 -m compileall -q .`
- `pytest -q`
- `npm run typecheck`