### PR TITLE
Update gather_context thread-safety

### DIFF
--- a/agent_s3/tools/context_management/context_manager.py
+++ b/agent_s3/tools/context_management/context_manager.py
@@ -758,7 +758,20 @@ class ContextManager:
         Returns:
             An optimized context dictionary.
         """
-        # ...existing code...
+        # Update the context with the latest task information
+        updates: Dict[str, Any] = {}
+        if current_files is not None:
+            updates["current_files"] = current_files
+        if task_description is not None:
+            updates["task_description"] = task_description
+        if task_type is not None:
+            updates["task_type"] = task_type
+        if related_files is not None:
+            updates["related_files"] = related_files
+
+        if updates:
+            self.update_context(updates)
+
         # Use the configured allocation strategy
         # The allocation strategy (e.g., TaskAdaptiveAllocation) should internally use task_keywords
         with self._context_lock:

--- a/tests/tools/context_management/test_context_manager.py
+++ b/tests/tools/context_management/test_context_manager.py
@@ -334,8 +334,7 @@ def test_gather_context_uses_lock_and_copy():
     cm.allocation_strategy = Mock()
     cm.allocation_strategy.allocate.return_value = {"optimized_context": {}}
 
-    with cm._context_lock:
-        cm.current_context = {"code_context": {"a.py": "print('hi')"}}
+    cm.update_context({"code_context": {"a.py": "print('hi')"}})
 
     dummy_lock = DummyLock()
     cm._context_lock = dummy_lock


### PR DESCRIPTION
## Summary
- update `gather_context` to store task info before allocating
- keep gather_context updates thread safe using `_context_lock`
- remove manual context mutation from unit test

## Testing
- `ruff check agent_s3/tools/context_management/context_manager.py tests/tools/context_management/test_context_manager.py`
- `mypy agent_s3/tools/context_management/context_manager.py`
- `pytest -q tests/tools/context_management/test_context_manager.py::test_gather_context_uses_lock_and_copy`