### PR TITLE
Fix logging stack traces

### DIFF
--- a/agent_s3/planner_json_enforced.py
+++ b/agent_s3/planner_json_enforced.py
@@ -1484,7 +1484,9 @@ def _parse_and_validate_json(response_text: str, schema: Optional[Dict[str, Any]
     try:
         data = json.loads(json_text)
     except json.JSONDecodeError as e:
-        raise JSONPlannerError(f"Invalid JSON received from LLM: {e}\nResponse Text: {response_text[:500]}...")
+        raise JSONPlannerError(
+            f"Invalid JSON received from LLM: {e}\nResponse Text: {response_text}"
+        )
 
     required_top_level_keys = {"architecture_review", "tests", "implementation_plan", "discussion"}
     missing_keys = required_top_level_keys - data.keys()

--- a/agent_s3/router_agent.py
+++ b/agent_s3/router_agent.py
@@ -100,8 +100,8 @@ def _load_llm_config():
         raise
     except json.JSONDecodeError as e:
         raise ValueError(f"Error decoding llm.json: {e}")
-    except Exception as e:
-        logger.error(f"Failed to load LLM configuration: {e}", exc_info=True)
+    except Exception:
+        logger.exception("Failed to load LLM configuration")
         raise
 
 class RouterAgent:
@@ -770,13 +770,13 @@ class RouterAgent:
             duration = time.time() - start
             self.metrics.record(role, model_name, duration, False, 0)
             response_text = e.response.text if e.response else "No response body"
-            error_msg = f"API call to {model_name} failed: {e}. Response: {response_text[:500]}"
+            error_msg = f"API call to {model_name} failed: {e}. Response: {response_text}"
             scratchpad.log("RouterAgent", error_msg, level="error")
             raise ConnectionError(error_msg)
         except (json.JSONDecodeError, KeyError, IndexError, AttributeError, ValueError) as e:
             duration = time.time() - start
             self.metrics.record(role, model_name, duration, False, 0)
-            error_msg = f"Failed to process response from {model_name}: {e}. Response data: {response.text[:500]}"
+            error_msg = f"Failed to process response from {model_name}: {e}. Response data: {response.text}"
             scratchpad.log("RouterAgent", error_msg, level="error")
             raise ValueError(error_msg)
         except Exception as e:

--- a/agent_s3/task_state_manager.py
+++ b/agent_s3/task_state_manager.py
@@ -458,8 +458,8 @@ class TaskStateManager:
 
             logger.info("%s", Saved task snapshot: {snapshot_file})
             return True
-        except Exception as e:
-            logger.error("%s", Error saving task snapshot: {e})
+        except Exception:
+            logger.exception("Error saving task snapshot")
             return False
 
     def load_task_snapshot(self, task_id: str, phase: str) -> Optional[TaskState]:
@@ -494,10 +494,10 @@ class TaskStateManager:
             logger.info("%s", Loaded task snapshot: {snapshot_file})
             return state
         except json.JSONDecodeError:
-            logger.error("%s", Invalid JSON in task snapshot: {snapshot_file})
+            logger.exception("Invalid JSON in task snapshot: %s", snapshot_file)
             return None
-        except Exception as e:
-            logger.error("%s", Error loading task snapshot: {e})
+        except Exception:
+            logger.exception("Error loading task snapshot")
             return None
 
     def get_active_tasks(self) -> List[Dict[str, Any]]:
@@ -544,15 +544,15 @@ class TaskStateManager:
                             os.path.getmtime(os.path.join(task_dir, latest_file))).isoformat(),
                         "request_text": state_dict.get("request_text", "Unknown task")
                     })
-                except Exception as e:
-                    logger.warning("%s", Error reading task snapshot: {e})
+                except Exception:
+                    logger.exception("Error reading task snapshot")
 
             # Sort by last updated time, newest first
             active_tasks.sort(key=lambda t: t.get("last_updated", ""), reverse=True)
 
             return active_tasks
-        except Exception as e:
-            logger.error("%s", Error getting active tasks: {e})
+        except Exception:
+            logger.exception("Error getting active tasks")
             return []
 
     def delete_task(self, task_id: str) -> bool:
@@ -580,8 +580,8 @@ class TaskStateManager:
 
             logger.info("%s", Deleted task: {task_id})
             return True
-        except Exception as e:
-            logger.error("%s", Error deleting task: {e})
+        except Exception:
+            logger.exception("Error deleting task")
             return False
 
     def clear_state(self, task_id: str) -> bool:
@@ -627,8 +627,8 @@ class TaskStateManager:
                     # Delete old tasks
                     logger.info("%s", Cleaning up old task: {task_id} (age: {age/86400:.1f} days))
                     self.delete_task(task_id)
-        except Exception as e:
-            logger.error("%s", Error cleaning up old snapshots: {e})
+        except Exception:
+            logger.exception("Error cleaning up old snapshots")
 
     def recover_from_corrupted_snapshot(self, task_id: str, phase: str) -> Optional[TaskState]:
         """Attempt to recover from a corrupted snapshot.
@@ -711,8 +711,8 @@ class TaskStateManager:
                         logger.info("%s", Found previous phase snapshot: {prev_phase})
                         return prev_state
 
-            logger.error("%s", Failed to recover task snapshot: {snapshot_file})
+            logger.exception("Failed to recover task snapshot: %s", snapshot_file)
             return None
-        except Exception as e:
-            logger.error("%s", Error recovering task snapshot: {e})
+        except Exception:
+            logger.exception("Error recovering task snapshot")
             return None

--- a/agent_s3/tools/context_management/coordinator_integration.py
+++ b/agent_s3/tools/context_management/coordinator_integration.py
@@ -137,9 +137,8 @@ class CoordinatorContextIntegration:
                 "Initialized adaptive configuration system in %s",
                 config_dir,
             )
-        except Exception as e:
-            logger.error("%s", "Failed to set up adaptive configuration: %s", e)
-            logger.debug(traceback.format_exc())
+        except Exception:
+            logger.exception("Failed to set up adaptive configuration")
 
     def integrate(self) -> bool:
         """
@@ -190,9 +189,8 @@ class CoordinatorContextIntegration:
             logger.info("Successfully integrated context management with Coordinator")
             return True
 
-        except Exception as e:
-            logger.error("%s", Failed to integrate context management with Coordinator: {e})
-            logger.debug(traceback.format_exc())
+        except Exception:
+            logger.exception("Failed to integrate context management with Coordinator")
             return False
 
     def _integrate_file_tracking(self) -> None:
@@ -397,7 +395,7 @@ class CoordinatorContextIntegration:
                     self.context_manager.update_context({
                         "recent_logs": {
                             "role": role,
-                            "message": message[:500] if message else "",  # Truncate long messages
+                            "message": message or "",
                             "level": level,
                             "section": section,
                             "metadata": metadata or {}
@@ -435,8 +433,8 @@ class CoordinatorContextIntegration:
                     try:
                         # Nothing to do here, metrics are saved automatically by the metrics collector
                         pass
-                    except Exception as e:
-                        logger.error("%s", Error finalizing adaptive configuration: {e})
+                    except Exception:
+                        logger.exception("Error finalizing adaptive configuration")
 
             # Call original shutdown
             return original_shutdown()
@@ -489,8 +487,8 @@ class CoordinatorContextIntegration:
                         logger.info("Running adaptive configuration optimization")
                         self.adaptive_config_manager.optimize_configuration()
 
-                except Exception as e:
-                    logger.error("%s", Error logging adaptive configuration metrics: {e})
+                except Exception:
+                    logger.exception("Error logging adaptive configuration metrics")
 
                 return response
 
@@ -580,10 +578,9 @@ def setup_context_management(coordinator):
         logger.info(setup_message)
         return True
 
-    except Exception as e:
-        # Log error
-        logger.error("%s", Failed to set up context management: {e})
-        logger.debug(traceback.format_exc())
+    except Exception:
+        # Log error with traceback
+        logger.exception("Failed to set up context management")
 
         if hasattr(coordinator, 'scratchpad'):
             coordinator.scratchpad.log(
@@ -610,7 +607,7 @@ def get_configuration_report(coordinator):
     try:
         return coordinator.config_explainer.get_human_readable_report()
     except Exception as e:
-        logger.error("%s", Failed to get configuration report: {e})
+        logger.exception("Failed to get configuration report")
         return f"Error generating configuration report: {e}"
 
 def optimize_configuration(coordinator, reason: str = "Manual optimization"):
@@ -636,7 +633,7 @@ def optimize_configuration(coordinator, reason: str = "Manual optimization"):
         else:
             return False, "No changes made to configuration"
     except Exception as e:
-        logger.error("%s", Failed to optimize configuration: {e})
+        logger.exception("Failed to optimize configuration")
         return False, f"Error optimizing configuration: {e}"
 
 def reset_configuration(coordinator):
@@ -660,7 +657,7 @@ def reset_configuration(coordinator):
         else:
             return False, "Failed to reset configuration"
     except Exception as e:
-        logger.error("%s", Failed to reset configuration: {e})
+        logger.exception("Failed to reset configuration")
         return False, f"Error resetting configuration: {e}"
 
 def analyze_repository_profile(coordinator):
@@ -695,5 +692,5 @@ def analyze_repository_profile(coordinator):
         profiler = ProjectProfiler(repo_path)
         return profiler.analyze_repository()
     except Exception as e:
-        logger.error("%s", Failed to analyze repository profile: {e})
+        logger.exception("Failed to analyze repository profile")
         return {"error": str(e)}

--- a/agent_s3/tools/test_critic/static_analysis.py
+++ b/agent_s3/tools/test_critic/static_analysis.py
@@ -967,11 +967,15 @@ class CriticStaticAnalyzer:
                 analysis = json.loads(json_str)
                 return analysis
             except json.JSONDecodeError as e:
-                logger.error("%s", Could not parse LLM response as JSON for test analysis. Error: {e}. Response: {response[:500]})
+                logger.exception(
+                    "Could not parse LLM response as JSON for test analysis. Error: %s. Response: %s",
+                    e,
+                    response,
+                )
                 return {"error": "Could not parse LLM response as JSON", "raw_response": response}
 
         except Exception as e:
-            logger.error(f"Error during LLM test analysis: {str(e)}", exc_info=True)
+            logger.exception("Error during LLM test analysis")
             return {"error": f"Error during LLM analysis: {str(e)}"}
 
 

--- a/agent_s3/vscode_integration.py
+++ b/agent_s3/vscode_integration.py
@@ -295,8 +295,8 @@ class VSCodeIntegration:
             logger.info(
                 f"Connection info written to {self.connect_file_path}"
             )
-        except Exception as e:
-            logger.error("Failed to write connection info: %s", e)
+        except Exception:
+            logger.exception("Failed to write connection info")
 
     def stop_server(self) -> None:
         """Stop the WebSocket server."""
@@ -323,8 +323,8 @@ class VSCodeIntegration:
             if os.path.exists(self.connect_file_path):
                 os.remove(self.connect_file_path)
                 logger.info("Connection file removed")
-        except Exception as e:
-            logger.error("Failed to remove connection file: %s", e)
+        except Exception:
+            logger.exception("Failed to remove connection file")
 
     def send_to_chat_ui(self, message: Dict[str, Any]) -> bool:
         """
@@ -343,8 +343,8 @@ class VSCodeIntegration:
         try:
             self.message_queue.put(message)
             return True
-        except Exception as e:
-            logger.error("Failed to queue message: %s", e)
+        except Exception:
+            logger.exception("Failed to queue message")
             return False
 
     def get_user_response(
@@ -388,8 +388,8 @@ class VSCodeIntegration:
                 "Timeout waiting for user response after %s seconds", timeout
             )
             return None
-        except Exception as e:
-            logger.error("Error getting user response: %s", e)
+        except Exception:
+            logger.exception("Error getting user response")
             return None
 
     def display_plan(self, plan: str, summary: str) -> None:


### PR DESCRIPTION
## Summary
- use `logger.exception` for stack traces in VS Code integration
- include stack traces in RouterAgent and remove log truncation
- log stack traces from context management integration
- return full error messages in planner and static analysis
- capture stack traces in TaskStateManager

## Testing
- `pytest -q`
- `mypy agent_s3`
- `ruff check agent_s3`
