### PR TITLE
Fix ruff unused import warnings

### DIFF
--- a/agent_s3/coordinator/orchestrator.py
+++ b/agent_s3/coordinator/orchestrator.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import logging
 import threading
-import time
 import uuid
 
 import json

--- a/agent_s3/planner_json_enforced.py
+++ b/agent_s3/planner_json_enforced.py
@@ -26,7 +26,6 @@ from agent_s3.tools.context_management.token_budget import TokenEstimator
 
 # Import from the planning module
 from agent_s3.planning import (
-    validate_json_schema,
     repair_json_structure,
     get_consolidated_plan_system_prompt,
     get_implementation_planning_system_prompt,

--- a/agent_s3/tools/context_management/compression/base.py
+++ b/agent_s3/tools/context_management/compression/base.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Dict
 
-from .utils import logger
 
 
 class CompressionStrategy(ABC):

--- a/agent_s3/tools/context_management/compression/key_info.py
+++ b/agent_s3/tools/context_management/compression/key_info.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional
 
 from .base import CompressionStrategy
-from .utils import logger
 
 class KeyInfoExtractor(CompressionStrategy):
     """

--- a/agent_s3/tools/context_management/compression/reference.py
+++ b/agent_s3/tools/context_management/compression/reference.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict
 
 from .base import CompressionStrategy
-from .utils import hash_content, logger
+from .utils import hash_content
 
 class ReferenceCompressor(CompressionStrategy):
     """

--- a/agent_s3/tools/context_management/compression/semantic.py
+++ b/agent_s3/tools/context_management/compression/semantic.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 import re
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from .base import CompressionStrategy
-from .utils import logger
 
 
 class SemanticSummarizer(CompressionStrategy):

--- a/agent_s3/tools/context_management/token_budget.py
+++ b/agent_s3/tools/context_management/token_budget.py
@@ -13,7 +13,7 @@ import tiktoken
 import os
 import ast
 from abc import ABC, abstractmethod
-from typing import Dict, List, Any, Optional, Tuple, Callable
+from typing import Dict, List, Any, Optional, Callable
 
 logger = logging.getLogger(__name__)
 

--- a/agent_s3/tools/implementation_validator.py
+++ b/agent_s3/tools/implementation_validator.py
@@ -9,7 +9,7 @@ aligned with the system design, and address issues raised in architecture review
 import json
 import logging
 import re
-from typing import Dict, Any, List, Set, Tuple
+from typing import Dict, Any, List, Set
 
 from .validation_result import ValidationResult
 from collections import defaultdict
@@ -36,23 +36,9 @@ from .implementation_repairs import (
     repair_structure,
 )
 from .implementation_validation import (
-    check_function_naming_consistency,
-    check_implementation_complexity,
-    check_dependency_management,
-    find_circular_dependencies,
-    check_error_handling_patterns,
-    check_solid_principles,
-    validate_implementation_security,
-    validate_implementation_test_alignment,
     extract_assertions,
     extract_edge_cases,
     extract_expected_behaviors,
-    extract_element_ids_from_system_design,
-    extract_architecture_issues,
-    extract_test_requirements,
-    validate_single_function,
-    validate_architecture_issue_coverage,
-    element_needs_implementation,
 )
 
 logger = logging.getLogger(__name__)

--- a/agent_s3/tools/plan_validator/__init__.py
+++ b/agent_s3/tools/plan_validator/__init__.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Tuple
 
 from .validator import PlanValidator
 from .ast_utils import CodeAnalyzer, PlanValidationError, validate_code_syntax
-from .config import RESERVED_ENV_VARS, TOKEN_BUDGET_LIMITS
+
 from .structural_checks import (
     validate_duplicate_symbols,
     validate_identifier_hygiene,

--- a/agent_s3/tools/system_design/patterns.py
+++ b/agent_s3/tools/system_design/patterns.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 import json
 from typing import Any, Dict, List, Set
 
-from .constants import ErrorMessages, logger
+from .constants import ErrorMessages
 from ...config import get_config
 
 

--- a/agent_s3/tools/system_design/relationships.py
+++ b/agent_s3/tools/system_design/relationships.py
@@ -6,7 +6,7 @@ import re
 from collections import defaultdict
 from typing import Any, Dict, List, Tuple
 
-from .constants import ErrorMessages, logger
+from .constants import ErrorMessages
 
 
 def validate_component_relationships(system_design: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/agent_s3/tools/system_design/structure.py
+++ b/agent_s3/tools/system_design/structure.py
@@ -5,7 +5,7 @@ import json
 import re
 from typing import Any, Dict, List, Set
 
-from .constants import ErrorMessages, logger
+from .constants import ErrorMessages
 
 
 def validate_code_elements(system_design: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/agent_s3/tools/test_critic/core.py
+++ b/agent_s3/tools/test_critic/core.py
@@ -7,10 +7,8 @@ analysis capabilities from the original TestCritic class.
 """
 
 import logging
-import re
-import json
 from pathlib import Path
-from typing import Dict, Any, List, Optional, Set
+from typing import Dict, Any, List, Optional
 from enum import StrEnum
 
 from .adapters.base import Adapter

--- a/agent_s3/tools/test_critic/static_analysis.py
+++ b/agent_s3/tools/test_critic/static_analysis.py
@@ -10,9 +10,8 @@ from __future__ import annotations
 import json
 import logging
 import re
-from pathlib import Path
 import os
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Set
 
 from agent_s3.security_utils import sanitize_prompt_text
 


### PR DESCRIPTION
## Summary
- remove unused `time` import
- remove unused `validate_json_schema` import
- clean up unused imports across compression tools, token budget, implementation validator, plan validator, system design helpers, and test critic modules

## Testing
- `ruff check agent_s3 --select F401`
- `ruff check agent_s3 | head -n 20`
- `pytest -q` *(fails: cannot collect test class 'TestRunnerTool')*