### PR TITLE
Fix error log message formatting

### DIFF
--- a/agent_s3/tools/context_management/adaptive_config/config_explainer.py
+++ b/agent_s3/tools/context_management/adaptive_config/config_explainer.py
@@ -322,7 +322,7 @@ class ConfigExplainer:
             return "\n".join(lines)
 
         except Exception as e:
-            logger.error("%s", Error generating human-readable report: {e})
+            logger.error("Error generating human-readable report: %s", e)
             return f"Error generating report: {e}"
 
     def _detect_config_changes(


### PR DESCRIPTION
## Summary
- correct logger usage in `config_explainer`

## Testing
- `pytest -q` *(fails: 59 errors during collection)*