### PR TITLE
Sanitize LLM prompt content

### DIFF
--- a/agent_s3/security_utils.py
+++ b/agent_s3/security_utils.py
@@ -1,8 +1,30 @@
 """Security-related utility functions for Agent-S3."""
 from typing import Dict
 from typing import MutableMapping
+import re
 
 SENSITIVE_HEADERS = {"authorization", "cookie", "set-cookie"}
+
+
+PROMPT_BREAK_PATTERN = re.compile(r"```")
+
+
+def sanitize_prompt_text(text: str) -> str:
+    """Return text safe for inclusion in LLM prompts.
+
+    Escapes tokens that could prematurely close code blocks or otherwise
+    disrupt the prompt. Currently this function escapes triple backticks.
+
+    Args:
+        text: Raw text to sanitize.
+
+    Returns:
+        Sanitized text safe for embedding in prompts.
+    """
+
+    if not isinstance(text, str):
+        raise TypeError("text must be a string")
+    return PROMPT_BREAK_PATTERN.sub("\`\`\`", text)
 
 
 def redact_sensitive_headers(headers: MutableMapping[str, str]) -> Dict[str, str]:


### PR DESCRIPTION
## Summary
- add `sanitize_prompt_text` helper for prompts
- sanitize test code before performing LLM analysis
- document sanitization in `perform_llm_analysis`

## Testing
- `ruff check agent_s3 | head -n 20`
- `mypy agent_s3 >/tmp/mypy.txt && tail -n 20 /tmp/mypy.txt`
- `pytest -q`