### PR TITLE
Add ignore for VS Code build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ vscode/node_modules/
 vscode/package-lock*.json
 vscode/webview-ui/node_modules/
 vscode/webview-ui/package-lock*.json
+vscode/out/
 
 # Duplicate, backup, and numbered files
 * 2.*


### PR DESCRIPTION
## Summary
- add `vscode/out/` to `.gitignore`

## Testing
- `ruff check agent_s3/`
- `mypy agent_s3/`
- `pytest -q` *(fails: 57 errors during collection)*
