### PR TITLE
Fix path validation to resolve symlinks

### DIFF
--- a/tests/test_context_manager_paths.py
+++ b/tests/test_context_manager_paths.py
@@ -1,0 +1,39 @@
+import os
+import pytest
+
+from agent_s3.context_manager import ContextManager
+
+
+def test_symlink_outside_workspace(tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret.txt"
+    secret.write_text("x")
+    link = workspace / "link.txt"
+    link.symlink_to(secret)
+
+    prev_cwd = os.getcwd()
+    os.chdir(workspace)
+    try:
+        with pytest.raises(ValueError):
+            ContextManager._validate_path(str(link))
+    finally:
+        os.chdir(prev_cwd)
+
+
+def test_symlink_inside_workspace(tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    target = workspace / "target.txt"
+    target.write_text("y")
+    link = workspace / "link.txt"
+    link.symlink_to(target)
+
+    prev_cwd = os.getcwd()
+    os.chdir(workspace)
+    try:
+        ContextManager._validate_path(str(link))
+    finally:
+        os.chdir(prev_cwd)


### PR DESCRIPTION
## Summary
- ensure `ContextManager._validate_path` resolves `realpath` before evaluating workspace boundaries
- test path validation with symlink escape attempts

## Testing
- `ruff check agent_s3`
- `mypy agent_s3`
- `pytest tests/test_terminal_executor_paths.py tests/test_context_manager_paths.py -q`