### PR TITLE
Extend PrePlanningValidator checks

### DIFF
--- a/agent_s3/pre_planning_validator.py
+++ b/agent_s3/pre_planning_validator.py
@@ -11,8 +11,10 @@ from .pattern_constants import (
     SECURITY_CONCERN_PATTERN,
     SECURITY_KEYWORD_PATTERNS,
 )
+from .pre_planner_json_validator import PrePlannerJsonValidator
 
 logger = logging.getLogger(__name__)
+
 
 class PrePlanningValidator:
     """Centralized validation for pre-planning data with different validation levels."""
@@ -42,7 +44,9 @@ class PrePlanningValidator:
             return False, errors
 
         # Validate feature_groups structure
-        if not isinstance(data.get("feature_groups"), list) or not data.get("feature_groups"):
+        if not isinstance(data.get("feature_groups"), list) or not data.get(
+            "feature_groups"
+        ):
             errors.append("feature_groups must be a non-empty list")
             return False, errors
 
@@ -65,7 +69,9 @@ class PrePlanningValidator:
         required_fields = {"group_name", "group_description", "features"}
         missing_fields = required_fields - set(group.keys())
         if missing_fields:
-            errors.append(f"Feature group {index} missing fields: {', '.join(missing_fields)}")
+            errors.append(
+                f"Feature group {index} missing fields: {', '.join(missing_fields)}"
+            )
 
         # Validate features
         if not isinstance(group.get("features"), list) or not group.get("features"):
@@ -78,7 +84,9 @@ class PrePlanningValidator:
 
         return errors
 
-    def _validate_feature(self, feature: Dict[str, Any], group_index: int, feature_index: int) -> List[str]:
+    def _validate_feature(
+        self, feature: Dict[str, Any], group_index: int, feature_index: int
+    ) -> List[str]:
         """Validate an individual feature."""
         errors = []
         prefix = f"Feature group {group_index}, feature {feature_index}"
@@ -95,7 +103,9 @@ class PrePlanningValidator:
 
         # Validate complexity
         if "complexity" in feature and not 1 <= feature.get("complexity", 0) <= 5:
-            errors.append(f"{prefix} has invalid complexity: {feature.get('complexity')}. Must be between 1-5.")
+            errors.append(
+                f"{prefix} has invalid complexity: {feature.get('complexity')}. Must be between 1-5."
+            )
 
         # Validate implementation steps if present
         if "implementation_steps" in feature:
@@ -106,16 +116,22 @@ class PrePlanningValidator:
                 steps_count = len(feature["implementation_steps"])
                 min_steps = max(1, feature.get("complexity", 1))
                 if steps_count < min_steps:
-                    errors.append(f"{prefix} has complexity {feature.get('complexity')} but only {steps_count} steps")
+                    errors.append(
+                        f"{prefix} has complexity {feature.get('complexity')} but only {steps_count} steps"
+                    )
 
         # Validate test requirements if present
         if "test_requirements" in feature:
-            test_errors = self._validate_test_requirements(feature["test_requirements"], group_index, feature_index)
+            test_errors = self._validate_test_requirements(
+                feature["test_requirements"], group_index, feature_index
+            )
             errors.extend(test_errors)
 
         # Validate risk assessment if present
         if "risk_assessment" in feature:
-            risk_errors = self._validate_risk_assessment(feature["risk_assessment"], group_index, feature_index)
+            risk_errors = self._validate_risk_assessment(
+                feature["risk_assessment"], group_index, feature_index
+            )
             errors.extend(risk_errors)
 
         return errors
@@ -125,7 +141,9 @@ class PrePlanningValidator:
     ) -> List[str]:
         """Validate test requirements structure."""
         errors = []
-        prefix = f"Feature group {group_index}, feature {feature_index}, test_requirements"
+        prefix = (
+            f"Feature group {group_index}, feature {feature_index}, test_requirements"
+        )
 
         if not isinstance(test_reqs, dict):
             errors.append(f"{prefix} must be a dictionary")
@@ -143,7 +161,9 @@ class PrePlanningValidator:
     ) -> List[str]:
         """Validate risk assessment structure."""
         errors = []
-        prefix = f"Feature group {group_index}, feature {feature_index}, risk_assessment"
+        prefix = (
+            f"Feature group {group_index}, feature {feature_index}, risk_assessment"
+        )
 
         if not isinstance(risk_assessment, dict):
             errors.append(f"{prefix} must be a dictionary")
@@ -156,12 +176,20 @@ class PrePlanningValidator:
             errors.append(f"{prefix} missing fields: {', '.join(missing_fields)}")
 
         # Validate risk level
-        if "risk_level" in risk_assessment and risk_assessment["risk_level"] not in {"low", "medium", "high"}:
-            errors.append(f"{prefix} has invalid risk_level: {risk_assessment.get('risk_level')}. Must be one of: low, medium, high")
+        if "risk_level" in risk_assessment and risk_assessment["risk_level"] not in {
+            "low",
+            "medium",
+            "high",
+        }:
+            errors.append(
+                f"{prefix} has invalid risk_level: {risk_assessment.get('risk_level')}. Must be one of: low, medium, high"
+            )
 
         return errors
 
-    def validate_semantic_coherence(self, data: Dict[str, Any]) -> Tuple[bool, List[str]]:
+    def validate_semantic_coherence(
+        self, data: Dict[str, Any]
+    ) -> Tuple[bool, List[str]]:
         """Perform semantic validation beyond structure checking."""
         errors = []
 
@@ -172,7 +200,9 @@ class PrePlanningValidator:
                 name = feature.get("name")
                 if name in feature_names:
                     prev_group, prev_index = feature_names[name]
-                    errors.append(f"Duplicate feature name '{name}' found in group {i} and group {prev_group}")
+                    errors.append(
+                        f"Duplicate feature name '{name}' found in group {i} and group {prev_group}"
+                    )
                 else:
                     feature_names[name] = (i, j)
 
@@ -184,11 +214,15 @@ class PrePlanningValidator:
 
                 # Very complex features should have substantial descriptions
                 if complexity >= 4 and desc_length < 100:
-                    errors.append(f"Feature '{feature.get('name')}' has high complexity ({complexity}) but short description ({desc_length} chars)")
+                    errors.append(
+                        f"Feature '{feature.get('name')}' has high complexity ({complexity}) but short description ({desc_length} chars)"
+                    )
 
                 # Simple features with very long descriptions may be more complex than rated
                 if complexity == 1 and desc_length > 300:
-                    errors.append(f"Feature '{feature.get('name')}' has low complexity (1) but very detailed description ({desc_length} chars)")
+                    errors.append(
+                        f"Feature '{feature.get('name')}' has low complexity (1) but very detailed description ({desc_length} chars)"
+                    )
 
         # 3. Validate coherence between risk assessment and test requirements
         for i, group in enumerate(data.get("feature_groups", [])):
@@ -196,8 +230,12 @@ class PrePlanningValidator:
                 risk = feature.get("risk_assessment", {}).get("risk_level")
                 test_reqs = feature.get("test_requirements", {})
 
-                if risk == "high" and (not test_reqs or not test_reqs.get("unit_tests")):
-                    errors.append(f"Feature '{feature.get('name')}' has high risk but insufficient test requirements")
+                if risk == "high" and (
+                    not test_reqs or not test_reqs.get("unit_tests")
+                ):
+                    errors.append(
+                        f"Feature '{feature.get('name')}' has high risk but insufficient test requirements"
+                    )
 
         return len(errors) == 0, errors
 
@@ -225,9 +263,13 @@ class PrePlanningValidator:
 
                     # Security features should have risk assessment
                     if not risk:
-                        errors.append(f"Security-related feature '{feature.get('name')}' lacks risk assessment")
+                        errors.append(
+                            f"Security-related feature '{feature.get('name')}' lacks risk assessment"
+                        )
                     elif risk.get("risk_level") not in {"medium", "high"}:
-                        errors.append(f"Security-related feature '{feature.get('name')}' has inappropriately low risk level")
+                        errors.append(
+                            f"Security-related feature '{feature.get('name')}' has inappropriately low risk level"
+                        )
 
                     # Security features should have specific security concerns
                     concerns = risk.get("concerns", [])
@@ -235,25 +277,24 @@ class PrePlanningValidator:
                         SECURITY_CONCERN_PATTERN.search(str(c)) for c in concerns
                     )
                     if not has_security_concern:
-                        errors.append(f"Security-related feature '{feature.get('name')}' has no explicit security concerns in risk assessment")
+                        errors.append(
+                            f"Security-related feature '{feature.get('name')}' has no explicit security concerns in risk assessment"
+                        )
 
         return len(errors) == 0, errors
 
     def validate_all(self, data: Dict[str, Any]) -> Tuple[bool, Dict[str, Any]]:
-        """Perform all validation checks and return comprehensive results."""
+        """Perform all validation checks and return comprehensive results.
+
+        This includes structural, semantic, security, cross-reference, and
+        content validations. Any errors from the extended checks are aggregated
+        under ``other`` in the returned dictionary.
+        """
         result = {
             "valid": True,
-            "errors": {
-                "structure": [],
-                "semantic": [],
-                "security": [],
-                "other": []
-            },
+            "errors": {"structure": [], "semantic": [], "security": [], "other": []},
             "warnings": [],
-            "metadata": {
-                "feature_count": 0,
-                "group_count": 0
-            }
+            "metadata": {"feature_count": 0, "group_count": 0},
         }
 
         # Structure validation (critical - fail fast)
@@ -266,8 +307,9 @@ class PrePlanningValidator:
 
         # Count metrics
         result["metadata"]["group_count"] = len(data.get("feature_groups", []))
-        result["metadata"]["feature_count"] = sum(len(group.get("features", []))
-                                               for group in data.get("feature_groups", []))
+        result["metadata"]["feature_count"] = sum(
+            len(group.get("features", [])) for group in data.get("feature_groups", [])
+        )
 
         # Semantic coherence validation
         semantic_valid, semantic_errors = self.validate_semantic_coherence(data)
@@ -277,7 +319,30 @@ class PrePlanningValidator:
         security_valid, security_errors = self.validate_security(data)
         result["errors"]["security"] = security_errors
 
-        # Update overall validity
-        result["valid"] = structure_valid and semantic_valid and security_valid
+        # Additional cross-reference and content validation using
+        # PrePlannerJsonValidator for deeper checks
+        other_errors: List[str] = []
+        validator = PrePlannerJsonValidator()
+
+        xref_valid, xref_errors, _ = validator.implement_cross_reference_validation(
+            data
+        )
+        if not xref_valid:
+            other_errors.extend(xref_errors)
+
+        content_valid, content_errors, _ = validator.implement_content_validation(data)
+        if not content_valid:
+            other_errors.extend(content_errors)
+
+        result["errors"]["other"] = other_errors
+
+        # Update overall validity including new checks
+        result["valid"] = (
+            structure_valid
+            and semantic_valid
+            and security_valid
+            and xref_valid
+            and content_valid
+        )
 
         return result["valid"], result

--- a/agent_s3/tests/test_pre_planning_validator.py
+++ b/agent_s3/tests/test_pre_planning_validator.py
@@ -4,6 +4,7 @@ import unittest
 
 from agent_s3.pre_planning_validator import PrePlanningValidator
 
+
 class TestPrePlanningValidator(unittest.TestCase):
     """Tests for the PrePlanningValidator class."""
 
@@ -22,17 +23,43 @@ class TestPrePlanningValidator(unittest.TestCase):
                             "name": "User Authentication",
                             "description": "Allow users to sign up and log in with secure credentials",
                             "complexity": 3,
-                            "implementation_steps": ["Setup auth API", "Create login form", "Implement session management"],
+                            "implementation_steps": [
+                                {"id": "step1", "description": "Setup auth API"},
+                                {"id": "step2", "description": "Create login form"},
+                                {
+                                    "id": "step3",
+                                    "description": "Implement session management",
+                                },
+                            ],
                             "risk_assessment": {
                                 "risk_level": "high",
-                                "concerns": ["Security vulnerabilities", "Data privacy issues"]
+                                "concerns": [
+                                    "Security vulnerabilities",
+                                    "Data privacy issues",
+                                ],
+                                "security_concerns": [
+                                    "password storage",
+                                    "session hijacking",
+                                ],
                             },
                             "test_requirements": {
-                                "unit_tests": ["Test password hashing", "Test login validation"],
-                                "integration_tests": ["Test auth flow"]
-                            }
+                                "unit_tests": [
+                                    {
+                                        "description": "Test password hashing security",
+                                        "implementation_step_id": "step1",
+                                    }
+                                ],
+                                "integration_tests": [
+                                    {
+                                        "description": "Test auth flow with token",
+                                        "implementation_step_id": "step3",
+                                    }
+                                ],
+                            },
+                            "files_affected": ["auth_module.py"],
+                            "dependencies": {},
                         }
-                    ]
+                    ],
                 }
             ]
         }
@@ -56,6 +83,7 @@ class TestPrePlanningValidator(unittest.TestCase):
         self.assertTrue(is_valid)
         self.assertEqual(result["metadata"]["feature_count"], 1)
         self.assertEqual(result["metadata"]["group_count"], 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- extend `PrePlanningValidator.validate_all` to integrate cross-reference and content validation from `PrePlannerJsonValidator`
- aggregate new errors under `result["errors"]["other"]`
- update tests to use richer sample data

## Testing
- `ruff check agent_s3/pre_planning_validator.py agent_s3/tests/test_pre_planning_validator.py`
- `PYTHONPATH=$PWD pytest -q agent_s3/tests/test_pre_planning_validator.py agent_s3/tests/test_complex_validator.py`
