### PR TITLE
Fix warning log formatting in context_adapter

### DIFF
--- a/agent_s3/tools/context_management/context_adapter.py
+++ b/agent_s3/tools/context_management/context_adapter.py
@@ -281,7 +281,11 @@ class ContextAdapter:
                 # Just store as text for other file types
                 self.config_cache[filename] = content
         except Exception as e:
-            logger.warning("%s", Failed to cache config file {file_path}: {e})
+            logger.warning(
+                "Failed to cache config file %s: %s",
+                file_path,
+                e,
+            )
 
     def _process_historical_context(self, historical: Dict[str, Any]) -> Dict[str, Any]:
         """


### PR DESCRIPTION
## Summary
- log missing config cache failures with file path and error details

## Testing
- `ruff check agent_s3/`
- `mypy agent_s3/`
- `pytest -q`