### PR TITLE
Fix GitHub token load logging

### DIFF
--- a/agent_s3/__init__.py
+++ b/agent_s3/__init__.py
@@ -22,6 +22,7 @@ _MODULE_MAP = {
     "DatabaseManager": "agent_s3.database_manager",
     "redact_sensitive_headers": "agent_s3.security_utils",
     "redact_auth_headers": "agent_s3.logging_utils",
+    "strip_sensitive_headers": "agent_s3.logging_utils",
     "AgentS3BaseError": "agent_s3.pre_planning_errors",
     "PrePlanningError": "agent_s3.pre_planning_errors",
     "ValidationError": "agent_s3.pre_planning_errors",

--- a/agent_s3/llm_utils.py
+++ b/agent_s3/llm_utils.py
@@ -15,6 +15,7 @@ except Exception:  # pragma: no cover - library optional
     create_client = None
 import json
 import logging
+from agent_s3.logging_utils import strip_sensitive_headers
 
 # Import GPTCache
 try:
@@ -151,8 +152,11 @@ def cached_call_llm(prompt, llm, return_kv=False, **kwargs):
                 token_data = load_token()
                 if token_data:
                     github_token = token_data.get('token') or token_data.get('access_token')
-        except Exception:
-            github_token = github_token
+        except RuntimeError as e:
+            logging.warning(
+                "Failed to load GitHub token: %s",
+                strip_sensitive_headers(str(e)),
+            )
 
         if not github_token:
             raise ValueError('GitHub token required for remote LLM')

--- a/agent_s3/logging_utils.py
+++ b/agent_s3/logging_utils.py
@@ -14,3 +14,30 @@ def redact_auth_headers(message: str) -> str:
     that include HTTP headers.
     """
     return _AUTH_HEADER_RE.sub(lambda m: m.group(1) + "[REDACTED]" + m.group(3), message)
+
+
+def strip_sensitive_headers(message: str) -> str:
+    """Remove sensitive HTTP header values from a log message.
+
+    This is primarily used when logging exceptions that may include request
+    or response headers. It ensures tokens, cookies and similar credentials
+    are not written to disk or stdout while still providing useful debugging
+    context.
+
+    Parameters
+    ----------
+    message:
+        The original log message possibly containing sensitive header values.
+
+    Returns
+    -------
+    str
+        The sanitized message safe for logging.
+    """
+    from .security_utils import SENSITIVE_HEADERS
+
+    sanitized = redact_auth_headers(message)
+    for header in SENSITIVE_HEADERS:
+        pattern = re.compile(fr"(?i)({header}\s*[:=]\s*)([^;\s]+)")
+        sanitized = pattern.sub(r"\1[REDACTED]", sanitized)
+    return sanitized


### PR DESCRIPTION
## Summary
- add `strip_sensitive_headers` util for safe log messages
- log sanitized token loading errors
- export new utility via package init

## Testing
- `ruff check agent_s3/llm_utils.py`
- `pytest -q` *(fails: SyntaxError in plan_validator, planner_json_enforced, pre_planner_json_enforced, etc.)*