### PR TITLE
Clean up residual Supabase code and fix Ruff warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,6 @@ This architecture enables a Copilot-like, interactive experience with immediate 
 - Required packages: `sqlalchemy` with optional adapters
   - `psycopg2-binary` for PostgreSQL
   - `pymysql` for MySQL
-  - `supabase-py` for Supabase integration
 - GitHub account and relevant tokens or app credentials
 
 ## Tree-sitter Grammar Setup

--- a/agent_s3/planner_json_enforced.py
+++ b/agent_s3/planner_json_enforced.py
@@ -13,6 +13,8 @@ from typing import Dict, Any, Optional, Tuple
 from datetime import datetime
 from collections import defaultdict
 from pathlib import Path
+import time
+import random
 
 from agent_s3.tools.implementation_validator import (
     validate_implementation_plan,
@@ -21,35 +23,14 @@ from agent_s3.tools.implementation_validator import (
 )
 from agent_s3.json_utils import extract_json_from_text, get_openrouter_json_params
 from agent_s3.tools.context_management.token_budget import TokenEstimator
-from agent_s3.llm_utils import cached_call_llm
-from agent_s3.errors import PlanningError
 
 # Import from the planning module
 from agent_s3.planning import (
     repair_json_structure,
-    get_consolidated_plan_system_prompt,
     get_stage_system_prompt,
     JSONPlannerError,
     validate_planning_semantic_coherence,
 )
-
-# Import common utilities
-from agent_s3.common_utils import (
-    retry_with_backoff,
-    call_with_retry,
-    ValidationResult,
-    handle_error_with_context,
-    create_error_response,
-    safe_json_loads,
-    extract_json_with_patterns,
-    repair_json_quotes,
-    log_function_entry_exit,
-    ProcessingError,
-    ValidationError,
-    exponential_backoff_with_jitter
-)
-# Extracted functions are now imported from the planning module
-
 
 def repair_json_structure_basic(data: Dict[str, Any]) -> Dict[str, Any]:
     """
@@ -312,7 +293,6 @@ Focus on creating a comprehensive and detailed plan that a developer can follow 
 """
 
     # Get LLM parameters from json_utils to maintain consistency
-    from .json_utils import get_openrouter_json_params
     llm_params = get_openrouter_json_params()
 
     # Call the LLM with enhanced retry logic

--- a/agent_s3/planning_helper.py
+++ b/agent_s3/planning_helper.py
@@ -1,8 +1,6 @@
 """Helper utilities for planning workflows."""
 from typing import Any
 from typing import Dict
-from typing import Optional
-
 from . import pre_planner_json_enforced
 
 def generate_plan_via_workflow(

--- a/agent_s3/tests/integration_test_errors.py
+++ b/agent_s3/tests/integration_test_errors.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 from agent_s3.errors import PrePlanningError as ValidationError
-from agent_s3.errors import ErrorContext
 from agent_s3.pre_planner_json_validator import PrePlannerJsonValidator as PrePlanningValidator
 
 # Create a simple validator

--- a/agent_s3/tools/test_critic/static_analysis.py
+++ b/agent_s3/tools/test_critic/static_analysis.py
@@ -868,14 +868,12 @@ class CriticStaticAnalyzer:
             # Unit tests are most common, always assume them if we have test specs
             test_types_found.add(TestType.UNIT)
 
-            framework = spec.get("framework", "").lower()
             scenarios = spec.get("scenarios", [])
             security_tests_spec = spec.get("security_tests", []) # Renamed to avoid conflict
             property_tests_spec = spec.get("property_tests", []) # Renamed
             approval_tests_spec = spec.get("approval_tests", []) # Renamed
 
             for scenario in scenarios:
-                function_name = scenario.get("function", "")  # Renamed to avoid conflict
 
                 # Look for property-based testing patterns
                 cases = scenario.get("cases", [])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,8 +66,6 @@ dependencies = [
     # Testing framework
     "pytest>=6.2.0",
     
-    # Supabase integration
-    "supabase>=2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,6 @@ pytest-mock>=3.10.0
 # Optional database adapters
 psycopg2-binary>=2.9.0
 pymysql>=1.0.0
-supabase>=2.0.0
 
 # Legacy PHP parsing (if needed)
 phply>=0.9.1

--- a/scripts/cleanup.py
+++ b/scripts/cleanup.py
@@ -7,13 +7,11 @@ This replaces multiple individual cleanup scripts with a unified tool.
 """
 import argparse
 import logging
-import os
 import re
 import shutil
-import subprocess
 import sys
 from pathlib import Path
-from typing import List, Set
+from typing import List
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')

--- a/scripts/lint_and_fix.py
+++ b/scripts/lint_and_fix.py
@@ -10,7 +10,7 @@ import logging
 import subprocess
 import sys
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')

--- a/tests/test_coordinator_coverage_improvements.py
+++ b/tests/test_coordinator_coverage_improvements.py
@@ -256,7 +256,7 @@ class TestCoordinatorErrorHandling:
             
             # This should trigger the error handling path
             with pytest.raises(Exception):
-                coordinator = Coordinator(config=mock_config)
+                Coordinator(config=mock_config)
 
 
 class TestCoordinatorPropertyMethods:
@@ -327,13 +327,13 @@ class TestCoordinatorComplexWorkflows:
         workflow_coordinator.prompt_moderator.max_plan_iterations = 3
         workflow_coordinator.prompt_moderator.present_consolidated_plan.return_value = ("yes", None)
         workflow_coordinator.context_registry = MagicMock()
-        
+
         with patch('agent_s3.tools.static_plan_checker.StaticPlanChecker'):
             # Test the workflow
-            result = workflow_coordinator.plan_approval_loop(plan)
-            
-            # Verify plan was presented
-            workflow_coordinator.prompt_moderator.present_consolidated_plan.assert_called_once()
+            workflow_coordinator.plan_approval_loop(plan)
+
+        # Verify plan was presented
+        workflow_coordinator.prompt_moderator.present_consolidated_plan.assert_called_once()
 
     def test_extract_keywords_from_task_method(self, workflow_coordinator):
         """Test keyword extraction method."""

--- a/tests/test_coordinator_debugging.py
+++ b/tests/test_coordinator_debugging.py
@@ -3,15 +3,12 @@ Unit tests for the debugging integration in the Coordinator class.
 """
 from unittest.mock import MagicMock
 from unittest.mock import patch
-from unittest.mock import PropertyMock
 
 import pytest
 
 from agent_s3.coordinator import Coordinator
 from agent_s3.debugging_manager import DebuggingManager
 from agent_s3.enhanced_scratchpad_manager import EnhancedScratchpadManager
-from agent_s3.enhanced_scratchpad_manager import LogLevel
-from agent_s3.enhanced_scratchpad_manager import Section
 
 @pytest.fixture
 def mock_config():

--- a/tests/test_coordinator_merged.py
+++ b/tests/test_coordinator_merged.py
@@ -7,9 +7,8 @@ Complex integration tests have been simplified or removed to focus on testable c
 import os
 import pytest
 import tempfile
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-from agent_s3.config import Config
 
 
 @pytest.fixture

--- a/tests/test_llm_config_schema.py
+++ b/tests/test_llm_config_schema.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+
 
 from agent_s3.router_agent import _load_llm_config
 

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -2,7 +2,6 @@ import requests
 import sys
 import types
 
-import pytest
 
 # Provide a minimal progress_tracker to satisfy llm_utils import
 sys.modules.setdefault(

--- a/tests/test_semantic_cache.py
+++ b/tests/test_semantic_cache.py
@@ -38,7 +38,7 @@ def test_set_and_get_cache_hit():
     cached_result = cache.get(prompt)
     assert cached_result is not None
     assert cached_result['response'] == response
-    assert cached_result['cached'] == True
+    assert cached_result['cached'] is True
 
     stats = cache.get_cache_stats()
     assert stats['hits'] == 1
@@ -57,7 +57,7 @@ def test_ttl_expiry():
     result = cache.get(prompt)
     assert result is not None
     assert result['response'] == response
-    assert result['cached'] == True
+    assert result['cached'] is True
     time.sleep(1.1)
     # Should expire
     assert cache.get(prompt) is None
@@ -90,7 +90,7 @@ def test_cache_miss_and_hit(monkeypatch):
     result = cache.get(prompt)
     assert result is not None
     assert result['response'] == {'res': 123}
-    assert result['cached'] == True
+    assert result['cached'] is True
     stats = cache.get_cache_stats()
     assert stats['misses'] == 1
     assert stats['hits'] == 1
@@ -128,4 +128,4 @@ def test_semantic_search_no_embedding(monkeypatch, count):
     result = cache.get(prompt)
     assert result is not None
     assert result['response'] == {'val': count}
-    assert result['cached'] == True
+    assert result['cached'] is True

--- a/tests_backup_20250526_224723/test_cli.py
+++ b/tests_backup_20250526_224723/test_cli.py
@@ -12,7 +12,7 @@ sys.modules['agent_s3.coordinator'] = types.SimpleNamespace(Coordinator=object)
 sys.modules['agent_s3.router_agent'] = types.SimpleNamespace(RouterAgent=object)
 sys.modules['agent_s3.config'] = types.SimpleNamespace(Config=object)
 
-from agent_s3.cli import process_command
+from agent_s3.cli import process_command  # noqa: E402
 
 
 class TestCliProcessCommand(unittest.TestCase):

--- a/tools/analyze_imports.py
+++ b/tools/analyze_imports.py
@@ -4,10 +4,9 @@ Comprehensive import and dependency analysis for agent_s3 codebase
 """
 
 import ast
-import os
 import sys
 from pathlib import Path
-from typing import Dict, List, Set, Tuple, Optional
+from typing import Dict, List, Tuple, Optional
 from collections import defaultdict
 import importlib.util
 
@@ -91,8 +90,6 @@ def analyze_file(file_path: Path, base_path: Path) -> Dict:
         return {"error": f"Could not parse {file_path}"}
     
     module_imports, from_imports = extract_imports(tree)
-    function_calls = extract_function_calls(tree)
-    attributes = extract_attribute_access(tree)
     
     issues = {
         'file': str(file_path),

--- a/validate_dependencies.py
+++ b/validate_dependencies.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 import json
 import os
-from typing import List, Dict, Any, Tuple
+from typing import List, Tuple
 
 
 class DependencyValidator:


### PR DESCRIPTION
## Summary
- drop Supabase mention from documentation and dependencies
- tidy unused imports across utilities and tests
- fix undefined names in `planner_json_enforced`
- silence `E402` for backup CLI test
- update semantic cache tests to avoid E712 warnings

## Testing
- `ruff check`
- `pytest -q` *(fails: ImportError in tests)*