### PR TITLE
Handle LLM generation failures

### DIFF
--- a/agent_s3/code_generator.py
+++ b/agent_s3/code_generator.py
@@ -138,6 +138,11 @@ class CodeGenerator:
             role="generator", system_prompt=system_prompt, user_prompt=user_prompt, config={"temperature": 0.2}
         )
         generated_code = self._extract_code_from_response(response, file_path)
+        if not generated_code:
+            self.scratchpad.log(
+                "CodeGenerator", "LLM returned no code", level=LogLevel.ERROR
+            )
+            return ""
         for attempt in range(max_validation_attempts):
             self.scratchpad.log(
                 "CodeGenerator", f"Validating generated code (attempt {attempt + 1}/{max_validation_attempts})"
@@ -193,7 +198,9 @@ class CodeGenerator:
 
     # ------------------------------------------------------------------
     @staticmethod
-    def _extract_code_from_response(response: str, file_path: str) -> str:
+    def _extract_code_from_response(response: Optional[str], file_path: str) -> str:
+        if response is None:
+            return ""
         code_block_pattern = r"```(?:python)?(?:\s*\n)(.*?)(?:\n```)"
         matches = re.findall(code_block_pattern, response, re.DOTALL)
         if matches:

--- a/agent_s3/code_validator.py
+++ b/agent_s3/code_validator.py
@@ -6,7 +6,7 @@ import json
 import os
 import re
 import tempfile
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Optional
 
 
 class CodeValidator:
@@ -75,7 +75,9 @@ class CodeValidator:
         refined = self._extract_code_from_response(response, file_path)
         return refined if refined else code
 
-    def _extract_code_from_response(self, response: str, file_path: str) -> str:
+    def _extract_code_from_response(self, response: Optional[str], file_path: str) -> str:
+        if response is None:
+            return ""
         code_block_pattern = r"```(?:python)?(?:\s*\n)(.*?)(?:\n```)"
         matches = re.findall(code_block_pattern, response, re.DOTALL)
         if matches:

--- a/agent_s3/debugging_manager.py
+++ b/agent_s3/debugging_manager.py
@@ -784,8 +784,10 @@ class DebuggingManager:
             # In case of any errors, fall back to current directory
             return os.getcwd()
 
-    def _extract_code_from_response(self, response: str) -> Optional[str]:
+    def _extract_code_from_response(self, response: Optional[str]) -> Optional[str]:
         """Extract code from a response."""
+        if response is None:
+            return ""
         # Look for code blocks with triple backticks
         import re
         pattern = r'```(?:\w*\n|\n)?(.*?)```'


### PR DESCRIPTION
## Summary
- return empty string from `_extract_code_from_response` when the LLM returns None
- stop generation if the LLM yields no code
- surface empty-string handling in `CodeValidator` and `DebuggingManager`
- test that generation aborts when the LLM fails

## Testing
- `ruff check agent_s3 tests/test_code_generator.py`
- `mypy agent_s3/code_generator.py agent_s3/code_validator.py agent_s3/debugging_manager.py`
- `pytest tests/test_code_generator.py::TestCodeGenerator::test_generate_with_validation_handles_llm_failure -q`
- `pytest tests/test_code_generator.py::TestCodeGenerator::test_generate_with_validation_applies_debug_fix -q`