### PR TITLE
Fix logging setup location

### DIFF
--- a/agent_s3/coordinator/__init__.py
+++ b/agent_s3/coordinator/__init__.py
@@ -56,9 +56,9 @@ from agent_s3.debugging_manager import DebuggingManager
 from agent_s3.code_generator import CodeGenerator
 from .registry import CoordinatorRegistry
 
-# Configure logging
+# Configure module logger. The logging system should be configured by the
+# application entry point (e.g. the CLI) before importing this module.
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
         
 class Coordinator:
     """Coordinates the workflow phases for Agent-S3."""


### PR DESCRIPTION
## Summary
- remove `logging.basicConfig` call from `coordinator`
- rely on CLI startup to configure logging

## Testing
- `pytest -q` *(fails: 54 errors during collection)*