### PR TITLE
Fix log message initialization

### DIFF
--- a/agent_s3/tools/context_management/adaptive_config/adaptive_config_manager.py
+++ b/agent_s3/tools/context_management/adaptive_config/adaptive_config_manager.py
@@ -89,7 +89,7 @@ class AdaptiveConfigManager:
             self._create_initial_configuration()
 
         except Exception as e:
-            logger.error("%s", Error initializing configuration: {e})
+            logger.error("Error initializing configuration: %s", e)
             logger.info("Falling back to default configuration")
 
             # Fall back to default configuration


### PR DESCRIPTION
## Summary
- fix typo in config manager log message

## Testing
- `ruff check agent_s3/tools/context_management/adaptive_config/adaptive_config_manager.py`
- `mypy agent_s3`
- `pytest -q`