### PR TITLE
Add configurable pattern limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,9 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
     limits incoming WebSocket payloads
   - `TEST_WS_TOKEN` (optional, defaults to `"replace-me"`)
     authentication token for `simple-test-server.js`
+  - `MAX_DESIGN_PATTERNS` (optional, defaults to `3`)
+    limits how many architectural patterns a system design may use to keep
+    the architecture consistent
 
   Example `.env`:
 

--- a/agent_s3/config.py
+++ b/agent_s3/config.py
@@ -90,6 +90,8 @@ EMBEDDER_ROLE_NAME       = os.getenv('EMBEDDER_ROLE_NAME',     'embedder')
 SUMMARIZER_ROLE_NAME     = os.getenv('SUMMARIZER_ROLE_NAME',   'summarizer')
 SUMMARIZER_MAX_CHUNK_SIZE = int(os.getenv('SUMMARIZER_MAX_CHUNK_SIZE', '2048'))
 SUMMARIZER_TIMEOUT       = float(os.getenv('SUMMARIZER_TIMEOUT',      '45.0'))
+# System design pattern validation
+MAX_DESIGN_PATTERNS      = int(os.getenv('MAX_DESIGN_PATTERNS', '3'))
 
 # Supabase configuration
 SUPABASE_URL               = os.getenv('SUPABASE_URL', '')
@@ -205,6 +207,7 @@ class ConfigModel(BaseModel):
     summarizer_role_name: str = SUMMARIZER_ROLE_NAME
     summarizer_max_chunk_size: int = SUMMARIZER_MAX_CHUNK_SIZE
     summarizer_timeout: float = SUMMARIZER_TIMEOUT
+    max_design_patterns: int = MAX_DESIGN_PATTERNS
     adaptive_config_enabled: bool = ADAPTIVE_CONFIG_ENABLED
     adaptive_config_repo_path: str = ADAPTIVE_CONFIG_REPO_PATH
     adaptive_config_dir: str = ADAPTIVE_CONFIG_DIR

--- a/agent_s3/tools/system_design/patterns.py
+++ b/agent_s3/tools/system_design/patterns.py
@@ -6,13 +6,19 @@ import json
 from typing import Any, Dict, List, Set
 
 from .constants import ErrorMessages, logger
+from ...config import get_config
 
 
 def validate_design_patterns(system_design: Dict[str, Any]) -> List[Dict[str, Any]]:
-    """Ensure appropriate architectural patterns are used."""
+    """Ensure appropriate architectural patterns are used.
+
+    Uses ``config.max_design_patterns`` to enforce a limit on the number of
+    architectural patterns allowed in ``system_design``.
+    """
     issues: List[Dict[str, Any]] = []
     patterns = extract_patterns(system_design)
-    if len(patterns) > 3:
+    max_allowed = get_config().max_design_patterns
+    if len(patterns) > max_allowed:
         issues.append(
             {
                 "issue_type": "too_many_patterns",

--- a/tests/test_system_design_modules.py
+++ b/tests/test_system_design_modules.py
@@ -4,7 +4,9 @@ from agent_s3.tools.system_design import (
     is_valid_signature,
     find_circular_dependencies,
     extract_patterns,
+    validate_design_patterns,
 )
+from agent_s3.config import get_config
 
 
 def test_is_valid_signature():
@@ -36,3 +38,15 @@ def test_validate_and_repair():
     assert needs_repair
     repaired = sdv.repair_system_design(validated, issues, reqs)
     assert "code_elements" in repaired
+
+
+def test_validate_design_patterns_limit():
+    config = get_config()
+    old = config.max_design_patterns
+    config.max_design_patterns = 2
+    design = {"overview": "mvc repository factory", "code_elements": []}
+    try:
+        issues = validate_design_patterns(design)
+        assert any(i["issue_type"] == "too_many_patterns" for i in issues)
+    finally:
+        config.max_design_patterns = old


### PR DESCRIPTION
## Summary
- add `MAX_DESIGN_PATTERNS` configuration option
- enforce the limit in `validate_design_patterns`
- document the new variable in README
- test the configurable limit

## Testing
- `pytest -q` *(fails: SyntaxError in repository)*
- `ruff check agent_s3` *(fails: found 4195 errors)*
- `mypy agent_s3` *(fails: 1 error found)*