### PR TITLE
Switch linting to ruff

### DIFF
--- a/agent_s3/coordinator/orchestrator.py
+++ b/agent_s3/coordinator/orchestrator.py
@@ -584,7 +584,7 @@ class WorkflowOrchestrator:
                     "coverage": None,
                 }
 
-            lint_exit, lint_output = self.coordinator.bash_tool.run_command("flake8 .", timeout=120)
+            lint_exit, lint_output = self.coordinator.bash_tool.run_command("ruff check .", timeout=120)
             results["lint_output"] = lint_output
             if lint_exit != 0:
                 results.update({"success": False, "step": "lint"})

--- a/tests/test_code_generator_agentic.py
+++ b/tests/test_code_generator_agentic.py
@@ -145,10 +145,10 @@ class TestCodeGeneratorAgentic:
         file_path = "agent_s3/test_module.py"
         valid_code = "def test_func():\n    return True"
 
-        # Mock bash tool response for flake8 and mypy (no errors)
-        # Simulate successful run for both flake8 and mypy
+        # Mock bash tool response for ruff and mypy (no errors)
+        # Simulate successful run for both ruff and mypy
         mock_coordinator.bash_tool.run_command.side_effect = [
-            (0, "", ""), # flake8 success
+            (0, "", ""), # ruff success
             (0, "", "")  # mypy success
         ]
 
@@ -160,7 +160,7 @@ class TestCodeGeneratorAgentic:
         # Assert
         assert is_valid is True
         assert len(issues) == 0
-        # Ensure bash_tool.run_command was called twice (for flake8 and mypy)
+        # Ensure bash_tool.run_command was called twice (for ruff and mypy)
         assert mock_coordinator.bash_tool.run_command.call_count == 2
 
 
@@ -171,9 +171,9 @@ class TestCodeGeneratorAgentic:
         file_path = "agent_s3/test_module.py"
         invalid_code = "def test_func()\n    \n    return undefined_variable"  # Missing colon and undefined variable
         
-        # Simulate flake8 finding an error and mypy finding an error
+        # Simulate ruff finding an error and mypy finding an error
         mock_coordinator.bash_tool.run_command.side_effect = [
-            (1, "E999 SyntaxError: invalid syntax", ""), # flake8 error
+            (1, "E999 SyntaxError: invalid syntax", ""), # ruff error
             (1, "test_module.py:2: error: Name 'undefined_variable' is not defined", "") # mypy error
         ]
 
@@ -184,11 +184,11 @@ class TestCodeGeneratorAgentic:
 
         # Assert
         assert is_valid is False
-        assert len(issues) > 0 # Expecting issues from ast.parse, flake8, and mypy
+        assert len(issues) > 0 # Expecting issues from ast.parse, ruff, and mypy
         assert any("SyntaxError: invalid syntax" in issue for issue in issues) # From ast.parse
-        assert any("E999 SyntaxError: invalid syntax" in issue for issue in issues) # From flake8
+        assert any("E999 SyntaxError: invalid syntax" in issue for issue in issues) # From ruff
         assert any("Name 'undefined_variable' is not defined" in issue for issue in issues) # From mypy
-        # Ensure bash_tool.run_command was called twice (for flake8 and mypy)
+        # Ensure bash_tool.run_command was called twice (for ruff and mypy)
         assert mock_coordinator.bash_tool.run_command.call_count == 2
 
 

--- a/tests/test_coordinator_validation.py
+++ b/tests/test_coordinator_validation.py
@@ -124,7 +124,7 @@ def test_validation_phase_lint_failure(coordinator):
     # Verify validations were performed up to the failing point
     coordinator.database_manager.setup_database.assert_called()
     coordinator.database_manager.database_tool.get_schema_info.assert_called()
-    coordinator.bash_tool.run_command.assert_called_once_with("flake8 .", timeout=120)
+    coordinator.bash_tool.run_command.assert_called_once_with("ruff check .", timeout=120)
     coordinator.orchestrator._run_tests.assert_not_called()
 
 def test_validation_phase_type_check_failure(coordinator):


### PR DESCRIPTION
## Summary
- use `ruff check .` for validation instead of `flake8 .`
- update tests to expect ruff

## Testing
- `pytest -q` *(fails: ImportError, SyntaxError)*
- `ruff check .`
- `mypy agent_s3`