### PR TITLE
Refactor implementation validator utilities

### DIFF
--- a/agent_s3/tools/implementation_repairs.py
+++ b/agent_s3/tools/implementation_repairs.py
@@ -1,0 +1,328 @@
+"""Helper functions for repairing implementation plans."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from typing import Any, Dict, List, Set
+
+from .utils import find_best_match
+
+
+# ---------------------------- Repair Functions ----------------------------
+
+
+def repair_structure(plan: Dict[str, Any], system_design: Dict[str, Any]) -> Dict[str, Any]:
+    """Repair basic structure issues in the implementation plan."""
+    if not isinstance(plan, dict):
+        plan = {}
+    if not plan:
+        code_elements = system_design.get("code_elements", [])
+        files_by_type: Dict[str, List[Dict[str, Any]]] = {}
+        for element in code_elements:
+            if isinstance(element, dict) and "element_id" in element:
+                element_type = element.get("element_type", "unknown")
+                files_by_type.setdefault(element_type, []).append(element)
+        for element_type, elements in files_by_type.items():
+            if element_type == "class":
+                file_path = "models.py"
+            elif element_type == "function":
+                file_path = "functions.py"
+            elif "service" in element_type or "controller" in element_type:
+                file_path = "services.py"
+            else:
+                file_path = f"{element_type.replace(' ', '_')}.py"
+            plan[file_path] = []
+            for element in elements:
+                element_id = element.get("element_id", "")
+                name = element.get("name", "Unknown")
+                signature = element.get("signature", f"def {name.lower()}():")
+                plan[file_path].append(
+                    {
+                        "function": signature,
+                        "description": f"Implementation of {name}",
+                        "element_id": element_id,
+                        "steps": [
+                            {
+                                "step_description": "Implement core functionality",
+                                "pseudo_code": "# TODO: Implement core functionality",
+                                "relevant_data_structures": [],
+                                "api_calls_made": [],
+                                "error_handling_notes": "Handle potential errors",
+                            }
+                        ],
+                        "edge_cases": ["Error handling needed"],
+                        "architecture_issues_addressed": [],
+                    }
+                )
+    return plan
+
+
+def repair_file_paths(plan: Dict[str, Any], issues: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Repair invalid file paths in the implementation plan."""
+    repaired_plan: Dict[str, Any] = {}
+    for file_path, functions in plan.items():
+        is_valid = True
+        for issue in issues:
+            if issue.get("file_path") == file_path:
+                is_valid = False
+                break
+        if is_valid:
+            repaired_plan[file_path] = functions
+        else:
+            if isinstance(file_path, (int, float, bool)):
+                new_file_path = f"file_{file_path}.py"
+                repaired_plan[new_file_path] = functions
+            elif not isinstance(file_path, str):
+                new_file_path = "unnamed_file.py"
+                repaired_plan[new_file_path] = functions
+            else:
+                if not file_path.endswith(
+                    (".py", ".js", ".ts", ".java", ".rb", ".go", ".c", ".cpp", ".h", ".hpp")
+                ):
+                    new_file_path = f"{file_path}.py"
+                    repaired_plan[new_file_path] = functions
+                else:
+                    repaired_plan[file_path] = functions
+    return repaired_plan
+
+
+def repair_functions_format(plan: Dict[str, Any], issues: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Repair invalid functions format in the implementation plan."""
+    repaired_plan: Dict[str, Any] = {}
+    for file_path, functions in plan.items():
+        needs_repair = any(issue.get("file_path") == file_path for issue in issues)
+        if not needs_repair or isinstance(functions, list):
+            repaired_plan[file_path] = functions
+        else:
+            if isinstance(functions, dict):
+                repaired_plan[file_path] = [functions]
+            elif isinstance(functions, str):
+                repaired_plan[file_path] = [
+                    {
+                        "function": functions,
+                        "description": "Auto-generated function description",
+                        "element_id": f"auto_generated_{file_path.replace('.', '_').replace('/', '_')}",
+                        "steps": [
+                            {
+                                "step_description": "Implement function logic",
+                                "pseudo_code": functions,
+                                "relevant_data_structures": [],
+                                "api_calls_made": [],
+                                "error_handling_notes": "",
+                            }
+                        ],
+                        "edge_cases": [],
+                        "architecture_issues_addressed": [],
+                    }
+                ]
+            else:
+                repaired_plan[file_path] = []
+    return repaired_plan
+
+
+def repair_missing_elements(
+    plan: Dict[str, Any], issues: List[Dict[str, Any]], system_design: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Repair missing element implementations in the implementation plan."""
+    repaired_plan = json.loads(json.dumps(plan))
+    elements_by_type: Dict[str, List[Dict[str, Any]]] = {}
+    for issue in issues:
+        element_id = issue.get("element_id")
+        if not element_id:
+            continue
+        element = next(
+            (e for e in system_design.get("code_elements", []) if isinstance(e, dict) and e.get("element_id") == element_id),
+            None,
+        )
+        if not element:
+            continue
+        element_type = element.get("element_type", "unknown")
+        elements_by_type.setdefault(element_type, []).append(element)
+    for element_type, elements in elements_by_type.items():
+        file_path = None
+        for fp, functions in repaired_plan.items():
+            if not isinstance(functions, list):
+                continue
+            for function in functions:
+                if not isinstance(function, dict):
+                    continue
+                function_element_id = function.get("element_id")
+                if not function_element_id:
+                    continue
+                function_element = next(
+                    (e for e in system_design.get("code_elements", []) if isinstance(e, dict) and e.get("element_id") == function_element_id),
+                    None,
+                )
+                if not function_element:
+                    continue
+                if function_element.get("element_type") == element_type:
+                    file_path = fp
+                    break
+            if file_path:
+                break
+        if not file_path:
+            if element_type == "class":
+                file_path = "models.py"
+            elif element_type == "function":
+                file_path = "functions.py"
+            elif "service" in element_type or "controller" in element_type:
+                file_path = "services.py"
+            else:
+                file_path = f"{element_type.replace(' ', '_')}.py"
+            base_path = file_path
+            counter = 1
+            while file_path in repaired_plan:
+                file_path = f"{base_path[:-3]}_{counter}.py"
+                counter += 1
+            repaired_plan[file_path] = []
+        for element in elements:
+            element_id = element.get("element_id")
+            name = element.get("name", "Unknown")
+            signature = element.get("signature", f"def {name.lower()}():")
+            repaired_plan[file_path].append(
+                {
+                    "function": signature,
+                    "description": f"Implementation of {name}",
+                    "element_id": element_id,
+                    "steps": [
+                        {
+                            "step_description": "Implement core functionality",
+                            "pseudo_code": "# TODO: Implement core functionality",
+                            "relevant_data_structures": [],
+                            "api_calls_made": [],
+                            "error_handling_notes": "Handle potential errors",
+                        }
+                    ],
+                    "edge_cases": ["Error handling needed"],
+                    "architecture_issues_addressed": [],
+                }
+            )
+    return repaired_plan
+
+
+def repair_element_id_references(
+    plan: Dict[str, Any], issues: List[Dict[str, Any]], system_design: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Repair invalid element ID references in the implementation plan."""
+    repaired_plan = json.loads(json.dumps(plan))
+    valid_element_ids: Set[str] = {
+        element["element_id"]
+        for element in system_design.get("code_elements", [])
+        if isinstance(element, dict) and "element_id" in element
+    }
+    for issue in issues:
+        file_path = issue.get("file_path")
+        function_index = issue.get("function_index")
+        invalid_id = issue.get("invalid_id")
+        if not file_path or function_index is None or not invalid_id:
+            continue
+        if file_path in repaired_plan and isinstance(repaired_plan[file_path], list):
+            functions = repaired_plan[file_path]
+            if 0 <= function_index < len(functions):
+                function = functions[function_index]
+                best_match = find_best_match(invalid_id, valid_element_ids)
+                if best_match:
+                    function["element_id"] = best_match
+                elif valid_element_ids:
+                    function["element_id"] = next(iter(valid_element_ids))
+    return repaired_plan
+
+
+def repair_incomplete_implementations(
+    plan: Dict[str, Any],
+    issues: List[Dict[str, Any]],
+    system_design: Dict[str, Any],
+    test_implementations: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Repair incomplete function implementations in the implementation plan."""
+    repaired_plan = json.loads(json.dumps(plan))
+    for issue in issues:
+        file_path = issue.get("file_path")
+        function_index = issue.get("function_index")
+        if file_path not in repaired_plan or not isinstance(repaired_plan[file_path], list):
+            continue
+        functions = repaired_plan[file_path]
+        if not (0 <= function_index < len(functions)):
+            continue
+        function = functions[function_index]
+        if "steps" not in function or not isinstance(function["steps"], list):
+            function["steps"] = [
+                {
+                    "step_description": "Implement logic",
+                    "pseudo_code": "# TODO: implement",
+                    "relevant_data_structures": [],
+                    "api_calls_made": [],
+                    "error_handling_notes": "",
+                }
+            ]
+        if "edge_cases" not in function or not isinstance(function["edge_cases"], list):
+            function["edge_cases"] = []
+        if "architecture_issues_addressed" not in function or not isinstance(function["architecture_issues_addressed"], list):
+            function["architecture_issues_addressed"] = []
+    return repaired_plan
+
+
+def repair_architecture_issue_coverage(
+    plan: Dict[str, Any], issues: List[Dict[str, Any]], architecture_review: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Repair architecture issue coverage in the implementation plan."""
+    repaired_plan = json.loads(json.dumps(plan))
+    element_map: Dict[str, List[tuple[str, int]]] = {}
+    for file_path, functions in repaired_plan.items():
+        if not isinstance(functions, list):
+            continue
+        for idx, function in enumerate(functions):
+            if isinstance(function, dict) and "element_id" in function:
+                element_id = function["element_id"]
+                element_map.setdefault(element_id, []).append((file_path, idx))
+    for issue in issues:
+        issue_type = issue.get("issue_type")
+        arch_issue_id = issue.get("arch_issue_id")
+        if issue_type == "unaddressed_critical_issue" and arch_issue_id:
+            arch_issue = None
+            for section in ("logical_gaps", "security_concerns", "optimization_opportunities"):
+                for ai in architecture_review.get(section, []):
+                    if isinstance(ai, dict) and ai.get("id") == arch_issue_id:
+                        arch_issue = ai
+                        break
+                if arch_issue:
+                    break
+            if not arch_issue:
+                continue
+            target_elements = arch_issue.get("target_element_ids", [])
+            if not target_elements:
+                description = arch_issue.get("description", "")
+                for element_id in element_map.keys():
+                    if element_id.lower() in description.lower():
+                        target_elements.append(element_id)
+            assigned = False
+            for element_id in target_elements:
+                if element_id in element_map:
+                    for file_path, function_idx in element_map[element_id]:
+                        function = repaired_plan[file_path][function_idx]
+                        function.setdefault("architecture_issues_addressed", [])
+                        if arch_issue_id not in function["architecture_issues_addressed"]:
+                            function["architecture_issues_addressed"].append(arch_issue_id)
+                            assigned = True
+            if not assigned and repaired_plan:
+                first_file = next(iter(repaired_plan.keys()))
+                functions = repaired_plan[first_file]
+                if isinstance(functions, list) and functions:
+                    first_function = functions[0]
+                    if isinstance(first_function, dict):
+                        first_function.setdefault("architecture_issues_addressed", [])
+                        if arch_issue_id not in first_function["architecture_issues_addressed"]:
+                            first_function["architecture_issues_addressed"].append(arch_issue_id)
+    return repaired_plan
+
+
+__all__ = [
+    "repair_structure",
+    "repair_file_paths",
+    "repair_functions_format",
+    "repair_missing_elements",
+    "repair_element_id_references",
+    "repair_incomplete_implementations",
+    "repair_architecture_issue_coverage",
+]

--- a/agent_s3/tools/utils/__init__.py
+++ b/agent_s3/tools/utils/__init__.py
@@ -1,0 +1,15 @@
+"""Helper utilities for validation modules."""
+
+from .diff_utils import find_best_match
+from .regex_utils import (
+    extract_assertions,
+    extract_edge_cases,
+    extract_expected_behaviors,
+)
+
+__all__ = [
+    "find_best_match",
+    "extract_assertions",
+    "extract_edge_cases",
+    "extract_expected_behaviors",
+]

--- a/agent_s3/tools/utils/diff_utils.py
+++ b/agent_s3/tools/utils/diff_utils.py
@@ -1,0 +1,25 @@
+"""Utility helpers for diff and similarity comparisons."""
+
+from difflib import SequenceMatcher
+from typing import Iterable, Optional
+
+
+def find_best_match(target: str, candidates: Iterable[str], threshold: float = 0.7) -> Optional[str]:
+    """Return the candidate most similar to *target* above *threshold*.
+
+    Args:
+        target: String we are trying to match.
+        candidates: Possible candidate strings.
+        threshold: Minimum similarity ratio required for a match.
+
+    Returns:
+        The best matching candidate if one exceeds the threshold, else ``None``.
+    """
+    best_match: Optional[str] = None
+    highest_similarity = 0.0
+    for candidate in candidates:
+        similarity = SequenceMatcher(None, target, candidate).ratio()
+        if similarity > highest_similarity and similarity >= threshold:
+            highest_similarity = similarity
+            best_match = candidate
+    return best_match

--- a/agent_s3/tools/utils/regex_utils.py
+++ b/agent_s3/tools/utils/regex_utils.py
@@ -1,0 +1,55 @@
+"""Utility helpers for common regex extraction routines."""
+
+import re
+from typing import Dict, List
+
+
+def extract_assertions(test_code: str) -> List[str]:
+    """Extract assertion statements from test code."""
+    pattern = r"assert\w*\s*\(.*?\)"
+    return [match.strip() for match in re.findall(pattern, test_code)]
+
+
+def extract_edge_cases(test_requirements: List[Dict[str, str]]) -> List[str]:
+    """Extract potential edge cases mentioned in test requirements."""
+    cases: List[str] = []
+    for req in test_requirements:
+        name = req.get("test_name", "").lower()
+        if any(term in name for term in ["edge", "boundary", "invalid", "null", "empty", "error"]):
+            cases.append(name)
+        for assertion in req.get("assertions", []):
+            text = assertion.lower()
+            if any(term in text for term in ["edge", "boundary", "invalid", "null", "empty", "error"]):
+                cases.append(assertion)
+        for line in req.get("code", "").split("\n"):
+            line_lower = line.lower()
+            if any(term in line_lower for term in ["edge case", "boundary", "invalid input", "null value", "empty"]):
+                start = max(0, line_lower.find("edge"))
+                cases.append(line[start:].strip())
+    return list(set(cases))
+
+
+def extract_expected_behaviors(tests: List[Dict[str, str]]) -> List[str]:
+    """Collect behavior descriptions from tests."""
+    behaviors: List[str] = []
+    for test in tests:
+        description = test.get("description")
+        if description:
+            behaviors.append(description)
+        for field in ("given", "when", "then"):
+            value = test.get(field)
+            if value:
+                behaviors.append(value)
+        for assertion in test.get("assertions", []):
+            match = re.search(r',[^,]*[\'\"]([^\'\"]*)[\'\"]', assertion)
+            if match:
+                behaviors.append(match.group(1).strip())
+        for line in test.get("code", "").split("\n"):
+            comment_match = re.match(r"\s*#\s*(.+)$", line)
+            if comment_match:
+                behaviors.append(comment_match.group(1))
+            else:
+                str_match = re.search(r"[\'\"](?:[\'\"][\'\"]\s*)?([^\'\"]*)(?:[\'\"][\'\"])?\s*[\'\"]", line)
+                if str_match:
+                    behaviors.append(str_match.group(1).strip())
+    return behaviors

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,54 @@
+
+from agent_s3.tools.utils import (
+    find_best_match,
+    extract_assertions,
+    extract_edge_cases,
+    extract_expected_behaviors,
+)
+
+
+def test_find_best_match():
+    candidates = {"alpha", "beta", "gamma"}
+    assert find_best_match("alp", candidates) == "alpha"
+    assert find_best_match("bet", candidates) == "beta"
+    assert find_best_match("unknown", candidates) is None
+
+
+def test_extract_assertions():
+    code = """
+    def test():
+        assert foo == 1
+        assertTrue(bar)
+    """
+    assertions = extract_assertions(code)
+    assert "assertTrue(bar)" in assertions
+    assert len(assertions) == 1
+
+
+def test_extract_edge_cases():
+    tests = [
+        {"test_name": "handles edge case", "assertions": [], "code": ""},
+        {"test_name": "normal", "assertions": ["assert fail"], "code": "# edge case"},
+    ]
+    cases = extract_edge_cases(tests)
+    assert any("edge" in c for c in cases)
+
+
+def test_extract_expected_behaviors():
+    tests = [
+        {
+            "description": "should work",
+            "given": "user logged in",
+            "when": "action",
+            "then": "result",
+            "assertions": ["assert 1 == 1, \"ok\""],
+            "code": "# comment",
+        }
+    ]
+    behaviors = extract_expected_behaviors(tests)
+    assert "should work" in behaviors
+    assert "user logged in" in behaviors
+    assert "result" in behaviors
+    assert "ok" in behaviors
+    assert "comment" in behaviors
+


### PR DESCRIPTION
## Summary
- split out repair helpers into `implementation_repairs`
- add generic regex and diff utilities under `tools.utils`
- update `implementation_validator` to use new helpers
- add unit tests for utility functions

## Testing
- `ruff check tests/test_utils.py`
- `mypy agent_s3/tools/utils`
- `mypy agent_s3/tools/implementation_repairs.py`
- `pytest tests/test_utils.py -q`
