### PR TITLE
fix(context_registry): correct logger warning syntax

### DIFF
--- a/agent_s3/tools/context_management/context_registry.py
+++ b/agent_s3/tools/context_management/context_registry.py
@@ -34,7 +34,7 @@ class ContextRegistry:
         for provider in self._providers.values():
             if isinstance(provider, FileContextProvider) and hasattr(provider, "get_relevant_files"):
                 return provider.get_relevant_files(query, top_n)
-        logger.warning("%s", No provider found for relevant files: {query})
+        logger.warning("No provider found for relevant files: %s", query)
         return []
     def get_file_history(self, file_path: str = None) -> Dict[str, Any]:
         for provider in self._providers.values():


### PR DESCRIPTION
## Summary
- fix logging for relevant file provider warning

## Testing
- `pytest -q` *(fails: 59 errors during collection)*