### PR TITLE
fix: aggregate validation errors

### DIFF
--- a/agent_s3/pre_planning_validator.py
+++ b/agent_s3/pre_planning_validator.py
@@ -256,18 +256,19 @@ class PrePlanningValidator:
             }
         }
 
-        # Structure validation (critical - fail fast)
+        # Structure validation (critical but no longer fail fast)
         structure_valid, structure_errors = self.validate_structure(data)
         result["errors"]["structure"] = structure_errors
 
-        if not structure_valid:
-            result["valid"] = False
-            return result["valid"], result
-
-        # Count metrics
-        result["metadata"]["group_count"] = len(data.get("feature_groups", []))
-        result["metadata"]["feature_count"] = sum(len(group.get("features", []))
-                                               for group in data.get("feature_groups", []))
+        # Count metrics based on whatever structure is present
+        if isinstance(data.get("feature_groups"), list):
+            result["metadata"]["group_count"] = len(data.get("feature_groups", []))
+            result["metadata"]["feature_count"] = sum(
+                len(group.get("features", [])) for group in data.get("feature_groups", [])
+            )
+        else:
+            result["metadata"]["group_count"] = 0
+            result["metadata"]["feature_count"] = 0
 
         # Semantic coherence validation
         semantic_valid, semantic_errors = self.validate_semantic_coherence(data)

--- a/agent_s3/tests/test_complex_validator.py
+++ b/agent_s3/tests/test_complex_validator.py
@@ -69,5 +69,41 @@ class TestComplexValidation(unittest.TestCase):
         self.assertFalse(is_valid)
         self.assertTrue(any("Duplicate feature name" in error for error in errors))
 
+    def test_validate_all_with_structure_issues(self):
+        """validate_all should gather errors from all categories."""
+        data = {
+            "feature_groups": [
+                {
+                    "group_name": "Group X",
+                    # Missing group_description -> structure error
+                    "features": [
+                        {
+                            "name": "SecFeature",
+                            "description": "Handle passwords",
+                            "complexity": 3,
+                            # Missing risk_assessment -> security error
+                        }
+                    ],
+                },
+                {
+                    "group_name": "Group Y",
+                    "group_description": "desc",
+                    "features": [
+                        {
+                            "name": "SecFeature",  # duplicate name -> semantic error
+                            "description": "Another",
+                            "complexity": 2,
+                        }
+                    ],
+                },
+            ]
+        }
+
+        is_valid, result = self.validator.validate_all(data)
+        self.assertFalse(is_valid)
+        self.assertGreater(len(result["errors"]["structure"]), 0)
+        self.assertGreater(len(result["errors"]["semantic"]), 0)
+        self.assertGreater(len(result["errors"]["security"]), 0)
+
 if __name__ == "__main__":
     unittest.main()

--- a/agent_s3/tests/test_pre_planning_validator.py
+++ b/agent_s3/tests/test_pre_planning_validator.py
@@ -57,5 +57,41 @@ class TestPrePlanningValidator(unittest.TestCase):
         self.assertEqual(result["metadata"]["feature_count"], 1)
         self.assertEqual(result["metadata"]["group_count"], 1)
 
+    def test_complete_validation_structure_failure(self):
+        """Validation should aggregate errors when structure is invalid."""
+        invalid_data = {
+            "feature_groups": [
+                {
+                    "group_name": "Security",
+                    # Missing group_description triggers structure error
+                    "features": [
+                        {
+                            "name": "Auth",  # duplicated below for semantic error
+                            "description": "Login system",
+                            "complexity": 3,
+                            # Missing risk_assessment triggers security error
+                        }
+                    ],
+                },
+                {
+                    "group_name": "More Security",
+                    "group_description": "desc",
+                    "features": [
+                        {
+                            "name": "Auth",  # duplicate name
+                            "description": "Another",
+                            "complexity": 2,
+                        }
+                    ],
+                },
+            ]
+        }
+
+        is_valid, result = self.validator.validate_all(invalid_data)
+        self.assertFalse(is_valid)
+        self.assertGreater(len(result["errors"]["structure"]), 0)
+        self.assertGreater(len(result["errors"]["semantic"]), 0)
+        self.assertGreater(len(result["errors"]["security"]), 0)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- remove fail-fast return in `validate_all`
- keep structure error info but continue with semantic and security validation
- adjust overall valid flag
- test aggregated errors when structure is invalid

## Testing
- `ruff check agent_s3`
- `mypy agent_s3`
- `PYTHONPATH=. python agent_s3/tests/test_pre_planning_validator.py`
- `PYTHONPATH=. python agent_s3/tests/test_complex_validator.py`
