### PR TITLE
Fix fallback validation and schema return

### DIFF
--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -230,7 +230,7 @@ def validate_preplan_all(data) -> Tuple[bool, str, Dict[str, Any]]:
     validated_data = data
 
     # 1. JSON schema validation
-    is_valid, validation_msg = validate_json_schema(validated_data)
+    is_valid, validation_msg, _ = validate_json_schema(validated_data)
     if not is_valid:
         errors.append(f"JSON schema validation error: {validation_msg}")
 
@@ -653,7 +653,7 @@ def process_response(
         return "question", data
 
     # Otherwise, validate schema - now with partial validation support
-    is_valid, validation_msg = validate_json_schema(data)
+    is_valid, validation_msg, _ = validate_json_schema(data)
 
     if is_valid:
         return True, data # Fully valid
@@ -666,7 +666,7 @@ def process_response(
         )
         try:
             repaired = repair_json_structure(data)
-            is_valid2, validation_msg2 = validate_json_schema(repaired)
+            is_valid2, validation_msg2, _ = validate_json_schema(repaired)
             if is_valid2:
                 return True, repaired
             else:
@@ -974,11 +974,11 @@ def call_pre_planner_with_enforced_json(
     )
     fallback_data = create_fallback_pre_planning_output(task_description)
     # Validate fallback data to ensure it meets minimum requirements
-    valid, validation_msg = validate_preplan_all(fallback_data)
+    valid, validation_msg, validated_fallback = validate_preplan_all(fallback_data)
     if not valid:
         logger.error("Fallback validation failed: %s", validation_msg)
-        return False, {"pre_planning_data": fallback_data, "error": validation_msg}
-    return False, fallback_data
+        return False, {"pre_planning_data": validated_fallback, "error": validation_msg}
+    return False, validated_fallback
 
 
 class PrePlanner:

--- a/tests/test_pre_planner_function_tests.py
+++ b/tests/test_pre_planner_function_tests.py
@@ -450,5 +450,5 @@ def test_create_fallback_json():
     assert len(fallback["feature_groups"]) > 0
     assert "features" in fallback["feature_groups"][0]
     assert len(fallback["feature_groups"][0]["features"]) > 0
-    valid, msg = pre_planner.validate_preplan_all(fallback)
+    valid, msg, _ = pre_planner.validate_preplan_all(fallback)
     assert valid, msg


### PR DESCRIPTION
## Summary
- fix `validate_preplan_all` to handle JSON schema return value
- return validated fallback plan in `call_pre_planner_with_enforced_json`
- adjust tests for new validation signature

## Testing
- `pytest tests/test_pre_planner_function_tests.py::test_create_fallback_json -q` *(fails: Static plan checker critical error)*