### PR TITLE
Handle non-list architecture issue targets

### DIFF
--- a/agent_s3/tools/implementation_repairs.py
+++ b/agent_s3/tools/implementation_repairs.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from collections import defaultdict
 from typing import Any, Dict, List, Set
 
 from .utils import find_best_match
@@ -290,7 +289,13 @@ def repair_architecture_issue_coverage(
                     break
             if not arch_issue:
                 continue
-            target_elements = arch_issue.get("target_element_ids", [])
+            raw_target_elements = arch_issue.get("target_element_ids", [])
+            if isinstance(raw_target_elements, list):
+                target_elements = [te for te in raw_target_elements if te]
+            elif raw_target_elements:
+                target_elements = [raw_target_elements]
+            else:
+                target_elements = []
             if not target_elements:
                 description = arch_issue.get("description", "")
                 for element_id in element_map.keys():

--- a/tests/test_implementation_repairs.py
+++ b/tests/test_implementation_repairs.py
@@ -1,5 +1,3 @@
-import pytest
-
 from agent_s3.tools.implementation_repairs import repair_architecture_issue_coverage
 
 
@@ -40,4 +38,27 @@ def test_architecture_issues_addressed_unique():
         for func in funcs:
             ai_list = func.get("architecture_issues_addressed", [])
             assert len(ai_list) == len(set(ai_list))
+
+
+def test_non_list_target_element_ids_handled():
+    plan = {
+        "file.py": [
+            {"element_id": "E1", "architecture_issues_addressed": []},
+        ]
+    }
+    issues = [{"issue_type": "unaddressed_critical_issue", "arch_issue_id": "A1"}]
+    architecture_review = {
+        "logical_gaps": [
+            {
+                "id": "A1",
+                "description": "",
+                "severity": "critical",
+                "target_element_ids": "E1",
+            }
+        ]
+    }
+
+    repaired = repair_architecture_issue_coverage(plan, issues, architecture_review)
+
+    assert repaired["file.py"][0]["architecture_issues_addressed"] == ["A1"]
 


### PR DESCRIPTION
## Summary
- convert non-list values for `target_element_ids` to lists before assignment
- add regression test for string `target_element_ids`
- remove unused imports in affected files

## Testing
- `ruff check agent_s3/tools/implementation_repairs.py tests/test_implementation_repairs.py`
- `mypy agent_s3/tools/implementation_repairs.py tests/test_implementation_repairs.py`
- `pytest tests/test_implementation_repairs.py -q`
- `ruff check agent_s3` *(fails: 3511 errors in unrelated files)*
- `mypy agent_s3` *(fails: invalid syntax in adaptive_config_manager.py)*
- `pytest -q` *(fails: 56 errors during collection)*