### PR TITLE
Add coverage parser wrapper and adjust tests

### DIFF
--- a/agent_s3/coordinator/orchestrator.py
+++ b/agent_s3/coordinator/orchestrator.py
@@ -524,11 +524,17 @@ class WorkflowOrchestrator:
         try:
             self.coordinator.env_tool.activate_virtual_env()
             self.coordinator.test_runner_tool.detect_runner()
-            success, output = self.coordinator.test_runner_tool.run_tests()
-            coverage = 0.0
-            if success and hasattr(self.coordinator.test_runner_tool, "parse_coverage_report"):
+            test_result = self.coordinator.test_runner_tool.run_tests()
+            success = test_result.get("success", False)
+            output = test_result.get("output", "")
+            coverage = test_result.get("coverage")
+            if success and not coverage:
                 coverage = self.coordinator.test_runner_tool.parse_coverage_report()
-            return {"success": success, "output": output, "coverage": coverage}
+            return {
+                "success": success,
+                "output": output,
+                "coverage": coverage or 0.0,
+            }
         except Exception as exc:  # pragma: no cover - safety net
             self.coordinator.scratchpad.log("Coordinator", f"Test execution failed: {exc}", level=self.coordinator.LogLevel.ERROR)
             return {"success": False, "output": str(exc), "coverage": 0.0}

--- a/agent_s3/tools/test_runner_tool.py
+++ b/agent_s3/tools/test_runner_tool.py
@@ -151,6 +151,15 @@ class TestRunnerTool:
             pass
         return None
 
+    def parse_coverage_report(self) -> float:
+        """Public wrapper around :meth:`_parse_coverage`.
+
+        Returns the parsed coverage percentage or ``0.0`` when no coverage
+        report is available or an error occurs.
+        """
+        coverage = self._parse_coverage()
+        return coverage if coverage is not None else 0.0
+
     def _parse_test_failures(self, output: str) -> List[Dict[str, Any]]:
         """Parse test output to extract structured failure information.
 

--- a/tests/test_parse_coverage_report.py
+++ b/tests/test_parse_coverage_report.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from agent_s3.tools.test_runner_tool import TestRunnerTool
+
+
+def test_parse_coverage_report(tmp_path):
+    coverage_data = {"totals": {"percent_covered": 92.5}}
+    coverage_file = tmp_path / ".coverage.json"
+    coverage_file.write_text(json.dumps(coverage_data))
+    tool = TestRunnerTool(MagicMock())
+    old_cwd = Path.cwd()
+    try:
+        import os
+        os.chdir(tmp_path)
+        assert tool.parse_coverage_report() == 92.5
+    finally:
+        os.chdir(old_cwd)
+
+
+def test_parse_coverage_report_missing(tmp_path):
+    tool = TestRunnerTool(MagicMock())
+    old_cwd = Path.cwd()
+    try:
+        import os
+        os.chdir(tmp_path)
+        assert tool.parse_coverage_report() == 0.0
+    finally:
+        os.chdir(old_cwd)


### PR DESCRIPTION
## Summary
- wrap `_parse_coverage` with new public `parse_coverage_report`
- call the new parser from orchestrator `_run_tests`
- update coordinator tests to use orchestrator helpers
- add unit tests for coverage report parsing

## Testing
- `ruff check agent_s3 tests`
- `pytest -q` *(fails: ImportError and SyntaxError in unrelated tests)*