### PR TITLE
Remove supabase dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ dependencies = [
     "pytest>=6.2.0",
     
     # Supabase integration
-    "supabase>=2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,6 @@ pytest-mock>=3.10.0
 # Optional database adapters
 psycopg2-binary>=2.9.0
 pymysql>=1.0.0
-supabase>=2.0.0
 
 # Legacy PHP parsing (if needed)
 phply>=0.9.1


### PR DESCRIPTION
## Summary
- drop `supabase` requirement from project dependencies

## Testing
- `python validate_dependencies.py`
- `pip check`
