### PR TITLE
Update block detection in bash tool

### DIFF
--- a/agent_s3/tools/bash_tool.py
+++ b/agent_s3/tools/bash_tool.py
@@ -4,6 +4,7 @@ This module provides containerized command execution as specified in instruction
 """
 
 import os
+import re
 import subprocess
 import tempfile
 import time
@@ -537,7 +538,10 @@ class BashTool:
             True if the command is blocked, False otherwise
         """
         command_lower = command.lower()
-        return any(blocked in command_lower for blocked in self.blocked_commands)
+        for block in self.blocked_commands:
+            if re.search(rf"\b{re.escape(block)}\b", command_lower):
+                return True
+        return False
 
     def _check_docker_available(self) -> bool:
         """Check if Docker is available.

--- a/tests/test_bash_tool_blocking.py
+++ b/tests/test_bash_tool_blocking.py
@@ -1,0 +1,41 @@
+import importlib.util
+from pathlib import Path
+import unittest
+from unittest.mock import patch
+
+
+def load_bash_tool():
+    module_path = Path(__file__).resolve().parents[1] / "agent_s3" / "tools" / "bash_tool.py"
+    spec = importlib.util.spec_from_file_location("bash_tool", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+BashTool = load_bash_tool().BashTool
+
+
+class TestBashToolBlocking(unittest.TestCase):
+    def setUp(self):
+        with patch.object(BashTool, "_check_docker_available", return_value=False):
+            self.tool = BashTool()
+
+    def test_blocked_command_with_spaces(self):
+        code, msg = self.tool.run_command(" rm -rf /tmp ")
+        self.assertEqual(code, 1)
+        self.assertIn("blocked", msg)
+
+    def test_blocked_command_in_quotes(self):
+        code, msg = self.tool.run_command("echo 'rm -rf'")
+        self.assertEqual(code, 1)
+        self.assertIn("blocked", msg)
+
+    def test_allowed_command(self):
+        with patch.object(self.tool, "_run_with_subprocess", return_value=(0, "ok")):
+            code, msg = self.tool.run_command("ls -la")
+        self.assertEqual(code, 0)
+        self.assertEqual(msg, "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- improve block detection with regex
- add tests for blocked commands with spaces or quotes

## Testing
- `ruff check agent_s3/tools/bash_tool.py tests/test_bash_tool_blocking.py`
- `pytest tests/test_bash_tool_blocking.py -q`