### PR TITLE
Add clarification flag plumbing

### DIFF
--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -314,8 +314,12 @@ def integrate_with_coordinator(
 
     mode = "enforced_json"
     config = getattr(coordinator, "config", None)
+    allow_interactive_clarification = True
     if config and isinstance(getattr(config, "config", None), dict):
         mode = config.config.get("pre_planning_mode", "enforced_json")
+        allow_interactive_clarification = config.config.get(
+            "allow_interactive_clarification", True
+        )
     if not isinstance(mode, str):
         mode = "enforced_json"
 
@@ -333,10 +337,14 @@ def integrate_with_coordinator(
             task_description,
             context,
             max_preplanning_attempts=max_preplanning_attempts,
+            allow_interactive_clarification=allow_interactive_clarification,
         )
     else:
         success, pre_planning_data = call_pre_planner_with_enforced_json(
-            router_agent, task_description, context
+            router_agent,
+            task_description,
+            context,
+            allow_interactive_clarification=allow_interactive_clarification,
         )
 
     if success:
@@ -923,7 +931,10 @@ You MUST follow these steps IN ORDER to produce a valid pre-planning JSON:
 
 
 def call_pre_planner_with_enforced_json(
-    router_agent, task_description: str, context: Optional[Dict[str, Any]] = None
+    router_agent,
+    task_description: str,
+    context: Optional[Dict[str, Any]] = None,
+    allow_interactive_clarification: bool = True,
 ) -> Tuple[bool, Dict[str, Any]]:
     """
     Run the JSON-enforced pre-planning workflow using the router_agent.
@@ -934,6 +945,8 @@ def call_pre_planner_with_enforced_json(
         router_agent: The agent responsible for LLM calls (must have a .run() method)
         task_description: The user-provided task description
         context: Optional context dictionary
+        allow_interactive_clarification: Enable interactive clarification when
+            ``True``. Unused currently but accepted for API parity.
 
     Returns:
         Tuple of (success: bool, pre_planning_data: dict)

--- a/agent_s3/tools/memory_manager.py
+++ b/agent_s3/tools/memory_manager.py
@@ -278,6 +278,31 @@ class MemoryManager:
                 )
                 self._save_embedding_access_log()
 
+    def _verify_manifest(self) -> None:
+        """Create the manifest file if it doesn't exist."""
+        try:
+            if not self.manifest_path.exists():
+                self.manifest_path.parent.mkdir(parents=True, exist_ok=True)
+                with open(self.manifest_path, "w", encoding="utf-8") as f:
+                    json.dump({}, f)
+        except OSError:
+            logger.error("Failed to verify manifest", exc_info=True)
+
+    def _update_manifest(self) -> None:
+        """Safely update the manifest file."""
+        try:
+            data: Dict[str, Any] = {}
+            if self.manifest_path.exists():
+                with open(self.manifest_path, "r", encoding="utf-8") as f:
+                    try:
+                        data = json.load(f) or {}
+                    except json.JSONDecodeError:
+                        data = {}
+            with open(self.manifest_path, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
+        except OSError:
+            logger.error("Failed to update manifest", exc_info=True)
+
     def apply_progressive_eviction(self, force=False):
         """
         Apply progressive embedding eviction strategy based on access patterns.

--- a/tests/integration/test_enforced_json_coordinator_integration.py
+++ b/tests/integration/test_enforced_json_coordinator_integration.py
@@ -159,7 +159,9 @@ class TestEnforcedJsonCoordinatorIntegration:
         assert result["success"] is True
         assert result["uses_enforced_json"] is True
         mock_call.assert_called_once_with(
-            mock_coordinator.router_agent, "Implement user authentication system"
+            mock_coordinator.router_agent,
+            "Implement user authentication system",
+            allow_interactive_clarification=True,
         )
 
     @patch('agent_s3.pre_planner_json_enforced.integrate_with_coordinator')
@@ -182,7 +184,11 @@ class TestEnforcedJsonCoordinatorIntegration:
                 mock_coordinator, "Test task"
             )
 
-        mock_call.assert_called_once_with(mock_coordinator.router_agent, "Test task")
+        mock_call.assert_called_once_with(
+            mock_coordinator.router_agent,
+            "Test task",
+            allow_interactive_clarification=True,
+        )
 
     @patch('agent_s3.pre_planner_json_enforced.call_pre_planner_with_enforced_json')
     def test_direct_integration_with_coordinator(self, mock_call, mock_coordinator):
@@ -239,7 +245,11 @@ class TestEnforcedJsonCoordinatorIntegration:
         assert "complexity_score" in result
 
         # Verify the right function was called with the right arguments
-        mock_call.assert_called_once_with(mock_coordinator.router_agent, task)
+        mock_call.assert_called_once_with(
+            mock_coordinator.router_agent,
+            task,
+            allow_interactive_clarification=True,
+        )
 
     def test_validator_repair_plan_used(self, mock_coordinator):
         """Ensure repaired plans are utilized by the coordinator."""

--- a/tests/test_coordinator_json_preplanning.py
+++ b/tests/test_coordinator_json_preplanning.py
@@ -94,7 +94,11 @@ class TestCoordinatorJsonPrePlanning:
         result = integrate_with_coordinator(mock_coordinator, task)
 
         # Verify the call to call_pre_planner_with_enforced_json
-        mock_call.assert_called_once_with(mock_coordinator.router_agent, task)
+        mock_call.assert_called_once_with(
+            mock_coordinator.router_agent,
+            task,
+            allow_interactive_clarification=True,
+        )
 
         # Verify the result
         assert result["success"] is True
@@ -160,7 +164,11 @@ class TestCoordinatorJsonPrePlanning:
         result = integrate_with_coordinator(mock_coordinator, task)
 
         # Verify the call to call_pre_planner_with_enforced_json
-        mock_call.assert_called_once_with(mock_coordinator.router_agent, task)
+        mock_call.assert_called_once_with(
+            mock_coordinator.router_agent,
+            task,
+            allow_interactive_clarification=True,
+        )
 
         # Verify the result
         assert result["success"] is True

--- a/tests/test_coordinator_phases.py
+++ b/tests/test_coordinator_phases.py
@@ -180,7 +180,11 @@ def test_pre_planning_phase_normal_flow(coordinator):
     assert result["status"] == "completed"
     assert result["is_complex"] is False
     assert result["complexity_score"] == 150.0
-    mock_call.assert_called_once_with(coordinator.router_agent, "Add feature X")
+    mock_call.assert_called_once_with(
+        coordinator.router_agent,
+        "Add feature X",
+        allow_interactive_clarification=True,
+    )
     coordinator.pre_planner.assess_complexity.assert_called_once()
 
 def test_pre_planning_phase_high_complexity(coordinator):
@@ -204,7 +208,11 @@ def test_pre_planning_phase_high_complexity(coordinator):
     assert result["status"] == "completed"
     assert result["is_complex"] is True
     assert result["complexity_score"] == 400.0
-    mock_call.assert_called_once_with(coordinator.router_agent, "Refactor module Y")
+    mock_call.assert_called_once_with(
+        coordinator.router_agent,
+        "Refactor module Y",
+        allow_interactive_clarification=True,
+    )
     coordinator.pre_planner.assess_complexity.assert_called_once()
 
 def test_pre_planning_assess_complexity_error(coordinator):
@@ -223,7 +231,11 @@ def test_pre_planning_assess_complexity_error(coordinator):
     assert result["success"] is True
     assert result["status"] == "completed"
     assert result["is_complex"] is False
-    mock_call.assert_called_once_with(coordinator.router_agent, "Add feature Z")
+    mock_call.assert_called_once_with(
+        coordinator.router_agent,
+        "Add feature Z",
+        allow_interactive_clarification=True,
+    )
     coordinator.pre_planner.assess_complexity.assert_called_once()
 
 def test_pre_planning_complexity_estimation_error(coordinator):
@@ -243,7 +255,11 @@ def test_pre_planning_complexity_estimation_error(coordinator):
     assert result["status"] == "completed"
     assert result["complexity_score"] is None
     assert result["is_complex"] is False
-    mock_call.assert_called_once_with(coordinator.router_agent, "Add feature W")
+    mock_call.assert_called_once_with(
+        coordinator.router_agent,
+        "Add feature W",
+        allow_interactive_clarification=True,
+    )
     coordinator.pre_planner.assess_complexity.assert_called_once()
 
 def test_pre_planning_prompt_error(coordinator):
@@ -289,7 +305,11 @@ def test_pre_planning_phase_updated_requirements(coordinator):
     assert result["success"] is True
     assert result["status"] == "completed"
     assert result["test_requirements"]["approval_baseline"] == ["Baseline test"]
-    mock_call.assert_called_once_with(coordinator.router_agent, "Add feature X")
+    mock_call.assert_called_once_with(
+        coordinator.router_agent,
+        "Add feature X",
+        allow_interactive_clarification=True,
+    )
     coordinator.pre_planner.assess_complexity.assert_called_once()
 
 def test_pre_planning_phase_updated_complexity(coordinator):
@@ -313,7 +333,11 @@ def test_pre_planning_phase_updated_complexity(coordinator):
     assert result["status"] == "completed"
     assert result["is_complex"] is True
     assert result["complexity_score"] == 55
-    mock_call.assert_called_once_with(coordinator.router_agent, "Add feature X")
+    mock_call.assert_called_once_with(
+        coordinator.router_agent,
+        "Add feature X",
+        allow_interactive_clarification=True,
+    )
     coordinator.pre_planner.assess_complexity.assert_called_once()
 
 def test_pre_planning_phase_with_caching(coordinator):


### PR DESCRIPTION
## Summary
- pass `allow_interactive_clarification` through `integrate_with_coordinator`
- adjust call signature for `call_pre_planner_with_enforced_json`
- update Coordinator phase tests for new kwarg
- handle manifest verification in memory manager for tests

## Testing
- `pytest tests/test_coordinator_phases.py::test_pre_planning_phase_normal_flow -q`
- `pytest tests/integration/test_enforced_json_coordinator_integration.py::TestEnforcedJsonCoordinatorIntegration::test_pre_planning_with_enforced_json -q`