### PR TITLE
Update generate_code return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ pip check
 - Resilient LLM calls with retry, exponential backoff, and fallback strategies (`agent_s3.llm_utils.call_llm_with_retry`)
 - Multi-phase task orchestration: pre-planning, feature group processing, code generation, execution/testing, and optional PR creation in `agent_s3.coordinator`
 - Iterative code generation & refinement (`agent_s3.code_generator`) with automated linting, testing, and diff-based user approvals
+- `generate_code` returns a mapping of file paths to code strings, using `None` when a file fails to generate
 - Retrieval-Augmented Generation (RAG) context: embedding-based search (`agent_s3.tools.embedding_client`) and hierarchical summarization (`agent_s3.tools.memory_manager`)
 - Tech stack detection with versioning and best practice identification (`agent_s3.tools.tech_stack_manager`)
 - Secure file operations (`FileTool`), sandboxed shell execution (`BashTool`, `TerminalExecutor`), and database interactions (`DatabaseTool`)

--- a/agent_s3/code_generator.py
+++ b/agent_s3/code_generator.py
@@ -28,8 +28,13 @@ class CodeGenerator:
         self.max_refinement_attempts = 2
 
     # ------------------------------------------------------------------
-    def generate_code(self, plan: Dict[str, Any], tech_stack: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
-        """Generate code for all files in the implementation plan."""
+    def generate_code(
+        self, plan: Dict[str, Any], tech_stack: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Optional[str]]:
+        """Generate code for all files in the implementation plan.
+
+        Failed generations will return ``None`` for that file path.
+        """
         self.scratchpad.log("CodeGenerator", "Starting agentic code generation")
         implementation_plan = plan.get("implementation_plan", {})
         tests = plan.get("tests", {})
@@ -44,12 +49,14 @@ class CodeGenerator:
                 "CodeGenerator", "No files found in implementation plan", level=LogLevel.ERROR
             )
             return {}
-        results: Dict[str, str] = {}
+        results: Dict[str, Optional[str]] = {}
         for file_path, implementation_details in files:
             self.scratchpad.log("CodeGenerator", f"Processing file {file_path}")
             context = self.context_manager.prepare_file_context(file_path, implementation_details)
-            generated_code = self.generate_file(file_path, implementation_details, tests, context)
-            results[file_path] = generated_code
+            generated_code = self.generate_file(
+                file_path, implementation_details, tests, context
+            )
+            results[file_path] = generated_code if generated_code else None
         self.scratchpad.log("CodeGenerator", f"Completed generation of {len(results)} files")
         return results
 

--- a/tests/test_code_generator_agentic.py
+++ b/tests/test_code_generator_agentic.py
@@ -245,3 +245,23 @@ def test_func():
         assert result["file2.py"] == "content2"
         assert code_generator.generate_file.call_count == 2
 
+    def test_generate_code_returns_none_on_failure(self, mock_coordinator):
+        """When file generation returns an empty string, the result should be None."""
+        code_generator = CodeGenerator(mock_coordinator)
+
+        code_generator._extract_files_from_plan = MagicMock(return_value=[
+            ("file1.py", [{"function": "func1"}])
+        ])
+        code_generator._prepare_file_context = MagicMock(return_value={})
+        code_generator.generate_file = MagicMock(return_value="")
+
+        plan = {
+            "implementation_plan": {"file1.py": []},
+            "tests": {},
+            "group_name": "Test Group"
+        }
+
+        result = code_generator.generate_code(plan)
+
+        assert result["file1.py"] is None
+


### PR DESCRIPTION
## Summary
- update `generate_code` to return `Dict[str, Optional[str]]`
- document None result for failed file generations
- adjust code generator tests for None returns

## Testing
- `ruff check`
- `mypy agent_s3/code_generator.py`
- `pytest -k generate_code_integration -q` *(fails: ImportError: cannot import name 'LLMUtils')*