### PR TITLE
Fix architecture repair index checks

### DIFF
--- a/agent_s3/tools/implementation_repairs.py
+++ b/agent_s3/tools/implementation_repairs.py
@@ -300,7 +300,10 @@ def repair_architecture_issue_coverage(
             for element_id in target_elements:
                 if element_id in element_map:
                     for file_path, function_idx in element_map[element_id]:
-                        function = repaired_plan[file_path][function_idx]
+                        functions = repaired_plan.get(file_path)
+                        if not isinstance(functions, list) or not (0 <= function_idx < len(functions)):
+                            continue
+                        function = functions[function_idx]
                         function.setdefault("architecture_issues_addressed", [])
                         if arch_issue_id not in function["architecture_issues_addressed"]:
                             function["architecture_issues_addressed"].append(arch_issue_id)

--- a/tests/test_implementation_repairs.py
+++ b/tests/test_implementation_repairs.py
@@ -1,0 +1,33 @@
+import pytest
+
+from agent_s3.tools.implementation_repairs import repair_architecture_issue_coverage
+
+
+def test_repair_architecture_issue_coverage_ignores_non_list():
+    plan = {"file.py": {"element_id": "e1"}}
+    issues = [
+        {"issue_type": "unaddressed_critical_issue", "arch_issue_id": "A1"}
+    ]
+    architecture_review = {
+        "logical_gaps": [
+            {"id": "A1", "target_element_ids": ["e1"], "description": ""}
+        ]
+    }
+
+    repaired = repair_architecture_issue_coverage(plan, issues, architecture_review)
+    assert repaired == plan
+
+
+def test_repair_architecture_issue_coverage_handles_missing_function():
+    plan = {}
+    issues = [
+        {"issue_type": "unaddressed_critical_issue", "arch_issue_id": "A2"}
+    ]
+    architecture_review = {
+        "logical_gaps": [
+            {"id": "A2", "target_element_ids": ["missing"], "description": ""}
+        ]
+    }
+
+    repaired = repair_architecture_issue_coverage(plan, issues, architecture_review)
+    assert repaired == {}


### PR DESCRIPTION
## Summary
- prevent `repair_architecture_issue_coverage` from crashing if a file's function list is malformed or indices are invalid
- add unit tests for malformed or missing function entries

## Testing
- `pytest tests/test_implementation_repairs.py -q`