### PR TITLE
Fix optional dependency test imports

### DIFF
--- a/tests/integration/backup_test.py
+++ b/tests/integration/backup_test.py
@@ -9,6 +9,9 @@ import os
 import pytest
 import tempfile
 import shutil
+
+# Skip tiktoken integration tests if the dependency isn't installed
+pytest.importorskip("tiktoken")
 from unittest.mock import MagicMock
 
 from agent_s3.config import Config
@@ -321,8 +324,10 @@ class TestCompressionNoWorkarounds:
         # A file with many repeating patterns is good for ReferenceCompressor
         context = {
             "code_context": {
-                "repeated.py": "def process_item(item)
-                    :\n    result = item * 2\n    return result\n" * 50,                "unique.py": "\n".join([f"def unique_function_{i}():\n    return {i}" for i in range(30)])
+                "repeated.py": (
+                    "def process_item(item):\n    result = item * 2\n    return result\n" * 50
+                ),
+                "unique.py": "\n".join([f"def unique_function_{i}():\n    return {i}" for i in range(30)]),
             }
         }
 

--- a/tests/test_auth_token_encryption.py
+++ b/tests/test_auth_token_encryption.py
@@ -1,7 +1,10 @@
 from typing import Any
 
-from cryptography.fernet import Fernet
 import pytest
+
+# Skip this module if cryptography isn't installed
+pytest.importorskip("cryptography")
+from cryptography.fernet import Fernet
 
 from agent_s3.auth import TOKEN_ENCRYPTION_KEY_ENV
 from agent_s3.auth import load_token

--- a/tests/tools/parsing/test_parser_registry.py
+++ b/tests/tools/parsing/test_parser_registry.py
@@ -1,3 +1,7 @@
+import pytest
+
+# Skip if tree-sitter parsers aren't installed
+pytest.importorskip("tree_sitter")
 from agent_s3.tools.parsing.parser_registry import ParserRegistry
 
 def test_parser_registry_dispatch():

--- a/tests/tools/parsing/test_php_parser.py
+++ b/tests/tools/parsing/test_php_parser.py
@@ -1,3 +1,8 @@
+import pytest
+
+# Skip if tree-sitter parsers aren't installed
+pytest.importorskip("tree_sitter")
+pytest.importorskip("tree_sitter_php")
 from agent_s3.tools.parsing.php_parser import PHPTreeSitterParser
 
 def test_analyze_php_function():

--- a/tests/tools/parsing/test_tree_sitter_parsers.py
+++ b/tests/tools/parsing/test_tree_sitter_parsers.py
@@ -2,6 +2,13 @@
 """
 Test script to verify Tree-sitter parser integration with the modern capsule-based approach.
 """
+import pytest
+
+# Skip if tree-sitter parsers aren't installed
+pytest.importorskip("tree_sitter")
+pytest.importorskip("tree_sitter_javascript")
+pytest.importorskip("tree_sitter_php")
+pytest.importorskip("tree_sitter_typescript")
 from agent_s3.tools.parsing.parser_registry import ParserRegistry
 
 def test_javascript_parser():

--- a/tests/tools/test_static_analyzer.py
+++ b/tests/tools/test_static_analyzer.py
@@ -4,6 +4,7 @@ import pytest
 # available. Importing ``StaticAnalyzer`` triggers the import of ``phply``
 # internally, so guard the import to prevent ImportError.
 pytest.importorskip("phply")
+pytest.importorskip("tree_sitter")
 
 from agent_s3.tools.static_analyzer import StaticAnalyzer
 


### PR DESCRIPTION
## Summary
- skip cryptography-based tests if `cryptography` isn't installed
- skip tiktoken integration tests when `tiktoken` is unavailable
- guard tree-sitter parser tests behind optional dependency checks
- ensure static analyzer tests skip if tree-sitter is missing
- fix malformed context block in `backup_test.py`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'LLMUtils' from 'agent_s3.llm_utils')*