### PR TITLE
Fix summarise_unit indentation

### DIFF
--- a/agent_s3/ast_tools/summariser.py
+++ b/agent_s3/ast_tools/summariser.py
@@ -17,7 +17,7 @@ def summarise_unit(
     code_unit: Dict[str, Any],
     router_agent: Any,
     config: Dict[str, Any] | None = None,
-) -> str:
+    ) -> str:
     """Summarize a code unit with validation and refinement."""
     code_text = code_unit.get("text", "")
     language = code_unit.get('language', None)


### PR DESCRIPTION
## Summary
- align closing parenthesis in `summarise_unit`

## Testing
- `ruff check agent_s3/ast_tools/summariser.py`
- `mypy agent_s3` *(fails: invalid syntax in adaptive_config_manager.py)*