### PR TITLE
Refactor debugging manager into modules

### DIFF
--- a/agent_s3/debugging/__init__.py
+++ b/agent_s3/debugging/__init__.py
@@ -1,0 +1,22 @@
+"""Debugging support utilities and models."""
+
+from .models import (
+    ErrorCategory,
+    DebuggingPhase,
+    RestartStrategy,
+    ErrorContext,
+    DebugAttempt,
+)
+from .patterns import ErrorPatternMatcher
+from .context import create_error_context, process_test_failure_data
+
+__all__ = [
+    "ErrorCategory",
+    "DebuggingPhase",
+    "RestartStrategy",
+    "ErrorContext",
+    "DebugAttempt",
+    "ErrorPatternMatcher",
+    "create_error_context",
+    "process_test_failure_data",
+]

--- a/agent_s3/debugging/context.py
+++ b/agent_s3/debugging/context.py
@@ -1,0 +1,84 @@
+"""Functions for building error context information."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from .models import ErrorContext
+from .patterns import ErrorPatternMatcher
+
+
+logger = logging.getLogger(__name__)
+
+
+def process_test_failure_data(metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Extract structured information from test failure metadata."""
+    if not metadata:
+        return {}
+
+    if metadata.get("failed_step") == "tests":
+        info = metadata.get("failure_info")
+        if isinstance(info, list) and info:
+            return info[0]
+        if isinstance(info, dict):
+            return info
+
+    test_failure_fields = {
+        "test_name",
+        "test_file",
+        "test_class",
+        "line_number",
+        "expected",
+        "actual",
+        "assertion",
+        "traceback",
+        "failure_category",
+        "possible_bad_test",
+        "variables",
+    }
+    extracted: Dict[str, Any] = {}
+    for field in test_failure_fields:
+        if field in metadata:
+            extracted[field] = metadata[field]
+    return extracted
+
+
+def create_error_context(
+    matcher: ErrorPatternMatcher,
+    error_message: str,
+    traceback_text: str,
+    file_path: Optional[str] = None,
+    line_number: Optional[int] = None,
+    function_name: Optional[str] = None,
+    code_snippet: Optional[str] = None,
+    variables: Optional[Dict[str, Any]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    error_context_manager: Any | None = None,
+) -> ErrorContext:
+    """Create an :class:`ErrorContext` with enriched information."""
+    category = matcher.categorize_error(error_message, traceback_text)
+
+    if not code_snippet and error_context_manager and file_path and line_number:
+        try:
+            context = error_context_manager.get_context_for_error(file_path, line_number, error_message)
+            if context:
+                code_snippet = context.get("code_snippet")
+                if not variables:
+                    variables = context.get("variables", {})
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Error getting additional context: %s", exc)
+
+    error_ctx = ErrorContext(
+        message=error_message,
+        traceback=traceback_text,
+        category=category,
+        file_path=file_path,
+        line_number=line_number,
+        function_name=function_name,
+        code_snippet=code_snippet,
+        variables=variables or {},
+        metadata=metadata or {},
+    )
+    matcher.update_learning(error_message, error_ctx.category)
+    return error_ctx

--- a/agent_s3/debugging/models.py
+++ b/agent_s3/debugging/models.py
@@ -1,0 +1,136 @@
+"""Data models for debugging components."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from datetime import datetime
+from enum import Enum, auto
+from typing import Any, Dict, Optional
+
+
+class ErrorCategory(Enum):
+    """Categories of errors for specialized handling."""
+
+    SYNTAX = auto()
+    TYPE = auto()
+    IMPORT = auto()
+    ATTRIBUTE = auto()
+    NAME = auto()
+    INDEX = auto()
+    VALUE = auto()
+    RUNTIME = auto()
+    MEMORY = auto()
+    PERMISSION = auto()
+    ASSERTION = auto()
+    NETWORK = auto()
+    DATABASE = auto()
+    UNKNOWN = auto()
+
+
+class DebuggingPhase(Enum):
+    """Phases of the debugging process."""
+
+    ANALYSIS = auto()
+    QUICK_FIX = auto()
+    FULL_DEBUG = auto()
+    STRATEGIC_RESTART = auto()
+
+
+class RestartStrategy(Enum):
+    """Strategies for strategic restart."""
+
+    REGENERATE_CODE = auto()
+    REDESIGN_PLAN = auto()
+    MODIFY_REQUEST = auto()
+
+
+@dataclass
+class ErrorContext:
+    """Context information about an error for debugging."""
+
+    message: str
+    traceback: str
+    category: ErrorCategory = ErrorCategory.UNKNOWN
+    file_path: Optional[str] = None
+    line_number: Optional[int] = None
+    function_name: Optional[str] = None
+    code_snippet: Optional[str] = None
+    variables: Dict[str, Any] = field(default_factory=dict)
+    occurred_at: str = field(default_factory=lambda: datetime.now().isoformat())
+    attempt_number: int = 1
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to a dictionary representation."""
+        result = asdict(self)
+        result["category"] = self.category.name
+        return result
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ErrorContext":
+        """Create an instance from a dictionary."""
+        category_name = data.get("category", "UNKNOWN")
+        category = ErrorCategory[category_name] if category_name in ErrorCategory.__members__ else ErrorCategory.UNKNOWN
+        return cls(
+            message=data.get("message", ""),
+            traceback=data.get("traceback", ""),
+            category=category,
+            file_path=data.get("file_path"),
+            line_number=data.get("line_number"),
+            function_name=data.get("function_name"),
+            code_snippet=data.get("code_snippet"),
+            variables=data.get("variables", {}),
+            occurred_at=data.get("occurred_at", datetime.now().isoformat()),
+            attempt_number=data.get("attempt_number", 1),
+            metadata=data.get("metadata", {}),
+        )
+
+    def get_summary(self) -> str:
+        """Return a concise summary of the error."""
+        location = ""
+        if self.file_path:
+            location = f" in {self.file_path}"
+            if self.line_number:
+                location += f" at line {self.line_number}"
+        return f"{self.category.name} error{location}: {self.message}"
+
+
+@dataclass
+class DebugAttempt:
+    """Record of a debugging attempt."""
+
+    error_context: ErrorContext
+    phase: DebuggingPhase
+    fix_description: str
+    code_changes: Dict[str, str]
+    success: bool
+    timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
+    duration_seconds: float = 0.0
+    reasoning: str = ""
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to a dictionary representation."""
+        result = asdict(self)
+        result["error_context"] = self.error_context.to_dict()
+        result["phase"] = self.phase.name
+        return result
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "DebugAttempt":
+        """Create an instance from a dictionary."""
+        error_data = data.get("error_context", {})
+        error_context = ErrorContext.from_dict(error_data)
+        phase_name = data.get("phase", "ANALYSIS")
+        phase = DebuggingPhase[phase_name] if phase_name in DebuggingPhase.__members__ else DebuggingPhase.ANALYSIS
+        return cls(
+            error_context=error_context,
+            phase=phase,
+            fix_description=data.get("fix_description", ""),
+            code_changes=data.get("code_changes", {}),
+            success=data.get("success", False),
+            timestamp=data.get("timestamp", datetime.now().isoformat()),
+            duration_seconds=data.get("duration_seconds", 0.0),
+            reasoning=data.get("reasoning", ""),
+            metadata=data.get("metadata", {}),
+        )

--- a/agent_s3/debugging/patterns.py
+++ b/agent_s3/debugging/patterns.py
@@ -1,0 +1,154 @@
+"""Utilities for categorizing and comparing errors."""
+
+from __future__ import annotations
+
+import logging
+import re
+from difflib import SequenceMatcher
+from typing import Dict, List
+
+from agent_s3.tools.error_pattern_learner import ErrorPatternLearner
+
+from .models import ErrorCategory, ErrorContext
+
+
+class ErrorPatternMatcher:
+    """Handle pattern-based error categorization."""
+
+    def __init__(self) -> None:
+        self.error_patterns: Dict[ErrorCategory, List[str]] = self._initialize_error_patterns()
+        self.pattern_learner = ErrorPatternLearner()
+        self.logger = logging.getLogger(__name__)
+
+    def _initialize_error_patterns(self) -> Dict[ErrorCategory, List[str]]:
+        """Return the default regex patterns for categorizing errors."""
+        return {
+            ErrorCategory.SYNTAX: [
+                r"SyntaxError",
+                r"IndentationError",
+                r"unexpected token",
+                r"invalid syntax",
+                r"unexpected indent",
+                r"expected an indented block",
+            ],
+            ErrorCategory.TYPE: [
+                r"TypeError",
+                r"unsupported operand type",
+                r"not subscriptable",
+                r"has no attribute",
+                r"not a function",
+                r"expected .* to be a",
+                r"can't convert .* to",
+            ],
+            ErrorCategory.IMPORT: [
+                r"ImportError",
+                r"ModuleNotFoundError",
+                r"No module named",
+                r"cannot import name",
+                r"cannot find module",
+            ],
+            ErrorCategory.ATTRIBUTE: [
+                r"AttributeError",
+                r"has no attribute",
+                r"object has no attribute",
+            ],
+            ErrorCategory.NAME: [
+                r"NameError",
+                r"name .* is not defined",
+                r"undefined variable",
+                r"ReferenceError",
+            ],
+            ErrorCategory.INDEX: [
+                r"IndexError",
+                r"out of range",
+                r"list index out of range",
+                r"array index out of bounds",
+            ],
+            ErrorCategory.VALUE: [
+                r"ValueError",
+                r"invalid literal",
+                r"could not convert",
+                r"invalid value",
+                r"value .* is not a valid",
+            ],
+            ErrorCategory.RUNTIME: [
+                r"RuntimeError",
+                r"RecursionError",
+                r"maximum recursion depth exceeded",
+                r"stack overflow",
+            ],
+            ErrorCategory.MEMORY: [
+                r"MemoryError",
+                r"out of memory",
+                r"memory allocation failed",
+                r"cannot allocate",
+            ],
+            ErrorCategory.PERMISSION: [
+                r"PermissionError",
+                r"Permission denied",
+                r"Access is denied",
+                r"not permitted",
+            ],
+            ErrorCategory.ASSERTION: [
+                r"AssertionError",
+                r"Assertion failed",
+                r"Expected .* but got",
+            ],
+            ErrorCategory.NETWORK: [
+                r"ConnectionError",
+                r"ConnectionRefusedError",
+                r"ConnectionResetError",
+                r"TimeoutError",
+                r"Connection refused",
+                r"Network is unreachable",
+                r"Connection timed out",
+            ],
+            ErrorCategory.DATABASE: [
+                r"DatabaseError",
+                r"OperationalError",
+                r"IntegrityError",
+                r"database is locked",
+                r"constraint failed",
+                r"syntax error in SQL",
+                r"no such table",
+            ],
+        }
+
+    def categorize_error(self, error_message: str, traceback_text: str) -> ErrorCategory:
+        """Categorize an error using regex patterns and the learned model."""
+        combined_text = f"{error_message}\n{traceback_text}".lower()
+        for category, patterns in self.error_patterns.items():
+            for pattern in patterns:
+                if re.search(pattern.lower(), combined_text):
+                    return category
+
+        prediction = self.pattern_learner.predict(error_message)
+        if prediction and prediction in ErrorCategory.__members__:
+            return ErrorCategory[prediction]
+        return ErrorCategory.UNKNOWN
+
+    def update_learning(self, message: str, category: ErrorCategory) -> None:
+        """Update the machine-learning model."""
+        try:
+            self.pattern_learner.update(message, category.name)
+        except Exception:  # pragma: no cover - defensive
+            self.logger.debug("Pattern learner update failed")
+
+    @staticmethod
+    def text_similarity(text1: str, text2: str) -> float:
+        """Calculate similarity between two strings."""
+        if not text1 or not text2:
+            return 0.0
+        return SequenceMatcher(None, text1, text2).ratio()
+
+    def is_similar_error(self, error1: ErrorContext, error2: ErrorContext) -> bool:
+        """Return True if two errors are similar enough to be treated the same."""
+        if error1.category != error2.category:
+            return False
+        if error1.file_path != error2.file_path:
+            return False
+        if error1.line_number is not None and error2.line_number is not None:
+            if abs(error1.line_number - error2.line_number) > 5:
+                return False
+        similarity = self.text_similarity(error1.message, error2.message)
+        return similarity > 0.7

--- a/tests/test_debugging_facade.py
+++ b/tests/test_debugging_facade.py
@@ -6,8 +6,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from agent_s3.debugging_manager import (
-    ErrorCategory, DebuggingPhase, ErrorContext, DebugAttempt, DebuggingManager
+from agent_s3.debugging_manager import DebuggingManager
+from agent_s3.debugging import (
+    ErrorCategory,
+    DebuggingPhase,
+    ErrorContext,
+    DebugAttempt,
 )
 from agent_s3.enhanced_scratchpad_manager import (
     EnhancedScratchpadManager, Section


### PR DESCRIPTION
## Summary
- extract debugging enums and dataclasses into `debugging/models.py`
- add `patterns` and `context` utilities for error handling logic
- update `debugging_manager` to orchestrate using the new modules
- adjust tests to import from the debugging package

## Testing
- `ruff check agent_s3/debugging_manager.py agent_s3/debugging tests/test_debugging_facade.py`
- `mypy agent_s3/debugging_manager.py agent_s3/debugging tests/test_debugging_facade.py` *(fails: invalid syntax in unrelated file)*
- `pytest -q` *(fails: 56 errors during collection)*