### PR TITLE
Fix log cleanup warning

### DIFF
--- a/agent_s3/enhanced_scratchpad_manager.py
+++ b/agent_s3/enhanced_scratchpad_manager.py
@@ -274,7 +274,9 @@ class EnhancedScratchpadManager:
 
         except Exception as e:
             # Don't fail if cleanup has issues
-            print(f"Warning: Error cleaning up old scratchpad sessions: {e}")
+            self.logger.warning(
+                "Error cleaning up old scratchpad sessions: %s", e
+            )
 
     def _check_and_rotate_log(self) -> None:
         """Check if log file size limit is reached and rotate if needed."""


### PR DESCRIPTION
## Summary
- log cleanup warnings using logger instead of print

## Testing
- `python -m py_compile agent_s3/enhanced_scratchpad_manager.py`
- `ruff check agent_s3/` *(fails: SyntaxError)*
- `mypy agent_s3/` *(fails: invalid syntax)*
- `pytest tests/test_code_generator.py::TestCodeGenerator::test_initialization -q`