### PR TITLE
Fix indentation for cross reference validation

### DIFF
--- a/agent_s3/pre_planner_json_validator.py
+++ b/agent_s3/pre_planner_json_validator.py
@@ -213,8 +213,10 @@ class PrePlannerJsonValidator:
 
         return errors
 
-    def implement_cross_reference_validation(self, data: Dict[str, Any]) -> Tuple[bool, List[str],
-         Dict[str, Any]]:        """
+    def implement_cross_reference_validation(
+        self, data: Dict[str, Any]
+    ) -> Tuple[bool, List[str], Dict[str, Any]]:
+        """
         Validate relationships between plan elements.
 
         Args:
@@ -323,8 +325,10 @@ class PrePlannerJsonValidator:
         is_valid = len(errors) == 0
         return is_valid, errors, data
 
-    def implement_content_validation(self, data: Dict[str, Any]) -> Tuple[bool, List[str], Dict[str,
-         Any]]:        """
+    def implement_content_validation(
+        self, data: Dict[str, Any]
+    ) -> Tuple[bool, List[str], Dict[str, Any]]:
+        """
         Perform semantic validation of plan content.
 
         Args:


### PR DESCRIPTION
## Summary
- normalize indentation for implement_cross_reference_validation
- normalize indentation for implement_content_validation

## Testing
- `ruff check agent_s3` *(fails: SyntaxError in many files)*
- `mypy agent_s3` *(fails: invalid syntax in adaptive_config_manager.py)*
- `pytest` *(fails: errors during collection)*