### PR TITLE
Add debug_last_test implementation

### DIFF
--- a/tests/test_command_processor.py
+++ b/tests/test_command_processor.py
@@ -71,8 +71,8 @@ class TestCommandProcessor:
 
     @patch('pathlib.Path.open')
     @patch('pathlib.Path.exists')
-    def test_execute_plan_command(self, mock_exists, mock_open, command_processor, mock_coordinator)
-        :        """Test execute_plan_command."""
+    def test_execute_plan_command(self, mock_exists, mock_open, command_processor, mock_coordinator):
+        """Test execute_plan_command."""
         # Setup
         mock_exists.return_value = False
         mock_file = MagicMock()


### PR DESCRIPTION
## Summary
- implement `debug_last_test` in `Coordinator`
- fix syntax error in `tests/test_command_processor`

## Testing
- `python -m py_compile agent_s3/coordinator/__init__.py`
- `python -m py_compile tests/test_command_processor.py`
- `pytest tests/test_cli.py -q` *(fails: Expected 'execute_continue' to be called once)*