### PR TITLE
Forward allow_interactive_clarification

### DIFF
--- a/agent_s3/coordinator/orchestrator.py
+++ b/agent_s3/coordinator/orchestrator.py
@@ -336,7 +336,10 @@ class WorkflowOrchestrator:
                 success, pre_plan = pre_planning_workflow(
                     self.coordinator.router_agent,
                     task,
-                    max_attempts=2,
+                    max_preplanning_attempts=2,
+                    allow_interactive_clarification=self.coordinator.config.config.get(
+                        "allow_interactive_clarification", True
+                    ),
                 )
             if not success:
                 self.coordinator.scratchpad.log("Coordinator", "Pre-planning failed", level=self.coordinator.LogLevel.ERROR)

--- a/agent_s3/planning_helper.py
+++ b/agent_s3/planning_helper.py
@@ -33,6 +33,9 @@ def generate_plan_via_workflow(
         task_description,
         context=context,
         max_preplanning_attempts=max_preplanning_attempts,
+        allow_interactive_clarification=coordinator.config.config.get(
+            "allow_interactive_clarification", True
+        ),
     )
     if not success:
         return {"success": False, "error": "Pre-planning failed", "plan": None}

--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -516,6 +516,8 @@ def pre_planning_workflow(
     task_description: str,
     context: Optional[Dict[str, Any]] = None,
     max_preplanning_attempts: int = 2,
+    *,
+    allow_interactive_clarification: bool = True,
 ) -> Tuple[bool, Dict[str, Any]]:
     """Run the JSON-enforced pre-planning workflow.
 
@@ -525,6 +527,8 @@ def pre_planning_workflow(
         context: Optional context dictionary passed to the LLM.
         max_preplanning_attempts: Maximum number of attempts to get valid
             pre-planning data.
+        allow_interactive_clarification: Whether the workflow may ask the user
+            clarification questions during execution. Defaults to ``True``.
 
     The workflow may prompt the user for additional clarification when the
     initial request lacks sufficient detail. Clarification exchanges are
@@ -568,7 +572,11 @@ def pre_planning_workflow(
         if status is True:
             return True, data
 
-        if status == "question" and clarification_attempts < max_clarifications:
+        if (
+            allow_interactive_clarification
+            and status == "question"
+            and clarification_attempts < max_clarifications
+        ):
             question = data.get("question", "") if isinstance(data, dict) else ""
             answer = input(question + " ")
             try:
@@ -1010,6 +1018,9 @@ class PrePlanner:
                 task_description,
                 context,
                 max_preplanning_attempts=max_preplanning_attempts,
+                allow_interactive_clarification=self.config.get(
+                    "allow_interactive_clarification", True
+                ),
             )
         else:
             system_prompt = get_base_system_prompt()

--- a/tests/integration/test_run_task_consolidated_plan.py
+++ b/tests/integration/test_run_task_consolidated_plan.py
@@ -89,7 +89,10 @@ def test_run_task_with_mocked_llm(monkeypatch):
     # Patch LLM-calling functions
     monkeypatch.setattr(
         'agent_s3.pre_planner_json_enforced.pre_planning_workflow',
-        lambda router, task, context=None, max_attempts=2: (True, PRE_PLAN_DATA)
+        lambda router, task, context=None, max_preplanning_attempts=2, *, allow_interactive_clarification=True: (
+            True,
+            PRE_PLAN_DATA,
+        )
     )
     monkeypatch.setattr(
         'agent_s3.tools.plan_validator.validate_pre_plan',

--- a/tests/test_integration_run_task.py
+++ b/tests/test_integration_run_task.py
@@ -33,7 +33,10 @@ def test_run_task_simple(monkeypatch):
     }
     monkeypatch.setattr(
         "agent_s3.pre_planner_json_enforced.pre_planning_workflow",
-        lambda router, task, context=None, max_attempts=2: (True, pre_plan_data),
+        lambda router, task, context=None, max_preplanning_attempts=2, *, allow_interactive_clarification=True: (
+            True,
+            pre_plan_data,
+        ),
     )
     monkeypatch.setattr(
         "agent_s3.pre_planner_json_enforced.regenerate_pre_planning_with_modifications",


### PR DESCRIPTION
## Summary
- support `allow_interactive_clarification` in the pre-planning workflow
- pass the flag from `PlanningHelper` and `WorkflowOrchestrator`
- update tests for new parameter

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and SyntaxError)*