### PR TITLE
Implement context snapshot forwarding

### DIFF
--- a/agent_s3/tools/context_management/context_registry.py
+++ b/agent_s3/tools/context_management/context_registry.py
@@ -169,22 +169,19 @@ class ContextRegistry:
         return {}
 
     def get_current_context_snapshot(self, context_type: str = None, query: str = None) -> Dict[str, Any]:
-        """Return a snapshot of the current context from the registered context manager."""
+        """Return a snapshot of the current context from the registered manager."""
         provider = self.get_provider("context_manager")
         if provider and hasattr(provider, "get_current_context_snapshot"):
-            return provider.get_current_context_snapshot(context_type=context_type, query=query)
-        logger.warning("No provider found for get_current_context_snapshot")
+            method = getattr(provider, "get_current_context_snapshot")
+            try:
+                return method(context_type=context_type, query=query)
+            except TypeError:
+                # Fallback for providers that do not accept parameters
+                return method()
+        logger.warning("No provider found for current context snapshot")
         return {}
 
     # --- End Added Passthrough Methods ---
-
-    def get_current_context_snapshot(self, context_type: str = None, query: str = None) -> Dict[str, Any]:
-        """Return a snapshot of the current context from the registered manager."""
-        for provider in self._providers.values():
-            if hasattr(provider, "get_current_context_snapshot"):
-                return provider.get_current_context_snapshot()
-        logger.warning("No provider found for current context snapshot")
-        return {}
 
     def get_optimized_context(self, context_type: str = None) -> Dict[str, Any]:
         result = {}

--- a/tests/test_coordinator_snapshot.py
+++ b/tests/test_coordinator_snapshot.py
@@ -1,0 +1,45 @@
+from agent_s3.tools.context_management.context_registry import ContextRegistry
+from agent_s3.error_handler import ErrorHandler
+
+class DummyContextManager:
+    def __init__(self):
+        self.received = None
+    def get_current_context_snapshot(self, context_type=None, query=None):
+        self.received = (context_type, query)
+        return {"snapshot": True}
+
+class DummyCoordinator:
+    def __init__(self, context_registry):
+        self.context_registry = context_registry
+        self.error_handler = ErrorHandler("CoordinatorTest", reraise=True)
+    def get_current_context_snapshot(self, context_type=None, query=None):
+        with self.error_handler.error_context(phase="context", operation="get_current_context_snapshot"):
+            return self.context_registry.get_current_context_snapshot(context_type=context_type, query=query)
+
+
+def test_coordinator_snapshot_forwarding():
+    registry = ContextRegistry()
+    manager = DummyContextManager()
+    registry.register_provider("context_manager", manager)
+    coordinator = DummyCoordinator(registry)
+
+    result = coordinator.get_current_context_snapshot(context_type="files", query="app.py")
+    assert result == {"snapshot": True}
+    assert manager.received == ("files", "app.py")
+
+
+def test_coordinator_snapshot_legacy_manager():
+    class LegacyManager:
+        def __init__(self):
+            self.called = False
+        def get_current_context_snapshot(self):
+            self.called = True
+            return {"legacy": True}
+    registry = ContextRegistry()
+    manager = LegacyManager()
+    registry.register_provider("context_manager", manager)
+    coordinator = DummyCoordinator(registry)
+
+    result = coordinator.get_current_context_snapshot(context_type="tech_stack", query="")
+    assert result == {"legacy": True}
+    assert manager.called


### PR DESCRIPTION
## Summary
- implement `get_current_context_snapshot` in `ContextRegistry`
- forward context_type and query when supported
- test coordinator retrieval of context snapshots

## Testing
- `ruff check agent_s3/tools/context_management/context_registry.py tests/test_coordinator_snapshot.py`
- `pytest -q tests/test_coordinator_snapshot.py -s`