### PR TITLE
Fix architecture issue assignment loop

### DIFF
--- a/agent_s3/tools/implementation_repairs.py
+++ b/agent_s3/tools/implementation_repairs.py
@@ -305,6 +305,9 @@ def repair_architecture_issue_coverage(
                         if arch_issue_id not in function["architecture_issues_addressed"]:
                             function["architecture_issues_addressed"].append(arch_issue_id)
                             assigned = True
+                            break
+                    if assigned:
+                        break
             if not assigned and repaired_plan:
                 first_file = next(iter(repaired_plan.keys()))
                 functions = repaired_plan[first_file]

--- a/tests/test_implementation_repairs.py
+++ b/tests/test_implementation_repairs.py
@@ -1,0 +1,43 @@
+import pytest
+
+from agent_s3.tools.implementation_repairs import repair_architecture_issue_coverage
+
+
+def test_architecture_issues_addressed_unique():
+    plan = {
+        "file1.py": [
+            {"element_id": "E1", "architecture_issues_addressed": []},
+            {"element_id": "E2", "architecture_issues_addressed": []},
+        ],
+        "file2.py": [
+            {"element_id": "E1", "architecture_issues_addressed": []},
+        ],
+    }
+    issues = [
+        {"issue_type": "unaddressed_critical_issue", "arch_issue_id": "A1"}
+    ]
+    architecture_review = {
+        "logical_gaps": [
+            {
+                "id": "A1",
+                "description": "",
+                "severity": "critical",
+                "target_element_ids": ["E1", "E2"],
+            }
+        ]
+    }
+
+    repaired = repair_architecture_issue_coverage(plan, issues, architecture_review)
+
+    occurrences = sum(
+        "A1" in func.get("architecture_issues_addressed", [])
+        for funcs in repaired.values()
+        for func in funcs
+    )
+    assert occurrences == 1
+
+    for funcs in repaired.values():
+        for func in funcs:
+            ai_list = func.get("architecture_issues_addressed", [])
+            assert len(ai_list) == len(set(ai_list))
+


### PR DESCRIPTION
## Summary
- stop iterating once an architecture issue is assigned to a function
- test that `architecture_issues_addressed` lists contain unique ids

## Testing
- `ruff check agent_s3` *(fails: 4195 errors)*
- `mypy agent_s3` *(fails: 1 error)*
- `pytest -q` *(fails: 59 errors during collection)*