### PR TITLE
Add tiktoken installation docs

### DIFF
--- a/docs/development_guidelines.md
+++ b/docs/development_guidelines.md
@@ -11,7 +11,12 @@ Description: Consolidated development guidelines for Agent-S3.
   ```bash
   python -m pip install -e . && pip install -r requirements.txt
   ```
+- Install optional tokenizers (required for some tests):
+  ```bash
+  pip install '.[tokenizers]'  # provides tiktoken for accurate token counting
+  ```
 - Run tests: `pytest`
+- If `tiktoken` is unavailable, unit tests under `tests/unit/context_management` mock the library to allow test execution.
 - Run a single test: `pytest tests/path_to_test.py::TestClass::test_function`
 - Run the CLI: `python -m agent_s3.cli`
 - Type checking: `mypy agent_s3/`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dependencies = [
 [project.optional-dependencies]
 postgresql = ["psycopg2-binary>=2.9.0"]
 mysql = ["pymysql>=1.0.0"]
+tokenizers = ["tiktoken>=0.5.0"]
 
 [project.scripts]
 agent-s3 = "agent_s3.cli:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ tree-sitter-php>=0.22.0
 gptcache>=0.1.44
 faiss-cpu>=1.7.0
 numpy>=1.24.0
-tiktoken>=0.5.0
+tiktoken>=0.5.0  # Install for accurate token counting
 rank-bm25>=0.2
 
 # Web framework and communication


### PR DESCRIPTION
## Summary
- document `tiktoken` optional install steps in the development docs
- mark `tiktoken` requirement in `requirements.txt`
- add `[tokenizers]` extras to `pyproject.toml`

## Testing
- `pytest tests/unit/context_management/test_token_budget_analyzer.py::test_allocate_tokens_truncates_important_files -q` *(fails: ImportError: attempted relative import with no known parent package)*