### PR TITLE
Add thread-safe context snapshot method

### DIFF
--- a/agent_s3/tools/context_management/context_manager.py
+++ b/agent_s3/tools/context_management/context_manager.py
@@ -620,8 +620,7 @@ class ContextManager:
         """Optimize the current context using :class:`ContextPruner`."""
         if not self.current_context:
             return
-        with self._context_lock:
-            context_copy = copy.deepcopy(self.current_context)
+        context_copy = self.get_current_context_snapshot()
         try:
             optimized = self.context_pruner.optimize(context_copy, self.config)
             with self._context_lock:
@@ -761,8 +760,7 @@ class ContextManager:
         # ...existing code...
         # Use the configured allocation strategy
         # The allocation strategy (e.g., TaskAdaptiveAllocation) should internally use task_keywords
-        with self._context_lock:
-            context_copy = copy.deepcopy(self.current_context)
+        context_copy = self.get_current_context_snapshot()
 
         allocation_result = self.allocation_strategy.allocate(
             context_copy,
@@ -1034,6 +1032,10 @@ class ContextManager:
     # Implement ContextProvider interface methods
     def get_context(self) -> Dict[str, Any]:
         """Get the current context."""
+        return self.get_current_context_snapshot()
+
+    def get_current_context_snapshot(self) -> Dict[str, Any]:
+        """Return a thread-safe snapshot of the current context."""
         with self._context_lock:
             return copy.deepcopy(self.current_context)
 
@@ -1062,8 +1064,7 @@ class ContextManager:
 
         self._optimize_context()
 
-        with self._context_lock:
-            return copy.deepcopy(self.current_context)
+        return self.get_current_context_snapshot()
 
     def clear_context(self) -> None:
         """Clear the entire context."""
@@ -1119,10 +1120,9 @@ class ContextManager:
             File content or None if file not found
         """
         # First check if we already have it in context
-        with self._context_lock:
-            files = self.current_context.get("files", {})
-            if file_path in files:
-                return files[file_path]
+        files = self.get_current_context_snapshot().get("files", {})
+        if file_path in files:
+            return files[file_path]
 
         # Otherwise try to load it with the file tool
         file_tool = self._tool_registry.get_tool_by_capability(ToolCapability.FILE_OPERATIONS)
@@ -1246,9 +1246,8 @@ class ContextManager:
         Returns:
             Stored value or None if key not found
         """
-        with self._context_lock:
-            memory = self.current_context.get("memory", {})
-            value = memory.get(key)
+        memory = self.get_current_context_snapshot().get("memory", {})
+        value = memory.get(key)
 
         # Record access for the pruning manager
         if value is not None:

--- a/agent_s3/tools/context_management/context_registry.py
+++ b/agent_s3/tools/context_management/context_registry.py
@@ -170,6 +170,14 @@ class ContextRegistry:
 
     # --- End Added Passthrough Methods ---
 
+    def get_current_context_snapshot(self, context_type: str = None, query: str = None) -> Dict[str, Any]:
+        """Return a snapshot of the current context from the registered manager."""
+        for provider in self._providers.values():
+            if hasattr(provider, "get_current_context_snapshot"):
+                return provider.get_current_context_snapshot()
+        logger.warning("No provider found for current context snapshot")
+        return {}
+
     def get_optimized_context(self, context_type: str = None) -> Dict[str, Any]:
         result = {}
         for provider in self._providers.values():

--- a/agent_s3/tools/error_context/hierarchy.py
+++ b/agent_s3/tools/error_context/hierarchy.py
@@ -26,8 +26,7 @@ class ContextHierarchyManager:
         try:
             if primary_file and hasattr(self.context_manager, '_refine_current_context'):
                 self.context_manager._refine_current_context(file_paths, max_tokens=max_token_count)
-                with self.context_manager._context_lock:
-                    context_files = self.context_manager.current_context.get("files", {})
+                context_files = self.context_manager.get_current_context_snapshot().get("files", {})
                 context["relevant_code"] = context_files
             elif hasattr(self.context_manager, 'get_context'):
                 cm_context = self.context_manager.get_context()


### PR DESCRIPTION
## Summary
- implement `get_current_context_snapshot` in `ContextManager`
- use snapshot helper in background optimization and context gathering
- expose snapshot via `ContextRegistry`
- update error context retrieval to use snapshot

## Testing
- `ruff check agent_s3` *(fails: 63 errors)*
- `mypy agent_s3`
- `pytest -q` *(fails: 12 errors)*