### PR TITLE
Remove remote LLM fallback

### DIFF
--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -1,9 +1,6 @@
-import json
 import requests
 import sys
 import types
-
-import pytest
 
 # Provide a minimal progress_tracker to satisfy llm_utils import
 sys.modules.setdefault(
@@ -11,88 +8,10 @@ sys.modules.setdefault(
     types.SimpleNamespace(progress_tracker=lambda *a, **k: None),
 )
 
-from agent_s3.llm_utils import (  # noqa: E402
-    call_llm_via_supabase,
-    call_llm_with_retry,
-)
+from agent_s3.llm_utils import call_llm_with_retry  # noqa: E402
 
 
-class DummyResponse:
-    def __init__(self, text: str, status_code: int = 200) -> None:
-        self.text = text
-        self.status_code = status_code
 
-    def json(self) -> dict:
-        raise json.JSONDecodeError("error", self.text, 0)
-
-
-class DummyFunctions:
-    def __init__(self) -> None:
-        pass
-
-    def invoke(self, *args, **kwargs):
-        import requests  # delayed import for patching
-
-        return requests.post("http://example.com")
-
-
-class DummyClient:
-    def __init__(self) -> None:
-        self.functions = DummyFunctions()
-
-
-# fake create_client to avoid network
-
-def fake_create_client(url: str, key: str) -> DummyClient:
-    return DummyClient()
-
-
-def test_invalid_json_snippet(monkeypatch):
-    monkeypatch.setattr("agent_s3.llm_utils.create_client", fake_create_client)
-
-    def fake_post(*_args, **_kwargs):
-        return DummyResponse("{bad")
-
-    monkeypatch.setattr("requests.post", fake_post)
-
-    cfg = {
-        "supabase_url": "https://supabase",
-        "supabase_service_role_key": "key",
-        "supabase_function_name": "func",
-    }
-
-    with pytest.raises(ValueError) as exc:
-        call_llm_via_supabase("hi", "tok", cfg)
-
-    assert "{bad" in str(exc.value)
-
-
-def test_invalid_request_body(monkeypatch):
-    """Error is raised for a payload that cannot be JSON serialized."""
-    def dummy_client(*_args, **_kwargs):
-        raise AssertionError("client should not be created for invalid payload")
-
-    monkeypatch.setattr("agent_s3.llm_utils.create_client", dummy_client)
-
-    cfg = {
-        "supabase_url": "https://supabase",
-        "supabase_service_role_key": "key",
-        "supabase_function_name": "func",
-    }
-
-    with pytest.raises(ValueError):
-        call_llm_via_supabase(object(), "tok", cfg)
-
-
-def test_invalid_supabase_url_scheme(monkeypatch):
-    cfg = {
-        "supabase_url": "http://supabase",
-        "supabase_service_role_key": "key",
-        "supabase_function_name": "func",
-    }
-
-    with pytest.raises(ValueError):
-        call_llm_via_supabase("hi", "tok", cfg)
 
 
 def test_call_llm_with_retry_fallback_executes():


### PR DESCRIPTION
## Summary
- drop `call_llm_via_supabase` and remote fallback logic
- simplify `call_llm` to always use the local LLM
- clean up docstrings and unused imports
- update tests for local-only behaviour

## Testing
- `ruff check agent_s3/llm_utils.py tests/test_llm_utils.py tests/test_remote_llm.py`
- `mypy agent_s3/llm_utils.py`
- `pytest tests/test_llm_utils.py tests/test_remote_llm.py -q`
