### PR TITLE
Fix method definitions in base extractor

### DIFF
--- a/agent_s3/tools/parsing/framework_extractors/base_extractor.py
+++ b/agent_s3/tools/parsing/framework_extractors/base_extractor.py
@@ -6,15 +6,11 @@ from typing import Any, Dict, List, Optional
 
 class FrameworkExtractor(ABC):
     @abstractmethod
-    def extract(self, root_node: Any, file_path: str, content: str, language: str,
-         tech_stack: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:        """
-        Extract framework-specific nodes and edges from the AST.
-        """
+    def extract(self, root_node: Any, file_path: str, content: str, language: str, tech_stack: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
+        """Extract framework-specific nodes and edges from the AST."""
         pass
 
     @abstractmethod
-    def is_relevant_framework(self, tech_stack: Dict[str, Any], file_path: str, content: str)
-         -> bool:        """
-        Determine if this extractor should run for the given context.
-        """
+    def is_relevant_framework(self, tech_stack: Dict[str, Any], file_path: str, content: str) -> bool:
+        """Determine if this extractor should run for the given context."""
         pass


### PR DESCRIPTION
## Summary
- single-line method signatures for `extract` and `is_relevant_framework`
- keep docstrings on the line following method definitions

## Testing
- `python -m py_compile agent_s3/tools/parsing/framework_extractors/base_extractor.py`