### PR TITLE
Add VS Code activation events

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -12,6 +12,13 @@
   "categories": [
     "Other"
   ],
+  "activationEvents": [
+    "onCommand:agent-s3.init",
+    "onCommand:agent-s3.request",
+    "onCommand:agent-s3.openChatWindow",
+    "onCommand:agent-s3.openInteractiveView",
+    "onStartupFinished"
+  ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [


### PR DESCRIPTION
## Summary
- enable activation when VS Code starts or commands are run

## Testing
- `npm run vscode:prepublish` *(fails: Exit handler never called)*