### PR TITLE
Fix logging format in code_analysis_tool

### DIFF
--- a/agent_s3/tools/code_analysis_tool.py
+++ b/agent_s3/tools/code_analysis_tool.py
@@ -389,7 +389,10 @@ class CodeAnalysisTool:
                 # Replace results with enhanced results
                 results = enhanced_results
 
-                logger.info("%s", Enhanced search results with structural analysis for query: {query[:50]}...)
+                logger.info(
+                    "Enhanced search results with structural analysis for query: %s...",
+                    query[:50],
+                )
             except Exception as e:
                 logger.error("%s", Error enhancing search results with structural analysis: {e})
 


### PR DESCRIPTION
## Summary
- fix `logger.info` message formatting

## Testing
- `ruff check agent_s3` *(fails: SyntaxError in multiple files)*
- `mypy agent_s3` *(fails: many SyntaxErrors)*
- `pytest -q` *(fails: SyntaxError during test collection)*