### PR TITLE
Fix context gather lock

### DIFF
--- a/agent_s3/tools/context_management/context_manager.py
+++ b/agent_s3/tools/context_management/context_manager.py
@@ -734,8 +734,11 @@ class ContextManager:
         # ...existing code...
         # Use the configured allocation strategy
         # The allocation strategy (e.g., TaskAdaptiveAllocation) should internally use task_keywords
+        with self._context_lock:
+            context_copy = copy.deepcopy(self.current_context)
+
         allocation_result = self.allocation_strategy.allocate(
-            self.current_context,
+            context_copy,
             task_type=task_type,
             task_keywords=task_keywords,  # Pass keywords here
         )


### PR DESCRIPTION
## Summary
- ensure gather_context uses lock-protected copy of current context
- test gather_context lock usage

## Testing
- `ruff check agent_s3 tests`
- `mypy agent_s3`
- `pytest -q` *(fails: 13 errors during collection)*