### PR TITLE
Update gather_context snapshot test

### DIFF
--- a/agent_s3/tools/context_management/context_manager.py
+++ b/agent_s3/tools/context_management/context_manager.py
@@ -1037,6 +1037,11 @@ class ContextManager:
         with self._context_lock:
             return copy.deepcopy(self.current_context)
 
+    def get_current_context_snapshot(self) -> Dict[str, Any]:
+        """Return a snapshot of the current context."""
+        with self._context_lock:
+            return copy.deepcopy(self.current_context)
+
     def update_context(self, updates: Dict[str, Any]) -> None:
         """
         Update the context with the provided updates.


### PR DESCRIPTION
## Summary
- add `get_current_context_snapshot` helper in `ContextManager`
- extend gather_context test to check snapshot keys

## Testing
- `pytest tests/tools/context_management/test_context_manager.py::test_gather_context_uses_lock_and_copy -q`