### PR TITLE
Fix assertion style

### DIFF
--- a/tests/test_security_validator.py
+++ b/tests/test_security_validator.py
@@ -85,5 +85,5 @@ class TestSecurityValidator:
         # Valid structure
         result, issues = self.validator.validate_architecture_security_items(
             self.architecture_review)
-        assert result == True
+        assert result
         assert not issues


### PR DESCRIPTION
## Summary
- simplify assertion in security validator test

## Testing
- `pytest -q tests/test_security_validator.py` *(fails: ModuleNotFoundError)*
- `pytest -q` *(fails: multiple syntax errors during collection)*