### PR TITLE
Add gather_context snapshot test

### DIFF
--- a/agent_s3/tools/context_management/context_manager.py
+++ b/agent_s3/tools/context_management/context_manager.py
@@ -731,7 +731,18 @@ class ContextManager:
         Returns:
             An optimized context dictionary.
         """
-        # ...existing code...
+        # Update the current context with provided parameters
+        if current_files:
+            self.update_context({"files": {f: "" for f in current_files}})
+
+        if task_description or task_type:
+            task_info: Dict[str, Any] = {}
+            if task_description:
+                task_info["description"] = task_description
+            if task_type:
+                task_info["type"] = task_type
+            self.update_context({"task": task_info})
+
         # Use the configured allocation strategy
         # The allocation strategy (e.g., TaskAdaptiveAllocation) should internally use task_keywords
         with self._context_lock:
@@ -1009,6 +1020,10 @@ class ContextManager:
         """Get the current context."""
         with self._context_lock:
             return copy.deepcopy(self.current_context)
+
+    def get_current_context_snapshot(self) -> Dict[str, Any]:
+        """Return a snapshot of the current context state."""
+        return self.get_context()
 
     def update_context(self, updates: Dict[str, Any]) -> None:
         """

--- a/tests/tools/context_management/test_context_manager.py
+++ b/tests/tools/context_management/test_context_manager.py
@@ -345,3 +345,23 @@ def test_gather_context_uses_lock_and_copy():
     called_context = cm.allocation_strategy.allocate.call_args[0][0]
     assert called_context == {"code_context": {"a.py": "print('hi')"}}
     assert called_context is not cm.current_context
+
+
+def test_gather_context_refines_and_updates():
+    cm = ContextManager()
+
+    cm.allocation_strategy = Mock()
+    cm.allocation_strategy.allocate.return_value = {"optimized_context": {}}
+
+    result = cm.gather_context(
+        current_files=["foo.py"],
+        task_description="desc",
+        task_type="debug",
+    )
+
+    snapshot = cm.get_current_context_snapshot()
+
+    assert result == {}
+    assert "files" in snapshot
+    assert "task" in snapshot and "description" in snapshot["task"]
+    assert "task" in snapshot and "type" in snapshot["task"]


### PR DESCRIPTION
## Summary
- update `ContextManager.gather_context` to store task details and files
- expose `get_current_context_snapshot` for inspecting current context
- refine gather context test to check snapshot fields

## Testing
- `pytest tests/tools/context_management/test_context_manager.py::test_gather_context_refines_and_updates -q`