### PR TITLE
Refactor CodeGenerator into submodules

### DIFF
--- a/agent_s3/__init__.py
+++ b/agent_s3/__init__.py
@@ -31,6 +31,10 @@ _MODULE_MAP = {
     "RepairError": "agent_s3.pre_planning_errors",
     "ComplexityError": "agent_s3.pre_planning_errors",
     "handle_pre_planning_errors": "agent_s3.pre_planning_errors",
+    "CodeGenerator": "agent_s3.code_generator",
+    "ContextManager": "agent_s3.context_manager",
+    "CodeValidator": "agent_s3.code_validator",
+    "DebugUtils": "agent_s3.debug_utils",
 }
 
 __all__ = list(_MODULE_MAP.keys())

--- a/agent_s3/code_generator.py
+++ b/agent_s3/code_generator.py
@@ -1,329 +1,77 @@
-"""Code generator for transforming plans into implementation code.
-
-Implements agentic code generation with processing, context management,
-validation, refinement, and debugging integration.
-"""
+"""Code generator for transforming plans into implementation code."""
+from __future__ import annotations
 
 import json
 import re
 import os
 import ast
-import tempfile
-import datetime
-from typing import Dict, Any, Optional, List, Tuple
-
+from typing import Any, Dict, List, Optional, Tuple
 
 from .enhanced_scratchpad_manager import LogLevel
-
-from .config import CONTEXT_WINDOW_GENERATOR
+from .context_manager import ContextManager
+from .code_validator import CodeValidator
+from .debug_utils import DebugUtils
 
 
 class CodeGenerator:
-    """Generates code based on plans and tests with agentic capabilities."""
+    """Generates code for implementation plans."""
 
-    def __init__(self, coordinator):
-        """Initialize with a reference to the coordinator."""
+    def __init__(self, coordinator: Any) -> None:
         self.coordinator = coordinator
         self.scratchpad = coordinator.scratchpad
-        self.debugging_manager = getattr(coordinator, 'debugging_manager', None)
-        self.llm = getattr(coordinator, 'llm', None)
-        self.file_tool = getattr(coordinator, 'file_tool', None)
-        self.memory_manager = getattr(coordinator, 'memory_manager', None)
-        self.code_analysis_tool = getattr(coordinator, 'code_analysis_tool', None)
-
-        # Track generation attempts
-        self.current_attempt = 0
+        self.debugging_manager = getattr(coordinator, "debugging_manager", None)
+        self.llm = getattr(coordinator, "llm", None)
+        self.context_manager = ContextManager(coordinator)
+        self.validator = CodeValidator(coordinator)
+        self.debug_utils = DebugUtils(self.debugging_manager, self.scratchpad)
         self.max_validation_attempts = 3
         self.max_refinement_attempts = 2
-
-        # Add context cache
-        self._context_cache = {}
-        self._context_cache_max_size = 10  # Limit cache size
-        self._context_dependency_map = {}  # Track dependencies between files
-        # Track how many times each file has been generated to avoid
-        # infinite regeneration loops. Attempts are capped by
-        # ``max_validation_attempts`` in ``generate_file``.
         self._generation_attempts: Dict[str, int] = {}
 
-    def _allocate_token_budget(self, total_tokens: int, attempt_num: int = 1) -> Dict[str, int]:
-        """Allocate token budget for different context elements."""
-        task_tokens = int(total_tokens * 0.1)
-        plan_tokens = int(total_tokens * 0.3)
-        code_tokens = int(total_tokens * 0.5)
-        tech_tokens = total_tokens - (task_tokens + plan_tokens + code_tokens)
-
-        if attempt_num >= 2:
-            code_tokens += int(total_tokens * 0.1)
-            plan_tokens = max(plan_tokens - int(total_tokens * 0.05), 0)
-        if attempt_num >= 3:
-            code_tokens += int(total_tokens * 0.1)
-            plan_tokens = max(plan_tokens - int(total_tokens * 0.05), 0)
-
-        # adjust to ensure the sum equals total_tokens
-        allocation = {
-            "task": task_tokens,
-            "plan": plan_tokens,
-            "code_context": code_tokens,
-            "tech_stack": tech_tokens,
-        }
-        diff = total_tokens - sum(allocation.values())
-        allocation["code_context"] += diff
-        return allocation
-
-    def _gather_minimal_context(
-        self,
-        task: str,
-        plan: Any,
-        tech_stack: Dict[str, Any],
-        token_budgets: Dict[str, int],
-    ) -> Dict[str, Any]:
-        """Return minimal context for generation, handling JSON plans."""
-        is_json = isinstance(plan, dict)
-        context = {
-            "task": task,
-            "tech_stack": tech_stack,
-            "code_context": {},
-            "is_json_plan": is_json,
-            "previous_attempts": [],
-        }
-        if is_json:
-            context["test_plan"] = plan.get("test_plan")
-            context["plan"] = json.dumps(plan.get("functional_plan", plan), indent=2)
-        else:
-            context["plan"] = str(plan)
-        return context
-
-    def _gather_full_context(
-        self,
-        task: str,
-        plan: Any,
-        tech_stack: Dict[str, Any],
-        token_budgets: Dict[str, int],
-        failed_attempts: Optional[List[Dict[str, Any]]] = None,
-    ) -> Dict[str, Any]:
-        """Gather full context for generation with optional summarization."""
-        context = self._gather_minimal_context(task, plan, tech_stack, token_budgets)
-        context["previous_attempts"] = failed_attempts or []
-
-        if self.coordinator and hasattr(self.coordinator, "memory_manager"):
-            mm = self.coordinator.memory_manager
-            plan_str = context["plan"]
-            budget = token_budgets.get("plan", len(plan_str))
-            if isinstance(plan_str, str) and mm.estimate_token_count(plan_str) > budget:
-                context["plan"] = mm.summarize(plan_str, budget)
-        return context
-
-    def _create_generation_prompt(self, context: Dict[str, Any]) -> str:
-        """Create a generation prompt from gathered context."""
-        task = context.get("task", "")
-        plan = context.get("plan", "")
-        prompt_sections = [f"# Task\n{task}"]
-        if context.get("is_json_plan"):
-            prompt_sections.append("# Structured Plan (JSON Format)")
-            prompt_sections.append(str(plan))
-            if context.get("test_plan") is not None:
-                prompt_sections.append("# Test Plan")
-                prompt_sections.append(json.dumps(context["test_plan"], indent=2))
-            prompt_sections.append("# Instructions for JSON Plan Implementation")
-            prompt_sections.append(
-                "Follow these steps to implement the feature based on the JSON structured plan"
-            )
-        else:
-            prompt_sections.append("# Plan")
-            prompt_sections.append(str(plan))
-        return "\n".join(prompt_sections)
-
-    def generate_code(
-        self, plan: Dict[str, Any], tech_stack: Optional[Dict[str, Any]] = None
-    ) -> Dict[str, str]:
-        """Generates code for all files in the implementation plan.
-
-        Args:
-            plan: The consolidated plan dictionary for a feature group.
-                  Expected keys: 'implementation_plan', 'tests', 'group_name'.
-            tech_stack: Optional dictionary describing the project's tech stack.
-
-        Returns:
-            A dictionary mapping file paths to generated code content.
-            Will return an empty dictionary if no files could be generated.
-        """
+    # ------------------------------------------------------------------
+    def generate_code(self, plan: Dict[str, Any], tech_stack: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+        """Generate code for all files in the implementation plan."""
         self.scratchpad.log("CodeGenerator", "Starting agentic code generation")
-
         implementation_plan = plan.get("implementation_plan", {})
         tests = plan.get("tests", {})
         group_name = plan.get("group_name", "Unnamed Group")
         plan_id = plan.get("plan_id", "N/A")
-
-        self.scratchpad.log("CodeGenerator", f"Generating code for feature group: {group_name} (Plan ID: {plan_id})")
-
-        # Extract files from plan
+        self.scratchpad.log(
+            "CodeGenerator", f"Generating code for feature group: {group_name} (Plan ID: {plan_id})"
+        )
         files = self._extract_files_from_plan(implementation_plan)
         if not files:
-            self.scratchpad.log("CodeGenerator", "No files found in implementation plan", level=LogLevel.ERROR)
-            return {}  # Return empty dictionary to indicate failure
-
-        self.scratchpad.log("CodeGenerator", f"Found {len(files)} files to generate")
-
-        results = {}
-
-        # Generate files one by one
+            self.scratchpad.log(
+                "CodeGenerator", "No files found in implementation plan", level=LogLevel.ERROR
+            )
+            return {}
+        results: Dict[str, str] = {}
         for file_path, implementation_details in files:
             self.scratchpad.log("CodeGenerator", f"Processing file {file_path}")
-
-            # Prepare context for this specific file
-            context = self._prepare_file_context(file_path, implementation_details)
-
-            # Generate the file
+            context = self.context_manager.prepare_file_context(file_path, implementation_details)
             generated_code = self.generate_file(file_path, implementation_details, tests, context)
-
             results[file_path] = generated_code
-
         self.scratchpad.log("CodeGenerator", f"Completed generation of {len(results)} files")
         return results
 
-    def _extract_files_from_plan(
-        self, implementation_plan: Dict[str, Any]
-    ) -> List[Tuple[str, List[Dict[str, Any]]]]:
-        """Extract file paths and their implementation details from the plan.
-
-        Args:
-            implementation_plan: The implementation plan containing file details
-
-        Returns:
-            List of tuples containing (file_path, implementation_details)
-        """
-        files = []
-
+    # ------------------------------------------------------------------
+    def _extract_files_from_plan(self, implementation_plan: Dict[str, Any]) -> List[Tuple[str, List[Dict[str, Any]]]]:
+        files: List[Tuple[str, List[Dict[str, Any]]]] = []
         try:
             for file_path, details in implementation_plan.items():
-                # Ensure the file path is a string and details is a list
                 if isinstance(file_path, str) and isinstance(details, list):
                     files.append((file_path, details))
                 else:
-                    self.scratchpad.log("CodeGenerator", f"Skipping invalid entry in implementation plan: {file_path}", level=LogLevel.WARNING)
-        except Exception as e:
+                    self.scratchpad.log(
+                        "CodeGenerator",
+                        f"Skipping invalid entry in implementation plan: {file_path}",
+                        level=LogLevel.WARNING,
+                    )
+        except Exception as e:  # pragma: no cover - defensive
             self.scratchpad.log("CodeGenerator", f"Error extracting files from plan: {e}", level=LogLevel.ERROR)
-
         return files
 
-    def _prepare_file_context(
-        self, file_path: str, implementation_details: List[Dict[str, Any]]
-    ) -> Dict[str, Any]:
-        """Prepare context for a file by reading related existing files.
-
-        Args:
-            file_path: The path of the file being generated
-            implementation_details: Details about the functions/classes to implement
-
-        Returns:
-            Dictionary containing context information for the file
-        """
-        self.scratchpad.log("CodeGenerator", f"Preparing context for {file_path}")
-
-        # Check if context is already cached
-        cache_key = self._get_context_cache_key(file_path, implementation_details)
-        cached_context = self._context_cache.get(cache_key)
-        if cached_context and self._is_context_cache_valid(file_path, cached_context):
-            self.scratchpad.log("CodeGenerator", f"Using cached context for {file_path}")
-            return cached_context
-
-        context = {}
-
-        # Read the existing file if it exists
-        try:
-            if hasattr(self.coordinator, 'file_tool') and self.coordinator.file_tool:
-                if os.path.exists(file_path):
-                    existing_code = self.coordinator.file_tool.read_file(file_path)
-                    context['existing_code'] = existing_code
-                    self.scratchpad.log("CodeGenerator", f"Added existing code for {file_path} to context")
-                else:
-                    context['existing_code'] = ""
-        except Exception as e:
-            self.scratchpad.log("CodeGenerator", f"Error reading existing file {file_path}: {e}", level=LogLevel.WARNING)
-            context['existing_code'] = ""
-
-        # Extract imports from implementation details
-        imports = set()
-        for detail in implementation_details:
-            if 'imports' in detail:
-                if isinstance(detail['imports'], list):
-                    imports.update(detail['imports'])
-                elif isinstance(detail['imports'], str):
-                    imports.add(detail['imports'])
-
-            # Extract imports from function signatures if available
-            if 'signature' in detail:
-                signature = detail.get('signature', '')
-                import_matches = re.findall(r'from\s+(\S+)\s+import\s+|import\s+(\S+)', signature)
-                for from_import, direct_import in import_matches:
-                    if from_import:
-                        imports.add(from_import)
-                    if direct_import:
-                        imports.add(direct_import)
-
-        context['imports'] = list(imports)
-
-        # Identify and read related files based on imports and directory structure
-        related_files = {}
-
-        # First, find dependencies based on imports
-        dependency_paths = self._extract_imports_and_dependencies(file_path, context['imports'])
-
-        # Then, find other files in the same directory
-        file_dir = os.path.dirname(file_path)
-        if hasattr(self.coordinator, 'file_tool') and self.coordinator.file_tool:
-            try:
-                if os.path.exists(file_dir):
-                    dir_files = [os.path.join(file_dir, f) for f in os.listdir(file_dir)
-                                if os.path.isfile(os.path.join(file_dir, f)) and f.endswith('.py')]
-
-                    # Add up to 3 most relevant files from the same directory
-                    for dep_path in dir_files[:3]:
-                        if dep_path != file_path and dep_path not in dependency_paths:
-                            dependency_paths.append(dep_path)
-            except Exception as e:
-                self.scratchpad.log("CodeGenerator", f"Error listing directory {file_dir}: {e}", level=LogLevel.WARNING)
-
-        # Read content for all dependency paths
-        for dep_path in dependency_paths:
-            try:
-                if hasattr(self.coordinator, 'file_tool') and self.coordinator.file_tool:
-                    if os.path.exists(dep_path):
-                        related_content = self.coordinator.file_tool.read_file(dep_path)
-                        if related_content:
-                            # Limit content size for context efficiency
-                            if len(related_content) > 2000:
-                                related_content = related_content[:2000] + "... [truncated]"
-                            related_files[dep_path] = related_content
-            except Exception as e:
-                self.scratchpad.log("CodeGenerator", f"Error reading related file {dep_path}: {e}", level=LogLevel.WARNING)
-
-        context['related_files'] = related_files
-        self.scratchpad.log("CodeGenerator", f"Added {len(related_files)} related files to context")
-
-        # Add class and function requirements from implementation details
-        functions_to_implement = []
-        for detail in implementation_details:
-            if 'function' in detail:
-                functions_to_implement.append(detail['function'])
-
-        context['functions_to_implement'] = functions_to_implement
-
-        # Calculate dynamic token budget based on model and file complexity
-        file_complexity = self._estimate_file_complexity(implementation_details)
-        max_tokens = self._get_model_token_capacity()
-        token_budget = min(int(max_tokens * 0.75), 6000 + (file_complexity * 1000))
-
-        # Prioritize context to fit within token budget
-        prioritized_context = self._prioritize_context(context, token_budget)
-
-        self.scratchpad.log("CodeGenerator", f"Context preparation complete for {file_path} (complexity: {file_complexity:.1f}, budget: {token_budget} tokens)")
-
-        # Cache the context
-        self._cache_context(file_path, prioritized_context, dependency_paths)
-
-        return prioritized_context
-
+    # ------------------------------------------------------------------
     def generate_file(
         self,
         file_path: str,
@@ -331,724 +79,192 @@ class CodeGenerator:
         tests: Dict[str, Any],
         context: Dict[str, Any],
     ) -> str:
-        """Generate code for a single file with validation and test execution.
-
-        Generation attempts for each file are tracked and capped by
-        ``max_validation_attempts`` to prevent endless retries.
-
-        Args:
-            file_path: Path to the file being generated
-            implementation_details: List of details about functions/classes to implement
-            tests: Dictionary of tests relevant to this implementation
-            context: Additional context information
-
-        Returns:
-            Generated code as a string
-        """
-        self.scratchpad.log("CodeGenerator", f"Generating code for {file_path}")
-
-        # Track how many times we have attempted to generate this file
-        attempt = self._generation_attempts.get(file_path, 0) + 1
-        self._generation_attempts[file_path] = attempt
-        if attempt > self.max_validation_attempts:
-            self.scratchpad.log(
-                "CodeGenerator",
-                f"Max generation attempts exceeded for {file_path}",
-                level=LogLevel.ERROR,
-            )
-            return ""
-
-        # Extract relevant tests
+        """Generate code for a single file with validation and tests."""
+        system_prompt = self.context_manager.create_generation_prompt(context)
+        functions_str = "\n\n".join(
+            [
+                f"Function: {d.get('function', 'unnamed')}\n"
+                + (f"Signature: {d.get('signature', 'Not provided')}\n" if 'signature' in d else "")
+                + f"Description: {d.get('description', 'Not provided')}\n"
+                + (f"Imports: {', '.join(d.get('imports', []))}\n" if d.get('imports') else "")
+                for d in implementation_details
+            ]
+        )
         relevant_tests = self._extract_relevant_tests(tests, file_path)
-
-        # Create system prompt
-        system_prompt = f"""You are an expert software engineer generating code for '{file_path}'.
-        Generate high-quality, idiomatic Python code based on the implementation details and tests provided.
-        Your task is to generate ONLY the code for this specific file, not multiple files.
-
-        **Follow these project guidelines:**
-        *   Include all necessary imports at the top of the file.
-        *   Implement all specified functions/classes according to details.
-        *   Add comprehensive docstrings for all public functions and classes.
-        *   Provide type hints for all parameters and return values.
-        *   Follow PEP 8 style guidelines and any repo-specific conventions.
-        *   Apply OWASP Top 10 security practices and secure coding techniques.
-        *   Consider performance implications: algorithmic complexity and resource usage.
-        *   Ensure the code will pass the specified tests.
-        *   Respond only with the complete code, no explanations.
-        """
-
-        # Create user prompt with implementation details and test requirements
-        functions_str = "\n\n".join([
-            f"Function: {detail.get('function', 'unnamed')}\n" +
-            (f"Signature: {detail.get('signature', 'Not provided')}\n" if 'signature' in detail else "") +
-                                                            f"Description: {detail.get('description', 'Not provided')}\n" +
-                                                            (f"Imports: {', '.join(detail.get('imports', []))}\n" if detail.get('imports') else "")
-            for detail in implementation_details
-        ])
-
         test_cases_str = ""
         if relevant_tests:
             unit_tests = relevant_tests.get("unit_tests", [])
             integration_tests = relevant_tests.get("integration_tests", [])
-
             if unit_tests:
                 test_cases_str += "\n\nUnit Tests:\n"
                 for test in unit_tests:
                     test_cases_str += f"- Test: {test.get('test_name', 'unnamed')}\n"
-                    if 'tested_functions' in test:
-                        test_cases_str += (
-                            f"  Tests functions: {', '.join(test['tested_functions'])}\n"
-                        )
-                    if 'code' in test:
+                    if "tested_functions" in test:
+                        test_cases_str += f"  Tests functions: {', '.join(test['tested_functions'])}\n"
+                    if "code" in test:
                         test_cases_str += f"  Code:\n```python\n{test['code']}\n```\n"
-
             if integration_tests:
                 test_cases_str += "\n\nIntegration Tests:\n"
                 for test in integration_tests:
                     test_cases_str += f"- Test: {test.get('test_name', 'unnamed')}\n"
-                    if 'components_involved' in test:
-                        test_cases_str += (
-                            f"  Components: {', '.join(test['components_involved'])}\n"
-                        )
-                    if 'code' in test:
+                    if "components_involved" in test:
+                        test_cases_str += f"  Components: {', '.join(test['components_involved'])}\n"
+                    if "code" in test:
                         test_cases_str += f"  Code:\n```python\n{test['code']}\n```\n"
-
-        # Include existing code if available
         existing_code_str = ""
         if context.get("existing_code"):
             existing_code_str = f"\nExisting code (to modify/extend):\n```python\n{context['existing_code']}\n```"
-
-        # Include related files for context
         related_files_str = ""
         if context.get("related_files"):
             related_files_str = "\nRelated files:\n"
             for related_path, content in context.get("related_files", {}).items():
-                # Truncate content to keep prompt size manageable
                 truncated = content[:1000] + "..." if len(content) > 1000 else content
                 related_files_str += f"\nFile: {related_path}\n```python\n{truncated}\n```\n"
-
-        user_prompt = f"""Generate the code for file: {file_path}
-
-        {existing_code_str}
-
-        Implementation details:
-        {functions_str}
-
-        {test_cases_str}
-
-        {related_files_str}
-
-        Write the complete code for {file_path} that implements all the specified functionality.
-        Ensure your code is properly formatted, well-documented, and will pass all tests.
-        """
-
-        # Generate code with validation
+        user_prompt = (
+            f"Generate the code for file: {file_path}\n\n{existing_code_str}\n\nImplementation details:\n{functions_str}\n"
+            f"{test_cases_str}\n{related_files_str}\nWrite the complete code for {file_path} that implements all the specified functionality."
+        )
         generated_code = self._generate_with_validation(file_path, system_prompt, user_prompt)
-
         return generated_code
 
-    def _generate_with_validation(self, file_path: str, system_prompt: str, user_prompt: str,
-                                  max_validation_attempts: int = None) -> str:
-        """Generates code with validation and refinement until it passes or reaches max attempts.
-
-        Implements a multi-stage process:
-        1. Initial code generation
-        2. Syntax and linting validation
-        3. Test execution and validation
-        4. Refinement based on issues (if any)
-
-        Args:
-            file_path: Path to the file being generated
-            system_prompt: System prompt for the LLM
-            user_prompt: User prompt containing implementation details
-            max_validation_attempts: Maximum number of validation attempts (defaults to class attribute)
-
-        Returns:
-            Generated and validated code as a string
-        """
+    # ------------------------------------------------------------------
+    def _generate_with_validation(
+        self, file_path: str, system_prompt: str, user_prompt: str, max_validation_attempts: Optional[int] = None
+    ) -> str:
         self.scratchpad.log("CodeGenerator", f"Generating initial code for {file_path}")
-
         if max_validation_attempts is None:
             max_validation_attempts = self.max_validation_attempts
-
-        # Initial generation
         response = self.coordinator.router_agent.call_llm_by_role(
-            role='generator',
-            system_prompt=system_prompt,
-            user_prompt=user_prompt,
-            config={'temperature': 0.2}  # Lower temperature for precision
+            role="generator", system_prompt=system_prompt, user_prompt=user_prompt, config={"temperature": 0.2}
         )
-
-        # Extract code from response
         generated_code = self._extract_code_from_response(response, file_path)
-
-        # Validate and refine cycle
         for attempt in range(max_validation_attempts):
             self.scratchpad.log(
-                "CodeGenerator",
-                f"Validating generated code (attempt {attempt + 1}/{max_validation_attempts})",
+                "CodeGenerator", f"Validating generated code (attempt {attempt + 1}/{max_validation_attempts})"
             )
-            # Check for syntax and lint issues
-            is_valid, issues = self._validate_generated_code(file_path, generated_code)
-
+            is_valid, issues = self.validator.validate_generated_code(file_path, generated_code)
             if is_valid:
                 self.scratchpad.log("CodeGenerator", f"Generated valid code for {file_path}")
                 break
-
             self.scratchpad.log("CodeGenerator", f"Validation found issues: {issues}")
-
-            if attempt < max_validation_attempts - 1:  # Still have attempts left
-                # Refine based on validation issues
+            if attempt < max_validation_attempts - 1:
                 generated_code = self._refine_code(file_path, generated_code, issues)
-            else:  # Last attempt, try debugging if available
-                if self.debugging_manager:
-                    # Collect debug information
-                    debug_info = self._collect_debug_info(file_path, generated_code, issues)
-
-                    # Try to debug the generation issue
-                    debug_result = self._debug_generation_issue(file_path, debug_info, 'validation_failure')
-
-                    if debug_result.get("success", False) and "fixed_code" in debug_result:
-                        self.scratchpad.log("CodeGenerator", f"Applied debugging fix for {file_path}")
-                        generated_code = debug_result["fixed_code"]
-
-                        # Verify the fix
-                        is_valid, issues = self._validate_generated_code(file_path, generated_code)
-                        if is_valid:
-                            self.scratchpad.log("CodeGenerator", f"Debugging fix resolved all issues for {file_path}")
-                        else:
-                            self.scratchpad.log("CodeGenerator", f"Debugging fix still has issues: {issues}",
-                                               level=LogLevel.WARNING)
-
-        # Final step: Run tests against our best code (even if it has minor issues)
-        test_results = self._run_tests(file_path, generated_code)
-
-        if not test_results["success"]:
-            self.scratchpad.log("CodeGenerator", f"Tests failed for {file_path}: {test_results['issues']}",
-                               level=LogLevel.WARNING)
-
-            # Try to refine based on test failures
-            refined_code = self._refine_based_on_test_results(file_path, generated_code, test_results)
-
-            # Verify that the refined code is at least syntactically valid
+            else:
+                debug_info = self.debug_utils.collect_debug_info(file_path, generated_code, issues)
+                debug_result = self.debug_utils.debug_generation_issue(file_path, debug_info, "validation_failure")
+                if debug_result.get("success") and "fixed_code" in debug_result:
+                    generated_code = debug_result["fixed_code"]
+                    is_valid, issues = self.validator.validate_generated_code(file_path, generated_code)
+                    if is_valid:
+                        self.scratchpad.log(
+                            "CodeGenerator", f"Debugging fix resolved all issues for {file_path}"
+                        )
+                    else:
+                        self.scratchpad.log(
+                            "CodeGenerator", f"Debugging fix still has issues: {issues}", level=LogLevel.WARNING
+                        )
+        test_results = self.validator.run_tests(file_path, generated_code)
+        if not test_results.get("success", True):
+            self.scratchpad.log(
+                "CodeGenerator", f"Tests failed for {file_path}: {test_results.get('issues')}", level=LogLevel.WARNING
+            )
+            refined_code = self.validator.refine_based_on_test_results(file_path, generated_code, test_results)
             try:
                 ast.parse(refined_code)
-                self.scratchpad.log("CodeGenerator", f"Applied test-based refinements for {file_path}")
                 generated_code = refined_code
-
-                # Run tests one more time
-                final_test_results = self._run_tests(file_path, generated_code)
-
-                if final_test_results["success"]:
+                final_results = self.validator.run_tests(file_path, generated_code)
+                if final_results.get("success", False):
                     self.scratchpad.log("CodeGenerator", f"All tests now pass for {file_path}")
                 else:
-                    self.scratchpad.log("CodeGenerator",
-                                       f"Some tests still fail after refinement: {final_test_results['issues']}",
-                                       level=LogLevel.WARNING)
+                    self.scratchpad.log(
+                        "CodeGenerator",
+                        f"Some tests still fail after refinement: {final_results.get('issues')}",
+                        level=LogLevel.WARNING,
+                    )
             except SyntaxError:
-                self.scratchpad.log("CodeGenerator",
-                                   "Test-based refinement produced invalid code, keeping previous version",
-                                   level=LogLevel.WARNING)
+                self.scratchpad.log(
+                    "CodeGenerator",
+                    "Test-based refinement produced invalid code, keeping previous version",
+                    level=LogLevel.WARNING,
+                )
         else:
             self.scratchpad.log("CodeGenerator", f"All tests pass for {file_path}")
-
         return generated_code
 
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _extract_code_from_response(response: str, file_path: str) -> str:
+        code_block_pattern = r"```(?:python)?(?:\s*\n)(.*?)(?:\n```)"
+        matches = re.findall(code_block_pattern, response, re.DOTALL)
+        if matches:
+            return matches[0].strip()
+        lines = response.split("\n")
+        code_lines: List[str] = []
+        in_code = False
+        for line in lines:
+            if not in_code and not line.strip():
+                continue
+            if not in_code and (
+                line.strip().startswith("import ")
+                or line.strip().startswith("from ")
+                or line.strip().startswith("def ")
+                or line.strip().startswith("class ")
+                or line.strip().startswith("#")
+            ):
+                in_code = True
+            if in_code:
+                code_lines.append(line)
+        if code_lines:
+            return "\n".join(code_lines)
+        return response
+
+    # ------------------------------------------------------------------
+    def _refine_code(self, file_path: str, original_code: str, validation_issues: List[str]) -> str:
+        self.scratchpad.log("CodeGenerator", f"Refining code for {file_path}")
+        system_prompt = (
+            "You are an expert software engineer fixing code that has validation issues.\n"
+            "Review the code and the reported issues carefully.\n"
+            "Return only the fixed code with no explanations or markdown."
+        )
+        user_prompt = (
+            f"The following code for '{file_path}' has validation issues that need to be fixed:\n\n"
+            f"```python\n{original_code}\n```\n\nThese are the validation issues that need to be fixed:\n"
+            f"{json.dumps(validation_issues, indent=2)}\n\nPlease fix the code and return only the fixed code."
+        )
+        response = self.coordinator.router_agent.call_llm_by_role(
+            role="generator", system_prompt=system_prompt, user_prompt=user_prompt, config={"temperature": 0.1}
+        )
+        refined_code = self._extract_code_from_response(response, file_path)
+        if not refined_code or len(refined_code.strip()) < 10:
+            self.scratchpad.log(
+                "CodeGenerator", "Refinement returned invalid code, using original", level=LogLevel.WARNING
+            )
+            return original_code
+        return refined_code
+
+    # ------------------------------------------------------------------
     def _extract_relevant_tests(self, tests: Dict[str, Any], file_path: str) -> Dict[str, Any]:
-        """Extract tests relevant to a specific file.
-
-        Supported keys in ``tests`` include ``"unit_tests"``, ``"integration_tests"``,
-        ``"property_based_tests"``, and ``"acceptance_tests"``. These categories
-        are optional and skipped when missing.
-
-        Args:
-            tests: Dictionary of all tests
-            file_path: Path to the file being implemented
-
-        Returns:
-            Dictionary with relevant test definitions
-        """
-        # Extract base file name without extension for matching
         file_name = os.path.basename(file_path)
         file_base = os.path.splitext(file_name)[0]
 
-        # Helper function to check if a test is relevant to this file
-        def is_test_relevant(test):
-            # Check for direct file path match
+        def is_test_relevant(test: Dict[str, Any]) -> bool:
             if test.get("file", "").endswith(file_path):
                 return True
-
-            # Check for module name match (e.g., "test_module.py" matches "module.py")
             if "tested_functions" in test:
                 for func in test["tested_functions"]:
                     if file_base in func:
                         return True
-
-            # Check for component involvement in integration tests
             if "components_involved" in test:
                 for component in test["components_involved"]:
                     if file_base == component or file_base == component.replace("_", ""):
                         return True
-
             return False
 
-        relevant_tests = {}
-
-        # Filter unit tests
+        relevant_tests: Dict[str, Any] = {}
         if "unit_tests" in tests:
-            relevant_tests["unit_tests"] = [
-                test for test in tests.get("unit_tests", [])
-                if is_test_relevant(test)
-            ]
-
-        # Filter integration tests
+            relevant_tests["unit_tests"] = [test for test in tests.get("unit_tests", []) if is_test_relevant(test)]
         if "integration_tests" in tests:
             relevant_tests["integration_tests"] = [
-                test for test in tests.get("integration_tests", [])
-                if is_test_relevant(test)
+                test for test in tests.get("integration_tests", []) if is_test_relevant(test)
             ]
-
         return relevant_tests
-
-    def _extract_code_from_response(self, response: str, file_path: str) -> str:
-        """Extract code from an LLM response.
-
-        Args:
-            response: The LLM response string
-            file_path: Path to the file being generated (for context)
-
-        Returns:
-            Extracted code as a string
-        """
-        # First try to extract code from markdown code blocks
-        code_block_pattern = r'```(?:python)?(?:\s*\n)(.*?)(?:\n```)'
-        matches = re.findall(code_block_pattern, response, re.DOTALL)
-
-        if matches:
-            return matches[0].strip()
-
-        # Fallback: Try to extract the first substantial code-like segment
-        lines = response.split('\n')
-        code_lines = []
-        in_code = False
-
-        for line in lines:
-            # Skip explanatory text at the beginning
-            if not in_code and not line.strip():
-                continue
-
-            # Start collecting when we see something that looks like code
-            if not in_code and (line.strip().startswith('import ') or
-                              line.strip().startswith('from ') or
-                              line.strip().startswith('def ') or
-                              line.strip().startswith('class ') or
-                              line.strip().startswith('#')):
-                in_code = True
-
-            if in_code:
-                code_lines.append(line)
-
-        if code_lines:
-            return '\n'.join(code_lines)
-
-        # If nothing else works, return the whole response but log a warning
-        self.scratchpad.log("CodeGenerator", f"Could not extract code from LLM response for {file_path}", level=LogLevel.WARNING)
-        return response
-
-    def _refine_code(self, file_path: str, original_code: str, validation_issues: List[str]) -> str:
-        """Refines code based on validation issues.
-
-        Args:
-            file_path: Path to the file being refined
-            original_code: Current version of the code
-            validation_issues: List of validation issues to address
-
-        Returns:
-            Refined code as a string
-        """
-        self.scratchpad.log("CodeGenerator", f"Refining code for {file_path}")
-
-        system_prompt = """You are an expert software engineer fixing code that has validation issues.
-        Review the code and the reported issues carefully.
-        Your task is to fix all the issues while preserving the core functionality and structure.
-        Ensure the fixes maintain security best practices and do not degrade performance.
-        Return only the fixed code with no explanations or markdown.
-        """
-
-        user_prompt = f"""The following code for '{file_path}' has validation issues that need to be fixed:
-
-```python
-{original_code}
-```
-
-These are the validation issues that need to be fixed:
-{json.dumps(validation_issues, indent=2)}
-
-Please fix the code to address all these issues while maintaining security best practices and performance considerations. Return only the fixed code.
-"""
-
-        response = self.coordinator.router_agent.call_llm_by_role(
-            role='generator',
-            system_prompt=system_prompt,
-            user_prompt=user_prompt,
-            config={'temperature': 0.1}  # Lower temperature for refinement
-        )
-
-        # Extract code
-        refined_code = self._extract_code_from_response(response, file_path)
-        if not refined_code or len(refined_code.strip()) < 10:  # Fallback if extraction fails
-            self.scratchpad.log("CodeGenerator", "Refinement returned invalid code, using original", level=LogLevel.WARNING)
-            return original_code
-
-        return refined_code
-
-    def _collect_debug_info(
-        self, file_path: str, generated_code: str, issues: List[str]
-    ) -> Dict[str, Any]:
-        """Collect debug information for problematic code generation.
-
-        Args:
-            file_path: Path to the file with issues
-            generated_code: The problematic code
-            issues: List of validation issues
-
-        Returns:
-            Dictionary with debug information
-        """
-        debug_info = {
-            "file_path": file_path,
-            "generated_code": generated_code,
-            "issues": issues,
-            "issue_count": len(issues),
-            "timestamp": datetime.datetime.now().isoformat(),
-            "issue_categories": {}
-        }
-
-        # Categorize issues
-        syntax_issues = []
-        lint_issues = []
-        type_issues = []
-        test_issues = []
-        import_issues = []
-        undefined_issues = []
-        other_issues = []
-
-        for issue in issues:
-            if "Syntax error" in issue or "invalid syntax" in issue:
-                syntax_issues.append(issue)
-            elif "No module named" in issue:
-                import_issues.append(issue)
-            elif "not defined" in issue or "undefined" in issue:
-                undefined_issues.append(issue)
-            elif "Linting" in issue:
-                lint_issues.append(issue)
-            elif "Type checking" in issue or "Incompatible" in issue:
-                type_issues.append(issue)
-            elif "Test failure" in issue or "Test '" in issue:
-                test_issues.append(issue)
-            else:
-                other_issues.append(issue)
-
-        if syntax_issues:
-            debug_info["issue_categories"]["syntax"] = syntax_issues
-        if import_issues:
-            debug_info["issue_categories"]["import"] = import_issues
-        if undefined_issues:
-            debug_info["issue_categories"]["undefined"] = undefined_issues
-        if lint_issues:
-            debug_info["issue_categories"]["lint"] = lint_issues
-        if type_issues:
-            debug_info["issue_categories"]["type"] = type_issues
-        if test_issues:
-            debug_info["issue_categories"]["test"] = test_issues
-        if other_issues:
-            debug_info["issue_categories"]["other"] = other_issues
-
-        # Add summary for quick reference
-        debug_info["summary"] = (
-            f"{len(syntax_issues)} syntax, {len(lint_issues)} lint, "
-            f"{len(type_issues)} type, {len(test_issues)} test issues"
-        )
-
-        # Critical issues include syntax errors, import errors and undefined variables
-        debug_info["critical_issues"] = (
-            syntax_issues + import_issues + undefined_issues + test_issues
-        )
-
-        return debug_info
-
-    def _get_context_cache_key(self, file_path: str, details: Any) -> str:
-        """Return a cache key for context based on file path and details."""
-        try:
-            serialized = json.dumps(details, sort_keys=True, default=str)
-        except Exception:
-            serialized = str(details)
-        return f"{file_path}:{hash(serialized)}"
-
-    def _is_context_cache_valid(self, file_path: str, cached_context: Dict[str, Any]) -> bool:
-        """Check if the cached context for a file is still valid."""
-        cache_key = self._get_context_cache_key(file_path, cached_context.get("functions_to_implement", []))
-        dep_info = self._context_dependency_map.get(cache_key)
-        if not dep_info:
-            return False
-
-        for path, mtime in dep_info.get("timestamps", {}).items():
-            try:
-                if os.path.exists(path) and os.path.getmtime(path) > mtime:
-                    return False
-            except Exception:
-                return False
-        return True
-
-    def _cache_context(
-        self, file_path: str, context: Dict[str, Any], dependencies: List[str]
-    ) -> None:
-        """Cache prepared context for a file."""
-        cache_key = self._get_context_cache_key(file_path, context.get("functions_to_implement", []))
-
-        if len(self._context_cache) >= self._context_cache_max_size:
-            oldest_key = next(iter(self._context_cache))
-            self._context_cache.pop(oldest_key, None)
-            self._context_dependency_map.pop(oldest_key, None)
-
-        self._context_cache[cache_key] = context
-        timestamps = {}
-        for p in [file_path] + list(dependencies):
-            if os.path.exists(p):
-                try:
-                    timestamps[p] = os.path.getmtime(p)
-                except Exception:
-                    pass
-        self._context_dependency_map[cache_key] = {"paths": dependencies, "timestamps": timestamps}
-
-    def _extract_imports_and_dependencies(self, file_path: str, imports: List[str]) -> List[str]:
-        """Return paths of modules imported by the file within the workspace."""
-        dep_paths: List[str] = []
-        base_dir = os.path.dirname(file_path)
-        for imp in imports:
-            module_path = os.path.join(base_dir, imp.replace(".", os.sep) + ".py")
-            if os.path.exists(module_path):
-                dep_paths.append(module_path)
-            else:
-                alt_path = imp.replace(".", os.sep) + ".py"
-                if os.path.exists(alt_path):
-                    dep_paths.append(alt_path)
-        return dep_paths
-
-    def _prioritize_context(self, context: Dict[str, Any], token_budget: int) -> Dict[str, Any]:
-        """Trim context information so it fits within the token budget."""
-        def approx_tokens(s: str) -> int:
-            """Approximate token count based on string length."""
-            return len(s) // 4
-
-        prioritized = {
-            "existing_code": context.get("existing_code", ""),
-            "related_files": dict(context.get("related_files", {})),
-            "imports": context.get("imports", []),
-            "functions_to_implement": context.get("functions_to_implement", []),
-        }
-
-        def total_tokens(ctx: Dict[str, Any]) -> int:
-            tokens = approx_tokens(ctx.get("existing_code", ""))
-            for content in ctx.get("related_files", {}).values():
-                tokens += approx_tokens(content)
-            return tokens
-
-        while total_tokens(prioritized) > token_budget and prioritized["related_files"]:
-            # Drop the largest related file
-            largest = max(prioritized["related_files"].items(), key=lambda x: len(x[1]))[0]
-            prioritized["related_files"].pop(largest)
-
-        if total_tokens(prioritized) > token_budget and prioritized.get("existing_code"):
-            excess = total_tokens(prioritized) - token_budget
-            cut_chars = excess * 4
-            prioritized["existing_code"] = prioritized["existing_code"][:-cut_chars]
-
-        return prioritized
-
-    def _validate_generated_code(
-        self, file_path: str, generated_code: str
-    ) -> Tuple[bool, List[str]]:
-        """Validate generated code with syntax, linting and type checks."""
-        issues: List[str] = []
-
-        # Syntax check
-        try:
-            ast.parse(generated_code)
-        except SyntaxError as e:
-            issues.append(f"Syntax error: {e.msg}")
-
-        # Write code to a temporary file for tooling
-        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".py")
-        try:
-            tmp.write(generated_code.encode())
-            tmp.flush()
-            if hasattr(self.coordinator, "bash_tool") and self.coordinator.bash_tool:
-                rc, output = self.coordinator.bash_tool.run_command(f"flake8 {tmp.name}")
-                if rc != 0 and output:
-                    issues.extend(
-                        [f"Linting: {line}" for line in output.splitlines() if line.strip()]
-                    )
-
-                rc, output = self.coordinator.bash_tool.run_command(f"python -m mypy {tmp.name}")
-                if rc != 0 and output:
-                    issues.extend(
-                        [
-                            f"Type checking: {line}"
-                            for line in output.splitlines()
-                            if line.strip()
-                        ]
-                    )
-        finally:
-            tmp.close()
-            os.unlink(tmp.name)
-
-        return len(issues) == 0, issues
-
-    def _run_tests(self, file_path: str, generated_code: str) -> Dict[str, Any]:
-        """Run project tests and return structured results."""
-        if hasattr(self.coordinator, "test_runner_tool") and self.coordinator.test_runner_tool:
-            try:
-                return self.coordinator.test_runner_tool.run_tests()
-            except Exception as e:
-                return {"success": False, "issues": [str(e)]}
-        elif hasattr(self.coordinator, "bash_tool") and self.coordinator.bash_tool:
-            rc, output = self.coordinator.bash_tool.run_command("python -m pytest -v")
-            success = rc == 0
-            result = {"success": success, "output": output}
-            if not success:
-                result["issues"] = output.splitlines()
-            return result
-        return {"success": True, "message": "No test runner available"}
-
-    def _debug_generation_issue(self, file_path: str, info: Any, issues: Any) -> Dict[str, Any]:
-        """Provide diagnostics for generation issues and integrate with debugging manager."""
-        if isinstance(info, dict) and isinstance(issues, str):
-            debug_info = info
-        else:
-            generated_code = info
-            issues_list = issues if isinstance(issues, list) else [issues]
-            debug_info = self._collect_debug_info(file_path, generated_code, issues_list)
-
-        debug_info["categorized_issues"] = list(debug_info.get("issue_categories", {}).keys())
-
-        suggested = []
-        for issue in debug_info.get("issues", []):
-            suggestion = "Review the issue"
-            if "No module named" in issue:
-                mod = re.search(r"No module named '([^']+)'", issue)
-                if mod:
-                    suggestion = f"Install or add module '{mod.group(1)}'"
-            elif "not defined" in issue or "undefined" in issue:
-                name_match = re.search(r"'([^']+)'", issue)
-                if name_match:
-                    suggestion = f"Define '{name_match.group(1)}' before use"
-            elif "Syntax error" in issue or "invalid syntax" in issue:
-                suggestion = "Fix the syntax near the referenced line"
-            elif "Incompatible" in issue or "type" in issue.lower():
-                suggestion = "Check type annotations and return values"
-            suggested.append({"issue": issue, "suggestion": suggestion})
-
-        debug_info["suggested_fixes"] = suggested
-
-        fixed_code = None
-        if self.debugging_manager:
-            if hasattr(self.debugging_manager, "register_generation_issues"):
-                self.debugging_manager.register_generation_issues(file_path, debug_info)
-
-            if hasattr(self.debugging_manager, "analyze_issue"):
-                try:
-                    analysis_result = self.debugging_manager.analyze_issue(file_path, debug_info)
-                    if isinstance(analysis_result, dict):
-                        if analysis_result.get("analysis"):
-                            debug_info["analysis"] = analysis_result["analysis"]
-                        if analysis_result.get("suggested_fixes"):
-                            debug_info.setdefault("suggested_fixes", []).extend(
-                                analysis_result.get("suggested_fixes")
-                            )
-                        fixed_code = analysis_result.get("fixed_code")
-                except Exception as e:  # pragma: no cover - best effort
-                    self.scratchpad.log(
-                        "CodeGenerator",
-                        f"Debugging manager analyze_issue failed: {e}",
-                        level=LogLevel.WARNING,
-                    )
-
-            if hasattr(self.debugging_manager, "log_diagnostic_result"):
-                self.debugging_manager.log_diagnostic_result()
-
-        if fixed_code:
-            return {"success": True, "fixed_code": fixed_code}
-
-        return debug_info
-
-    def _refine_based_on_test_results(
-        self, file_path: str, code: str, test_results: Dict[str, Any]
-    ) -> str:
-        """Refine generated code based on failing test results."""
-        failures = test_results.get("failure_info") or test_results.get("issues", [])
-        details = json.dumps(failures, indent=2)
-        system_prompt = "You are a developer fixing code to satisfy failing tests."
-        user_prompt = (
-            f"""The following code for '{file_path}' fails tests:
-```python
-{code}
-```
-
-Test failures:
-{details}
-
-Please update the code so that the tests pass. Return only the fixed code."""
-        )
-
-        response = self.coordinator.router_agent.call_llm_by_role(
-            role="generator",
-            system_prompt=system_prompt,
-            user_prompt=user_prompt,
-            config={"temperature": 0.1},
-        )
-        refined = self._extract_code_from_response(response, file_path)
-        return refined if refined else code
-
-    def _estimate_file_complexity(
-        self, implementation_details: List[Dict[str, Any]], file_path: str | None = None
-    ) -> float:
-        # Estimate file complexity based on implementation details and existing code.
-        complexity = 1.0
-        if not implementation_details:
-            return complexity
-
-        funcs = sum(1 for d in implementation_details if "function" in d)
-        classes = sum(1 for d in implementation_details if "class" in d)
-        imports = sum(len(d.get("imports", [])) for d in implementation_details)
-
-        complexity += 0.2 * funcs + 0.3 * classes + 0.05 * imports
-
-        for d in implementation_details:
-            sig = d.get("signature", "")
-            complexity += 0.02 * sig.count(",")
-            if re.search(r"thread|async|process", sig, re.IGNORECASE):
-                complexity += 0.3
-
-        if file_path and ("tests" in file_path or os.path.basename(file_path).startswith("test_")):
-            complexity += 0.3
-
-        if file_path and hasattr(self.coordinator, "file_tool") and self.coordinator.file_tool:
-            try:
-                if os.path.exists(file_path):
-                    existing = self.coordinator.file_tool.read_file(file_path)
-                    defs = (
-                        len(re.findall(r"^\s*def\s", existing, re.MULTILINE))
-                        + len(re.findall(r"^\s*class\s", existing, re.MULTILINE))
-                    )
-                    complexity += 0.1 * min(defs, 10)
-            except Exception:
-                pass
-
-        return complexity
-
-    def _get_model_token_capacity(self) -> int:
-        # Return the approximate token capacity of the generator model.
-        return CONTEXT_WINDOW_GENERATOR
-

--- a/agent_s3/code_validator.py
+++ b/agent_s3/code_validator.py
@@ -1,0 +1,83 @@
+"""Validation helpers for generated code."""
+from __future__ import annotations
+
+import ast
+import json
+import os
+import re
+import tempfile
+from typing import Any, Dict, List, Tuple
+
+
+class CodeValidator:
+    """Run validation checks and project tests."""
+
+    def __init__(self, coordinator: Any) -> None:
+        self.coordinator = coordinator
+        self.scratchpad = coordinator.scratchpad
+
+    def validate_generated_code(self, file_path: str, generated_code: str) -> Tuple[bool, List[str]]:
+        """Validate generated code with syntax, linting and type checks."""
+        issues: List[str] = []
+        try:
+            ast.parse(generated_code)
+        except SyntaxError as e:
+            issues.append(f"Syntax error: {e.msg}")
+
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".py")
+        try:
+            tmp.write(generated_code.encode())
+            tmp.flush()
+            if hasattr(self.coordinator, "bash_tool") and self.coordinator.bash_tool:
+                rc, output = self.coordinator.bash_tool.run_command(f"flake8 {tmp.name}")
+                if rc != 0 and output:
+                    issues.extend([f"Linting: {line}" for line in output.splitlines() if line.strip()])
+
+                rc, output = self.coordinator.bash_tool.run_command(f"python -m mypy {tmp.name}")
+                if rc != 0 and output:
+                    issues.extend([f"Type checking: {line}" for line in output.splitlines() if line.strip()])
+        finally:
+            tmp.close()
+            os.unlink(tmp.name)
+        return len(issues) == 0, issues
+
+    def run_tests(self, file_path: str, generated_code: str) -> Dict[str, Any]:
+        """Run project tests and return structured results."""
+        if hasattr(self.coordinator, "test_runner_tool") and self.coordinator.test_runner_tool:
+            try:
+                return self.coordinator.test_runner_tool.run_tests()
+            except Exception as e:
+                return {"success": False, "issues": [str(e)]}
+        if hasattr(self.coordinator, "bash_tool") and self.coordinator.bash_tool:
+            rc, output = self.coordinator.bash_tool.run_command("python -m pytest -v")
+            success = rc == 0
+            result = {"success": success, "output": output}
+            if not success:
+                result["issues"] = output.splitlines()
+            return result
+        return {"success": True, "message": "No test runner available"}
+
+    def refine_based_on_test_results(self, file_path: str, code: str, test_results: Dict[str, Any]) -> str:
+        """Refine generated code based on failing test results."""
+        failures = test_results.get("failure_info") or test_results.get("issues", [])
+        details = json.dumps(failures, indent=2)
+        system_prompt = "You are a developer fixing code to satisfy failing tests."
+        user_prompt = (
+            f"The following code for '{file_path}' fails tests:\n```python\n{code}\n```\n\n"
+            f"Test failures:\n{details}\n\nPlease update the code so that the tests pass. Return only the fixed code."
+        )
+        response = self.coordinator.router_agent.call_llm_by_role(
+            role="generator",
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            config={"temperature": 0.1},
+        )
+        refined = self._extract_code_from_response(response, file_path)
+        return refined if refined else code
+
+    def _extract_code_from_response(self, response: str, file_path: str) -> str:
+        code_block_pattern = r"```(?:python)?(?:\s*\n)(.*?)(?:\n```)"
+        matches = re.findall(code_block_pattern, response, re.DOTALL)
+        if matches:
+            return matches[0].strip()
+        return response

--- a/agent_s3/context_manager.py
+++ b/agent_s3/context_manager.py
@@ -1,0 +1,322 @@
+"""Utilities for preparing generation context."""
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Any, Dict, List, Optional
+
+from .enhanced_scratchpad_manager import LogLevel
+from .config import CONTEXT_WINDOW_GENERATOR
+
+
+class ContextManager:
+    """Manage context gathering and caching for code generation."""
+
+    def __init__(self, coordinator: Any) -> None:
+        self.coordinator = coordinator
+        self.scratchpad = coordinator.scratchpad
+        self._context_cache: Dict[str, Dict[str, Any]] = {}
+        self._context_cache_max_size = 10
+        self._context_dependency_map: Dict[str, Dict[str, Any]] = {}
+
+    def allocate_token_budget(self, total_tokens: int, attempt_num: int = 1) -> Dict[str, int]:
+        """Allocate token budget for context elements."""
+        task_tokens = int(total_tokens * 0.1)
+        plan_tokens = int(total_tokens * 0.3)
+        code_tokens = int(total_tokens * 0.5)
+        tech_tokens = total_tokens - (task_tokens + plan_tokens + code_tokens)
+
+        if attempt_num >= 2:
+            code_tokens += int(total_tokens * 0.1)
+            plan_tokens = max(plan_tokens - int(total_tokens * 0.05), 0)
+        if attempt_num >= 3:
+            code_tokens += int(total_tokens * 0.1)
+            plan_tokens = max(plan_tokens - int(total_tokens * 0.05), 0)
+
+        allocation = {
+            "task": task_tokens,
+            "plan": plan_tokens,
+            "code_context": code_tokens,
+            "tech_stack": tech_tokens,
+        }
+        diff = total_tokens - sum(allocation.values())
+        allocation["code_context"] += diff
+        return allocation
+
+    def gather_minimal_context(
+        self,
+        task: str,
+        plan: Any,
+        tech_stack: Dict[str, Any],
+        token_budgets: Dict[str, int],
+    ) -> Dict[str, Any]:
+        """Return minimal context for generation, handling JSON plans."""
+        is_json = isinstance(plan, dict)
+        context = {
+            "task": task,
+            "tech_stack": tech_stack,
+            "code_context": {},
+            "is_json_plan": is_json,
+            "previous_attempts": [],
+        }
+        if is_json:
+            context["test_plan"] = plan.get("test_plan")
+            context["plan"] = json.dumps(plan.get("functional_plan", plan), indent=2)
+        else:
+            context["plan"] = str(plan)
+        return context
+
+    def gather_full_context(
+        self,
+        task: str,
+        plan: Any,
+        tech_stack: Dict[str, Any],
+        token_budgets: Dict[str, int],
+        failed_attempts: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, Any]:
+        """Gather full context for generation with optional summarization."""
+        context = self.gather_minimal_context(task, plan, tech_stack, token_budgets)
+        context["previous_attempts"] = failed_attempts or []
+
+        if self.coordinator and hasattr(self.coordinator, "memory_manager"):
+            mm = self.coordinator.memory_manager
+            plan_str = context["plan"]
+            budget = token_budgets.get("plan", len(str(plan_str)))
+            if isinstance(plan_str, str) and mm.estimate_token_count(plan_str) > budget:
+                context["plan"] = mm.summarize(plan_str, budget)
+        return context
+
+    def create_generation_prompt(self, context: Dict[str, Any]) -> str:
+        """Create a generation prompt from gathered context."""
+        task = context.get("task", "")
+        plan = context.get("plan", "")
+        prompt_sections = [f"# Task\n{task}"]
+        if context.get("is_json_plan"):
+            prompt_sections.append("# Structured Plan (JSON Format)")
+            prompt_sections.append(str(plan))
+            if context.get("test_plan") is not None:
+                prompt_sections.append("# Test Plan")
+                prompt_sections.append(json.dumps(context["test_plan"], indent=2))
+            prompt_sections.append("# Instructions for JSON Plan Implementation")
+            prompt_sections.append(
+                "Follow these steps to implement the feature based on the JSON structured plan"
+            )
+        else:
+            prompt_sections.append("# Plan")
+            prompt_sections.append(str(plan))
+        return "\n".join(prompt_sections)
+
+    def prepare_file_context(
+        self, file_path: str, implementation_details: List[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        """Prepare context for a file by reading related existing files."""
+        self._validate_path(file_path)
+        self.scratchpad.log("ContextManager", f"Preparing context for {file_path}")
+
+        cache_key = self._get_context_cache_key(file_path, implementation_details)
+        cached_context = self._context_cache.get(cache_key)
+        if cached_context and self._is_context_cache_valid(file_path, cached_context):
+            self.scratchpad.log("ContextManager", f"Using cached context for {file_path}")
+            return cached_context
+
+        context: Dict[str, Any] = {}
+        try:
+            if hasattr(self.coordinator, "file_tool") and self.coordinator.file_tool:
+                if os.path.exists(file_path):
+                    existing_code = self.coordinator.file_tool.read_file(file_path)
+                    context["existing_code"] = existing_code
+                    self.scratchpad.log("ContextManager", f"Added existing code for {file_path} to context")
+                else:
+                    context["existing_code"] = ""
+        except Exception as e:
+            self.scratchpad.log(
+                "ContextManager", f"Error reading existing file {file_path}: {e}", level=LogLevel.WARNING
+            )
+            context["existing_code"] = ""
+
+        imports = set()
+        for detail in implementation_details:
+            if "imports" in detail:
+                if isinstance(detail["imports"], list):
+                    imports.update(detail["imports"])
+                elif isinstance(detail["imports"], str):
+                    imports.add(detail["imports"])
+            if "signature" in detail:
+                signature = detail.get("signature", "")
+                import_matches = re.findall(r"from\s+(\S+)\s+import\s+|import\s+(\S+)", signature)
+                for from_import, direct_import in import_matches:
+                    if from_import:
+                        imports.add(from_import)
+                    if direct_import:
+                        imports.add(direct_import)
+        context["imports"] = list(imports)
+
+        related_files: Dict[str, str] = {}
+        dependency_paths = self._extract_imports_and_dependencies(file_path, context["imports"])
+
+        file_dir = os.path.dirname(file_path)
+        if hasattr(self.coordinator, "file_tool") and self.coordinator.file_tool:
+            try:
+                if os.path.exists(file_dir):
+                    dir_files = [
+                        os.path.join(file_dir, f)
+                        for f in os.listdir(file_dir)
+                        if os.path.isfile(os.path.join(file_dir, f)) and f.endswith(".py")
+                    ]
+                    for dep_path in dir_files[:3]:
+                        if dep_path != file_path and dep_path not in dependency_paths:
+                            dependency_paths.append(dep_path)
+            except Exception as e:
+                self.scratchpad.log(
+                    "ContextManager", f"Error listing directory {file_dir}: {e}", level=LogLevel.WARNING
+                )
+
+        for dep_path in dependency_paths:
+            try:
+                if hasattr(self.coordinator, "file_tool") and self.coordinator.file_tool:
+                    if os.path.exists(dep_path):
+                        related_content = self.coordinator.file_tool.read_file(dep_path)
+                        if related_content:
+                            if len(related_content) > 2000:
+                                related_content = related_content[:2000] + "... [truncated]"
+                            related_files[dep_path] = related_content
+            except Exception as e:
+                self.scratchpad.log(
+                    "ContextManager", f"Error reading related file {dep_path}: {e}", level=LogLevel.WARNING
+                )
+
+        context["related_files"] = related_files
+        self.scratchpad.log("ContextManager", f"Added {len(related_files)} related files to context")
+
+        functions_to_implement = [d["function"] for d in implementation_details if "function" in d]
+        context["functions_to_implement"] = functions_to_implement
+
+        file_complexity = self._estimate_file_complexity(implementation_details, file_path)
+        max_tokens = self._get_model_token_capacity()
+        token_budget = min(int(max_tokens * 0.75), 6000 + (file_complexity * 1000))
+        prioritized_context = self._prioritize_context(context, token_budget)
+
+        self.scratchpad.log(
+            "ContextManager",
+            f"Context preparation complete for {file_path} (complexity: {file_complexity:.1f}, budget: {token_budget} tokens)",
+        )
+        self._cache_context(file_path, prioritized_context, dependency_paths)
+        return prioritized_context
+
+    # internal helpers
+    def _get_context_cache_key(self, file_path: str, details: Any) -> str:
+        try:
+            serialized = json.dumps(details, sort_keys=True, default=str)
+        except Exception:
+            serialized = str(details)
+        return f"{file_path}:{hash(serialized)}"
+
+    def _is_context_cache_valid(self, file_path: str, cached_context: Dict[str, Any]) -> bool:
+        cache_key = self._get_context_cache_key(file_path, cached_context.get("functions_to_implement", []))
+        dep_info = self._context_dependency_map.get(cache_key)
+        if not dep_info:
+            return False
+        for path, mtime in dep_info.get("timestamps", {}).items():
+            try:
+                if os.path.exists(path) and os.path.getmtime(path) > mtime:
+                    return False
+            except Exception:
+                return False
+        return True
+
+    def _cache_context(self, file_path: str, context: Dict[str, Any], dependencies: List[str]) -> None:
+        cache_key = self._get_context_cache_key(file_path, context.get("functions_to_implement", []))
+        if len(self._context_cache) >= self._context_cache_max_size:
+            oldest_key = next(iter(self._context_cache))
+            self._context_cache.pop(oldest_key, None)
+            self._context_dependency_map.pop(oldest_key, None)
+        self._context_cache[cache_key] = context
+        timestamps: Dict[str, float] = {}
+        for p in [file_path] + list(dependencies):
+            if os.path.exists(p):
+                try:
+                    timestamps[p] = os.path.getmtime(p)
+                except Exception:
+                    pass
+        self._context_dependency_map[cache_key] = {"paths": dependencies, "timestamps": timestamps}
+
+    def _extract_imports_and_dependencies(self, file_path: str, imports: List[str]) -> List[str]:
+        dep_paths: List[str] = []
+        base_dir = os.path.dirname(file_path)
+        for imp in imports:
+            module_path = os.path.join(base_dir, imp.replace(".", os.sep) + ".py")
+            if os.path.exists(module_path):
+                dep_paths.append(module_path)
+            else:
+                alt_path = imp.replace(".", os.sep) + ".py"
+                if os.path.exists(alt_path):
+                    dep_paths.append(alt_path)
+        return dep_paths
+
+    def _prioritize_context(self, context: Dict[str, Any], token_budget: int) -> Dict[str, Any]:
+        def approx_tokens(s: str) -> int:
+            return len(s) // 4
+
+        prioritized = {
+            "existing_code": context.get("existing_code", ""),
+            "related_files": dict(context.get("related_files", {})),
+            "imports": context.get("imports", []),
+            "functions_to_implement": context.get("functions_to_implement", []),
+        }
+
+        def total_tokens(ctx: Dict[str, Any]) -> int:
+            tokens = approx_tokens(ctx.get("existing_code", ""))
+            for content in ctx.get("related_files", {}).values():
+                tokens += approx_tokens(content)
+            return tokens
+
+        while total_tokens(prioritized) > token_budget and prioritized["related_files"]:
+            largest = max(prioritized["related_files"].items(), key=lambda x: len(x[1]))[0]
+            prioritized["related_files"].pop(largest)
+
+        if total_tokens(prioritized) > token_budget and prioritized.get("existing_code"):
+            excess = total_tokens(prioritized) - token_budget
+            cut_chars = excess * 4
+            prioritized["existing_code"] = prioritized["existing_code"][:-cut_chars]
+        return prioritized
+
+    def _estimate_file_complexity(
+        self, implementation_details: List[Dict[str, Any]], file_path: Optional[str] = None
+    ) -> float:
+        complexity = 1.0
+        if not implementation_details:
+            return complexity
+        funcs = sum(1 for d in implementation_details if "function" in d)
+        classes = sum(1 for d in implementation_details if "class" in d)
+        imports = sum(len(d.get("imports", [])) for d in implementation_details)
+        complexity += 0.2 * funcs + 0.3 * classes + 0.05 * imports
+        for d in implementation_details:
+            sig = d.get("signature", "")
+            complexity += 0.02 * sig.count(",")
+            if re.search(r"thread|async|process", sig, re.IGNORECASE):
+                complexity += 0.3
+        if file_path and ("tests" in file_path or os.path.basename(file_path).startswith("test_")):
+            complexity += 0.3
+        if file_path and hasattr(self.coordinator, "file_tool") and self.coordinator.file_tool:
+            try:
+                if os.path.exists(file_path):
+                    existing = self.coordinator.file_tool.read_file(file_path)
+                    defs = len(re.findall(r"^\s*def\s", existing, re.MULTILINE)) + len(
+                        re.findall(r"^\s*class\s", existing, re.MULTILINE)
+                    )
+                    complexity += 0.1 * min(defs, 10)
+            except Exception:
+                pass
+        return complexity
+
+    def _get_model_token_capacity(self) -> int:
+        return CONTEXT_WINDOW_GENERATOR
+
+    @staticmethod
+    def _validate_path(path: str) -> None:
+        normalized = os.path.normpath(path)
+        if os.path.isabs(normalized) and not normalized.startswith(os.getcwd()):
+            raise ValueError("Invalid absolute path outside workspace")
+        if ".." in normalized.split(os.sep):
+            raise ValueError("Path traversal detected")

--- a/agent_s3/debug_utils.py
+++ b/agent_s3/debug_utils.py
@@ -1,0 +1,116 @@
+"""Integration helpers for the debugging manager."""
+from __future__ import annotations
+
+import datetime
+import re
+from typing import Any, Dict, List
+
+from .enhanced_scratchpad_manager import LogLevel
+
+
+class DebugUtils:
+    """Assist with collection and analysis of debug information."""
+
+    def __init__(self, debugging_manager: Any, scratchpad: Any) -> None:
+        self.debugging_manager = debugging_manager
+        self.scratchpad = scratchpad
+
+    def collect_debug_info(self, file_path: str, generated_code: str, issues: List[str]) -> Dict[str, Any]:
+        """Collect debug information for problematic code generation."""
+        debug_info = {
+            "file_path": file_path,
+            "generated_code": generated_code,
+            "issues": issues,
+            "issue_count": len(issues),
+            "timestamp": datetime.datetime.now().isoformat(),
+            "issue_categories": {},
+        }
+        syntax_issues: List[str] = []
+        lint_issues: List[str] = []
+        type_issues: List[str] = []
+        test_issues: List[str] = []
+        import_issues: List[str] = []
+        undefined_issues: List[str] = []
+        other_issues: List[str] = []
+        for issue in issues:
+            if "Syntax error" in issue or "invalid syntax" in issue:
+                syntax_issues.append(issue)
+            elif "No module named" in issue:
+                import_issues.append(issue)
+            elif "not defined" in issue or "undefined" in issue:
+                undefined_issues.append(issue)
+            elif "Linting" in issue:
+                lint_issues.append(issue)
+            elif "Type checking" in issue or "Incompatible" in issue:
+                type_issues.append(issue)
+            elif "Test failure" in issue or "Test '" in issue:
+                test_issues.append(issue)
+            else:
+                other_issues.append(issue)
+        if syntax_issues:
+            debug_info["issue_categories"]["syntax"] = syntax_issues
+        if import_issues:
+            debug_info["issue_categories"]["import"] = import_issues
+        if undefined_issues:
+            debug_info["issue_categories"]["undefined"] = undefined_issues
+        if lint_issues:
+            debug_info["issue_categories"]["lint"] = lint_issues
+        if type_issues:
+            debug_info["issue_categories"]["type"] = type_issues
+        if test_issues:
+            debug_info["issue_categories"]["test"] = test_issues
+        if other_issues:
+            debug_info["issue_categories"]["other"] = other_issues
+        debug_info["summary"] = (
+            f"{len(syntax_issues)} syntax, {len(lint_issues)} lint, "
+            f"{len(type_issues)} type, {len(test_issues)} test issues"
+        )
+        debug_info["critical_issues"] = syntax_issues + import_issues + undefined_issues + test_issues
+        return debug_info
+
+    def debug_generation_issue(self, file_path: str, info: Any, issues: Any) -> Dict[str, Any]:
+        """Provide diagnostics for generation issues and integrate with debugging manager."""
+        if isinstance(info, dict) and isinstance(issues, str):
+            debug_info = info
+        else:
+            generated_code = info
+            issues_list = issues if isinstance(issues, list) else [issues]
+            debug_info = self.collect_debug_info(file_path, generated_code, issues_list)
+        debug_info["categorized_issues"] = list(debug_info.get("issue_categories", {}).keys())
+        suggested: List[Dict[str, str]] = []
+        for issue in debug_info.get("issues", []):
+            suggestion = "Review the issue"
+            if "No module named" in issue:
+                mod = re.search(r"No module named '([^']+)'", issue)
+                if mod:
+                    suggestion = f"Install or add module '{mod.group(1)}'"
+            elif "not defined" in issue or "undefined" in issue:
+                name_match = re.search(r"'([^']+)'", issue)
+                if name_match:
+                    suggestion = f"Define '{name_match.group(1)}' before use"
+            elif "Syntax error" in issue or "invalid syntax" in issue:
+                suggestion = "Fix the syntax near the referenced line"
+            elif "Incompatible" in issue or "type" in issue.lower():
+                suggestion = "Check type annotations and return values"
+            suggested.append({"issue": issue, "suggestion": suggestion})
+        debug_info["suggested_fixes"] = suggested
+        fixed_code = None
+        if self.debugging_manager:
+            if hasattr(self.debugging_manager, "register_generation_issues"):
+                self.debugging_manager.register_generation_issues(file_path, debug_info)
+            if hasattr(self.debugging_manager, "analyze_issue"):
+                try:
+                    analysis_result = self.debugging_manager.analyze_issue(file_path, debug_info)
+                    if isinstance(analysis_result, dict):
+                        if analysis_result.get("analysis"):
+                            debug_info["analysis"] = analysis_result["analysis"]
+                        if analysis_result.get("suggested_fixes"):
+                            debug_info.setdefault("suggested_fixes", []).extend(analysis_result.get("suggested_fixes"))
+                        fixed_code = analysis_result.get("fixed_code")
+                except Exception as e:  # pragma: no cover - best effort
+                    self.scratchpad.log("DebugUtils", f"Debugging manager analyze_issue failed: {e}", level=LogLevel.WARNING)
+            if hasattr(self.debugging_manager, "log_diagnostic_result"):
+                self.debugging_manager.log_diagnostic_result()
+        if fixed_code:
+            return {"success": True, "fixed_code": fixed_code}
+        return debug_info

--- a/tests/test_code_generator_json_plan.py
+++ b/tests/test_code_generator_json_plan.py
@@ -76,7 +76,7 @@ def test_minimal_context_with_json_plan(mock_coordinator, sample_json_plan):
     }
 
     # Test with JSON plan
-    context = generator._gather_minimal_context(
+    context = generator.context_manager.gather_minimal_context(
         task="Implement XYZ feature",
         plan=sample_json_plan,
         tech_stack={"languages": ["Python"]},
@@ -110,7 +110,7 @@ def test_create_generation_prompt_with_json_plan(mock_coordinator, sample_json_p
     }
 
     # Generate prompt
-    prompt = generator._create_generation_prompt(context)
+    prompt = generator.context_manager.create_generation_prompt(context)
 
     # Verify prompt contains JSON plan sections
     assert "# Structured Plan (JSON Format)" in prompt
@@ -141,7 +141,7 @@ def test_full_context_with_json_plan(mock_coordinator, sample_json_plan):
     mock_coordinator.memory_manager.estimate_token_count.side_effect = lambda x: len(x) if isinstance(x, str) else 5000
 
     # Test with JSON plan that needs truncation
-    context = generator._gather_full_context(
+    context = generator.context_manager.gather_full_context(
         task="Implement XYZ feature",
         plan=sample_json_plan,
         tech_stack={"languages": ["Python"]},


### PR DESCRIPTION
## Summary
- modularize code generator into `context_manager`, `code_validator`, and `debug_utils`
- update `CodeGenerator` to use new helpers
- export new classes in package init
- adjust tests for new modules

## Testing
- `ruff check agent_s3/context_manager.py agent_s3/code_validator.py agent_s3/debug_utils.py agent_s3/code_generator.py tests/test_code_generator.py tests/test_code_generator_json_plan.py agent_s3/__init__.py`
- `mypy agent_s3/context_manager.py agent_s3/code_validator.py agent_s3/debug_utils.py agent_s3/code_generator.py tests/test_code_generator.py tests/test_code_generator_json_plan.py agent_s3/__init__.py`
- `pytest tests/test_code_generator.py tests/test_code_generator_json_plan.py -q`