### PR TITLE
Fix bare except in Flask index route

### DIFF
--- a/agent_s3/deployment_manager.py
+++ b/agent_s3/deployment_manager.py
@@ -790,7 +790,8 @@ if os.getenv('DATABASE_URL'):
 def index():
     try:
         return render_template('index.html')
-    except:
+    except Exception as exc:
+        app.logger.error("Template rendering failed: %s", exc)
         return f"<h1>{os.getenv('APP_NAME', 'Flask App')}</h1><p>Running on http://{os.getenv('APP_HOST', '127.0.0.1')}:{os.getenv('APP_PORT', '5000')}</p>"
 
 @app.route('/api/status')


### PR DESCRIPTION
## Summary
- handle Exception explicitly in generated Flask index route
- log errors when index template fails to render

## Testing
- `pytest tests/test_deployment_manager.py::test_create_env_file_quotes_special_values -q` *(fails: assert 'SPECIAL="value "quote" and $dollar"' in ...)*