### PR TITLE
Add interactive clarification flag docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Description: Release notes for Agent-S3.
 - `SUPABASE_SERVICE_ROLE_KEY` – key used for privileged Supabase operations.
 - `SUPABASE_ANON_KEY` – optional key for anonymous access when applicable.
 - `SUPABASE_FUNCTION_NAME` – optional name of the Supabase function used for LLM calls.
+- `ALLOW_INTERACTIVE_CLARIFICATION` – optional flag (default: `True`) enabling interactive clarification questions.
 - `MAX_CLARIFICATION_ROUNDS` – optional number of clarification rounds allowed during pre-planning (default: `3`).
 - `MAX_PREPLANNING_ATTEMPTS` – optional number of retries for generating pre-planning data (default: `2`).
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,8 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
   - `SUPABASE_ANON_KEY` for client requests
   - `SUPABASE_FUNCTION_NAME` (optional, defaults to `call-llm`)
   - `USE_REMOTE_LLM` to toggle remote LLM usage
+  - `ALLOW_INTERACTIVE_CLARIFICATION` (optional, defaults to `True`)
+    enables clarifying questions during pre-planning
   - `MAX_CLARIFICATION_ROUNDS` (optional, defaults to `3`) limits pre-planning clarification exchanges
   - `MAX_PREPLANNING_ATTEMPTS` (optional, defaults to `2`) sets the maximum number of retries when generating pre-planning data
   - `pre_planning_mode` selects `off`, `json`, or `enforced_json` workflow. See `docs/pre_planning_workflow.md` for details.
@@ -370,6 +372,7 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
   SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
   SUPABASE_FUNCTION_NAME=call-llm
   USE_REMOTE_LLM=true
+  ALLOW_INTERACTIVE_CLARIFICATION=True
   MAX_CLARIFICATION_ROUNDS=3
   MAX_PREPLANNING_ATTEMPTS=2
   ```

--- a/docs/pre_planning_workflow.md
+++ b/docs/pre_planning_workflow.md
@@ -18,7 +18,7 @@ The pre-planning workflow follows these steps:
 
 5. **Repair**: If validation issues are found, the system attempts to repair them automatically.
 
-6. **User Interaction**: The system may ask clarifying questions to the user if needed. The number of clarification rounds is capped by the `MAX_CLARIFICATION_ROUNDS` environment variable (default: `3`).
+6. **User Interaction**: The system may ask clarifying questions to the user if needed. This behavior is controlled by the `ALLOW_INTERACTIVE_CLARIFICATION` environment variable (default: `True`). The number of clarification rounds is capped by the `MAX_CLARIFICATION_ROUNDS` environment variable (default: `3`).
 
 7. **Retry Logic**: The system retries generating pre-planning data up to `MAX_PREPLANNING_ATTEMPTS` times (default: `2`).
 
@@ -34,7 +34,7 @@ The `pre_planner_json_enforced.py` module is the canonical implementation for pr
 
 - Strict JSON schema definition and enforcement
 - Robust error handling and recovery
-- User interaction for clarifications (limited by `MAX_CLARIFICATION_ROUNDS`)
+- User interaction for clarifications (gated by `ALLOW_INTERACTIVE_CLARIFICATION` and limited by `MAX_CLARIFICATION_ROUNDS`)
 - Automatic repair of validation issues
 
 ### Pre-Planner JSON Validator


### PR DESCRIPTION
## Summary
- document `ALLOW_INTERACTIVE_CLARIFICATION` option in README
- mention clarification flag in pre-planning workflow docs
- log new environment variable in changelog

## Testing
- `pytest -q` *(fails: 13 errors)*