### PR TITLE
Refactor command dispatch into CLI subpackage

### DIFF
--- a/agent_s3/cli/__init__.py
+++ b/agent_s3/cli/__init__.py
@@ -8,6 +8,7 @@ import logging
 from agent_s3.config import Config
 from agent_s3.coordinator import Coordinator
 from agent_s3.router_agent import RouterAgent
+from .dispatcher import dispatch
 # Import authenticate_user only when needed to prevent circular imports
 # from agent_s3.auth import authenticate_user
 
@@ -99,17 +100,15 @@ def process_command(coordinator: Coordinator, command: str) -> None:
     # Handle help command at CLI level since it's display-specific
     if command == "/help":
         display_help()
-    else:
-        try:
-            # Delegate all other commands to CommandProcessor
-            result = coordinator.command_processor.process_command(command)
+        return
 
-            # Print result if it's non-empty
-            if result:
-                print(result)
-        except Exception as e:
-            print(f"Error processing command '{command}': {e}")
-            logger.error(f"Command processing error: {e}", exc_info=True)
+    try:
+        result = dispatch(coordinator.command_processor, command)
+        if result:
+            print(result)
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"Error processing command '{command}': {e}")
+        logger.error(f"Command processing error: {e}", exc_info=True)
 
 
 def main() -> None:

--- a/agent_s3/cli/__main__.py
+++ b/agent_s3/cli/__main__.py
@@ -1,0 +1,5 @@
+"""CLI module executed with ``python -m agent_s3.cli``."""
+from . import main
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    main()

--- a/agent_s3/cli/dispatcher.py
+++ b/agent_s3/cli/dispatcher.py
@@ -1,0 +1,41 @@
+"""Command dispatcher for Agent-S3 CLI."""
+
+from typing import Callable, Dict
+
+from agent_s3.command_processor import CommandProcessor
+
+# Map command names to CommandProcessor method names
+_COMMAND_MAP: Dict[str, str] = {
+    "init": "execute_init_command",
+    "plan": "execute_plan_command",
+    "test": "execute_test_command",
+    "debug": "execute_debug_command",
+    "terminal": "execute_terminal_command",
+    "personas": "execute_personas_command",
+    "guidelines": "execute_guidelines_command",
+    "design": "execute_design_command",
+    "implement": "execute_implement_command",
+    "continue": "execute_continue_command",
+    "deploy": "execute_deploy_command",
+    "help": "execute_help_command",
+    "config": "execute_config_command",
+    "reload-llm-config": "execute_reload_llm_config_command",
+    "explain": "execute_explain_command",
+    "request": "execute_request_command",
+    "tasks": "execute_tasks_command",
+    "clear": "execute_clear_command",
+    "db": "execute_db_command",
+}
+
+
+def dispatch(command_processor: CommandProcessor, raw_command: str) -> str:
+    """Parse and dispatch a command to the appropriate handler."""
+    if raw_command.startswith("/"):
+        raw_command = raw_command[1:]
+    cmd, _, args = raw_command.partition(" ")
+    cmd = cmd.lower()
+    handler_name = _COMMAND_MAP.get(cmd)
+    if not handler_name:
+        return f"Unknown command: {cmd}. Type /help for available commands."
+    handler: Callable[[str], str] = getattr(command_processor, handler_name)
+    return handler(args.strip())

--- a/agent_s3/command_processor.py
+++ b/agent_s3/command_processor.py
@@ -23,60 +23,13 @@ class CommandProcessor:
         """
         self.coordinator = coordinator
 
-        # Initialize command map
-        self.command_map = {
-            "init": self.execute_init_command,
-            "plan": self.execute_plan_command,
-            "test": self.execute_test_command,
-            "debug": self.execute_debug_command,
-            "terminal": self.execute_terminal_command,
-            "personas": self.execute_personas_command,
-            "guidelines": self.execute_guidelines_command,
-            "design": self.execute_design_command,
-            "implement": self.execute_implement_command,
-            "continue": self.execute_continue_command,
-            "deploy": self.execute_deploy_command,
-            "help": self.execute_help_command,
-            "config": self.execute_config_command,
-            "reload-llm-config": self.execute_reload_llm_config_command,
-            "explain": self.execute_explain_command,
-            "request": self.execute_request_command,
-            "tasks": self.execute_tasks_command,
-            "clear": self.execute_clear_command,
-            "db": self.execute_db_command,
-        }
 
-    def process_command(self, command: str, args: str = "") -> str:
-        """Process a command with optional arguments.
+    def process_command(self, command: str) -> str:
+        """Delegate parsing and execution to the CLI dispatcher."""
+        from agent_s3.cli.dispatcher import dispatch
 
-        Args:
-            command: Command name
-            args: Optional command arguments
-
-        Returns:
-            Command result message
-        """
-        # Strip leading slash if present (for compatibility with /command syntax)
-        if command.startswith('/'):
-            command = command[1:]
-
-        # Normalize to lowercase
-        command = command.lower()
-
-        # Log command execution
-        self._log(f"Processing command: {command} with args: {args}")
-
-        # Check if command exists in the map
-        if command in self.command_map:
-            try:
-                # Execute command handler
-                return self.command_map[command](args)
-            except Exception as e:
-                error_msg = f"Error executing command '{command}': {e}"
-                self._log(error_msg, level="error")
-                return error_msg
-        else:
-            return f"Unknown command: {command}. Type /help for available commands."
+        self._log(f"Processing command: {command}")
+        return dispatch(self, command)
 
     def execute_init_command(self, args: str) -> str:
         """Execute the init command to initialize workspace.

--- a/tests/test_integration_run_task.py
+++ b/tests/test_integration_run_task.py
@@ -14,7 +14,7 @@ def test_run_task_simple(monkeypatch):
                     {
                         "name": "hello-world",
                         "description": "Add print statement",
-                        "files_affected": ["agent_s3/cli.py"],
+                        "files_affected": ["agent_s3/cli/__init__.py"],
                         "test_requirements": {
                             "unit_tests": [],
                             "integration_tests": [],


### PR DESCRIPTION
## Summary
- move CLI implementation into `agent_s3/cli` package
- add `dispatcher` module for command parsing and dispatch
- update `CommandProcessor` to delegate to dispatcher
- adjust integration tests for new CLI path

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`
