### PR TITLE
Update docstring for test extraction

### DIFF
--- a/agent_s3/code_generator.py
+++ b/agent_s3/code_generator.py
@@ -558,6 +558,10 @@ class CodeGenerator:
     def _extract_relevant_tests(self, tests: Dict[str, Any], file_path: str) -> Dict[str, Any]:
         """Extract tests relevant to a specific file.
 
+        Supported keys in ``tests`` include ``"unit_tests"``, ``"integration_tests"``,
+        ``"property_based_tests"``, and ``"acceptance_tests"``. These categories
+        are optional and skipped when missing.
+
         Args:
             tests: Dictionary of all tests
             file_path: Path to the file being implemented


### PR DESCRIPTION
## Summary
- clarify `_extract_relevant_tests` docstring to include optional `property_based_tests` and `acceptance_tests`

## Testing
- `python -m pydocstyle agent_s3/code_generator.py` *(fails: No module named pydocstyle)*