### PR TITLE
Remove unused pytest import

### DIFF
--- a/tests/test_implementation_repairs.py
+++ b/tests/test_implementation_repairs.py
@@ -1,4 +1,3 @@
-import pytest
 
 from agent_s3.tools.implementation_repairs import repair_architecture_issue_coverage
 


### PR DESCRIPTION
## Summary
- remove unused pytest import from `tests/test_implementation_repairs.py`

## Testing
- `pytest tests/test_implementation_repairs.py -q`
