### PR TITLE
Add strip_sensitive_headers export

### DIFF
--- a/agent_s3/__init__.py
+++ b/agent_s3/__init__.py
@@ -21,6 +21,7 @@ _MODULE_MAP = {
     "ComplexityAnalyzer": "agent_s3.complexity_analyzer",
     "DatabaseManager": "agent_s3.database_manager",
     "redact_sensitive_headers": "agent_s3.security_utils",
+    "strip_sensitive_headers": "agent_s3.security_utils",
     "redact_auth_headers": "agent_s3.logging_utils",
     "AgentS3BaseError": "agent_s3.pre_planning_errors",
     "PrePlanningError": "agent_s3.pre_planning_errors",
@@ -32,6 +33,8 @@ _MODULE_MAP = {
 }
 
 __all__ = list(_MODULE_MAP.keys())
+if "strip_sensitive_headers" not in __all__:
+    __all__.append("strip_sensitive_headers")
 
 
 def __getattr__(name: str) -> Any:

--- a/agent_s3/security_utils.py
+++ b/agent_s3/security_utils.py
@@ -25,3 +25,19 @@ def redact_sensitive_headers(headers: MutableMapping[str, str]) -> Dict[str, str
         else:
             sanitized[name] = value
     return sanitized
+
+
+def strip_sensitive_headers(headers: MutableMapping[str, str]) -> Dict[str, str]:
+    """Return a copy of ``headers`` with sensitive entries removed.
+
+    Args:
+        headers: Mapping of header names to values.
+
+    Returns:
+        A new dictionary containing only non-sensitive headers.
+    """
+    sanitized: Dict[str, str] = {}
+    for name, value in headers.items():
+        if name.lower() not in SENSITIVE_HEADERS:
+            sanitized[name] = value
+    return sanitized

--- a/tests/test_redaction_utils.py
+++ b/tests/test_redaction_utils.py
@@ -1,5 +1,6 @@
 from agent_s3.security_utils import redact_sensitive_headers
 from agent_s3.logging_utils import redact_auth_headers
+from agent_s3 import strip_sensitive_headers
 
 
 def test_redact_sensitive_headers():
@@ -11,6 +12,18 @@ def test_redact_sensitive_headers():
     sanitized = redact_sensitive_headers(headers)
     assert sanitized["Authorization"] == "[REDACTED]"
     assert sanitized["Cookie"] == "[REDACTED]"
+    assert sanitized["Content-Type"] == "text/plain"
+
+
+def test_strip_sensitive_headers():
+    headers = {
+        "Authorization": "token secret",
+        "Content-Type": "text/plain",
+        "Cookie": "sessionid=abc",
+    }
+    sanitized = strip_sensitive_headers(headers)
+    assert "Authorization" not in sanitized
+    assert "Cookie" not in sanitized
     assert sanitized["Content-Type"] == "text/plain"
 
 


### PR DESCRIPTION
## Summary
- re-export strip_sensitive_headers through the package
- implement strip_sensitive_headers utility
- test header-stripping helper

## Testing
- `ruff check agent_s3/security_utils.py agent_s3/__init__.py tests/test_redaction_utils.py`
- `mypy agent_s3/security_utils.py agent_s3/__init__.py`
- `pytest tests/test_redaction_utils.py -q`
- `pytest` *(fails: 58 errors during collection)*