### PR TITLE
Add fallback validation in pre-planner

### DIFF
--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -948,6 +948,11 @@ def call_pre_planner_with_enforced_json(
         f" Last error: {last_error}"
     )
     fallback_data = create_fallback_pre_planning_output(task_description)
+    # Validate fallback data to ensure it meets minimum requirements
+    valid, validation_msg = validate_preplan_all(fallback_data)
+    if not valid:
+        logger.error("Fallback validation failed: %s", validation_msg)
+        return False, {"pre_planning_data": fallback_data, "error": validation_msg}
     return False, fallback_data
 
 

--- a/tests/test_pre_planner_function_tests.py
+++ b/tests/test_pre_planner_function_tests.py
@@ -450,3 +450,5 @@ def test_create_fallback_json():
     assert len(fallback["feature_groups"]) > 0
     assert "features" in fallback["feature_groups"][0]
     assert len(fallback["feature_groups"][0]["features"]) > 0
+    valid, msg = pre_planner.validate_preplan_all(fallback)
+    assert valid, msg


### PR DESCRIPTION
## Summary
- validate fallback data when pre-planning fails
- test fallback JSON validity

## Testing
- `ruff check .`
- `pytest -q` *(fails: 13 errors during collection)*