### PR TITLE
Update context manager test name

### DIFF
--- a/tests/tools/context_management/test_context_manager.py
+++ b/tests/tools/context_management/test_context_manager.py
@@ -328,7 +328,7 @@ class DummyLock:
         return False
 
 
-def test_gather_context_uses_lock_and_copy():
+def test_gather_context_snapshot_fields():
     cm = ContextManager()
 
     cm.allocation_strategy = Mock()


### PR DESCRIPTION
## Summary
- rename `test_gather_context_uses_lock_and_copy` to `test_gather_context_snapshot_fields`

## Testing
- `ruff check tests/tools/context_management/test_context_manager.py`
- `mypy agent_s3`
- `pytest tests/tools/context_management/test_context_manager.py::test_gather_context_snapshot_fields -q`