### PR TITLE
Run setup scripts and verify compile

### DIFF
--- a/vscode/extension.ts
+++ b/vscode/extension.ts
@@ -343,7 +343,7 @@ export function activate(context: vscode.ExtensionContext) {
   function getAgentTerminal(): vscode.Terminal {
     // Try to find existing terminal
     const existingTerminal = vscode.window.terminals.find(
-      (t) => t.name === "Agent-S3",
+      (t: vscode.Terminal) => t.name === "Agent-S3",
     );
 
     if (existingTerminal) {

--- a/vscode/stubs.d.ts
+++ b/vscode/stubs.d.ts
@@ -22,7 +22,7 @@ declare module "ws" {
     constructor(url: string);
     readyState: number;
     on(event: string, listener: (...args: any[]) => void): void;
-    send(data: any): void;
+    send(data: any, cb?: (err?: Error) => void): void;
     close(code?: number, reason?: string): void;
   }
   type RawData = any;
@@ -30,7 +30,7 @@ declare module "ws" {
 interface Buffer {}
 declare const Buffer: {
   new(...args: any[]): Buffer;
-  from(input: any): Buffer;
+  from(input: any, encoding?: string): Buffer;
   isBuffer(input: any): boolean;
 };
 namespace NodeJS {

--- a/vscode/types/node/index.d.ts
+++ b/vscode/types/node/index.d.ts
@@ -13,7 +13,7 @@ declare module "path" {
 interface Buffer {}
 declare const Buffer: {
   new(...args: any[]): Buffer;
-  from(input: string | any[] | ArrayBuffer | SharedArrayBuffer): Buffer;
+  from(input: string | any[] | ArrayBuffer | SharedArrayBuffer, encoding?: string): Buffer;
 };
 
 declare namespace NodeJS {

--- a/vscode/types/vscode/index.d.ts
+++ b/vscode/types/vscode/index.d.ts
@@ -16,7 +16,8 @@ declare namespace vscode {
   }
 
   interface Memento {
-    get(key: string, defaultValue?: any): any;
+    get<T>(key: string): T | undefined;
+    get<T>(key: string, defaultValue: T): T;
     update(key: string, value: any): Thenable<void>;
     [key: string]: any;
   }
@@ -34,7 +35,12 @@ declare namespace vscode {
   const workspace: any;
   const commands: any;
   const env: any;
-  const Uri: any;
+  class Uri {
+    fsPath: string;
+    constructor(path?: string);
+    static file(path: string): Uri;
+    static joinPath(base: Uri, ...paths: string[]): Uri;
+  }
   const ViewColumn: any;
 
   // Type placeholders used within the extension

--- a/vscode/websocket-client.ts
+++ b/vscode/websocket-client.ts
@@ -132,7 +132,7 @@ export class WebSocketClient implements vscode.Disposable {
       // Determine protocol: options override configuration file, then VS Code setting
       const configProtocol = vscode.workspace
         .getConfiguration("agent-s3")
-        .get<string>("websocketProtocol");
+        .get("websocketProtocol") as string | undefined;
       const protocol =
         this.options.protocol ||
         (configProtocol as "ws" | "wss" | undefined) ||

--- a/vscode/webview-ui-loader.ts
+++ b/vscode/webview-ui-loader.ts
@@ -62,7 +62,7 @@ export class InteractiveWebviewManager {
 
     // Handle messages from the webview
     this.panel.webview.onDidReceiveMessage(
-      (message) => {
+      (message: any) => {
         if (this.messageHandler) {
           this.messageHandler(message);
         }


### PR DESCRIPTION
## Notes
- Installed Node and Python dependencies (offline node types used)
- Fixed compile by updating VS Code stubs for Memento generics, Uri, Buffer, and WebSocket callback typings
- Adjusted extension code for explicit parameter typing and updated WebSocket config retrieval
- Added message type annotation in webview loader

## Testing
- `npm run compile` succeeds
- `pytest -q` fails with multiple syntax errors (57 errors)
