### PR TITLE
Make simple test server token configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
   - `pre_planning_mode` selects `off`, `json`, or `enforced_json` workflow. See `docs/pre_planning_workflow.md` for details.
   - `WEBSOCKET_MAX_MESSAGE_SIZE` (optional, defaults to `65536` bytes)
     limits incoming WebSocket payloads
+  - `TEST_WS_TOKEN` (optional, defaults to `"replace-me"`)
+    authentication token for `simple-test-server.js`
 
   Example `.env`:
 
@@ -432,6 +434,7 @@ pip install -r requirements-dev.txt
 - **Tests:** `pytest`
 - **Type Checking:** `mypy agent_s3`
 - **Linting:** `ruff check agent_s3`
+- **Test WebSocket server:** `TEST_WS_TOKEN=mytoken node simple-test-server.js`
 
 ## Contributing
 

--- a/simple-test-server.js
+++ b/simple-test-server.js
@@ -5,7 +5,8 @@ const path = require("path");
 
 // Configuration
 const PORT = 8080;
-const AUTH_TOKEN = "test-token-1234";
+// Authentication token used by clients. Set TEST_WS_TOKEN=mytoken when starting the server.
+const AUTH_TOKEN = process.env.TEST_WS_TOKEN || "replace-me";
 
 console.log("Starting WebSocket test server...");
 


### PR DESCRIPTION
## Summary
- allow setting `TEST_WS_TOKEN` for simple-test-server
- document the `TEST_WS_TOKEN` variable and how to run the test WebSocket server

## Testing
- `pytest -q` *(fails: SyntaxError in repository tests)*