### PR TITLE
Add non-interactive mode for pre-planning clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
   - `USE_REMOTE_LLM` to toggle remote LLM usage
   - `MAX_CLARIFICATION_ROUNDS` (optional, defaults to `3`) limits pre-planning clarification exchanges
   - `MAX_PREPLANNING_ATTEMPTS` (optional, defaults to `2`) sets the maximum number of retries when generating pre-planning data
+  - `ALLOW_INTERACTIVE_CLARIFICATION` (optional, defaults to `true`) when set to `false` disables interactive clarification prompts during pre-planning
   - `pre_planning_mode` selects `off`, `json`, or `enforced_json` workflow. See `docs/pre_planning_workflow.md` for details.
   - `WEBSOCKET_MAX_MESSAGE_SIZE` (optional, defaults to `65536` bytes)
     limits incoming WebSocket payloads

--- a/agent_s3/config.py
+++ b/agent_s3/config.py
@@ -173,6 +173,9 @@ class ConfigModel(BaseModel):
     check_auth: bool = True
     sandbox_environment: bool = True
     interactive: bool = True
+    allow_interactive_clarification: bool = bool(
+        os.getenv("ALLOW_INTERACTIVE_CLARIFICATION", "true").lower() == "true"
+    )
     openrouter_key: str = os.environ.get("OPENROUTER_KEY", "")
     openai_key: str = os.environ.get("OPENAI_KEY", "")
     encryption_key: str = os.environ.get("AGENT_S3_ENCRYPTION_KEY", "")

--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -16,7 +16,7 @@ import json
 import logging
 import os
 import time  # Added for potential delays in retry
-from typing import Dict, Any, Optional, Tuple, List, Union
+from typing import Callable, Dict, Any, Optional, Tuple, List, Union
 
 from agent_s3.progress_tracker import progress_tracker
 
@@ -491,6 +491,8 @@ def pre_planning_workflow(
     task_description: str,
     context: Optional[Dict[str, Any]] = None,
     max_preplanning_attempts: int = 2,
+    allow_interactive_clarification: bool = True,
+    clarification_callback: Optional[Callable[[str], str]] = None,
 ) -> Tuple[bool, Dict[str, Any]]:
     """Run the JSON-enforced pre-planning workflow.
 
@@ -500,6 +502,10 @@ def pre_planning_workflow(
         context: Optional context dictionary passed to the LLM.
         max_preplanning_attempts: Maximum number of attempts to get valid
             pre-planning data.
+        allow_interactive_clarification: Enable interactive ``input`` prompts
+            when the LLM asks clarification questions.
+        clarification_callback: Optional callback used to obtain clarification
+            answers programmatically when interactivity is disabled.
 
     The workflow may prompt the user for additional clarification when the
     initial request lacks sufficient detail. Clarification exchanges are
@@ -545,7 +551,16 @@ def pre_planning_workflow(
 
         if status == "question" and clarification_attempts < max_clarifications:
             question = data.get("question", "") if isinstance(data, dict) else ""
-            answer = input(question + " ")
+            if allow_interactive_clarification:
+                answer = input(question + " ")
+            elif clarification_callback is not None:
+                answer = clarification_callback(question)
+            else:
+                # Skip clarification if not interactive and no callback provided
+                attempts += 1
+                clarification_attempts += 1
+                continue
+
             try:
                 progress_tracker.logger.info(
                     json.dumps(


### PR DESCRIPTION
## Summary
- add `ALLOW_INTERACTIVE_CLARIFICATION` option to ConfigModel
- support non-interactive clarifications in `pre_planning_workflow`
- document the new option in `README.md`
- test skipping clarifications when interactivity is disabled

## Testing
- `ruff check .`
- `mypy agent_s3/compression.py`
- `python -m py_compile agent_s3/config.py agent_s3/pre_planner_json_enforced.py tests/test_pre_planner_function_tests.py`
- `pytest tests/test_pre_planner_function_tests.py::test_pre_planning_workflow_noninteractive -q`