### PR TITLE
Add interactive clarification option

### DIFF
--- a/agent_s3/config.py
+++ b/agent_s3/config.py
@@ -173,6 +173,7 @@ class ConfigModel(BaseModel):
     check_auth: bool = True
     sandbox_environment: bool = True
     interactive: bool = True
+    allow_interactive_clarification: bool = True
     openrouter_key: str = os.environ.get("OPENROUTER_KEY", "")
     openai_key: str = os.environ.get("OPENAI_KEY", "")
     encryption_key: str = os.environ.get("AGENT_S3_ENCRYPTION_KEY", "")
@@ -254,6 +255,7 @@ class Config:
     @property
     def config(self) -> Dict[str, Any]:
         """Dictionary representation for backward compatibility."""
+        self._config_dict = self.settings.dict()
         return self._config_dict
 
     @config.setter

--- a/tests/test_config_pydantic.py
+++ b/tests/test_config_pydantic.py
@@ -23,3 +23,17 @@ def test_invalid_config_file(tmp_path):
     with pytest.raises(ValueError):
         cfg.load(str(file_path))
 
+
+def test_allow_interactive_clarification_defaults(monkeypatch, tmp_path):
+    """Verify default and custom values for allow_interactive_clarification."""
+    monkeypatch.chdir(tmp_path)
+    cfg = Config()
+    cfg.load()
+    assert cfg.settings.allow_interactive_clarification is True
+
+    updated = cfg.config
+    updated["allow_interactive_clarification"] = False
+    cfg.config = updated
+    assert cfg.settings.allow_interactive_clarification is False
+    assert cfg.config["allow_interactive_clarification"] is False
+


### PR DESCRIPTION
## Summary
- expose fresh config dictionaries from the `Config` manager
- enable configurable interactive clarification via `ConfigModel`
- test that interactive clarification defaults to `True` and can be overridden

## Testing
- `pytest tests/test_config_pydantic.py::test_allow_interactive_clarification_defaults -q`
- `pytest -q` *(fails: ModuleNotFoundError, SyntaxError, ImportError, etc.)*