### PR TITLE
Fix supabase defaults in config

### DIFF
--- a/agent_s3/config.py
+++ b/agent_s3/config.py
@@ -12,7 +12,7 @@ import threading
 from pathlib import Path
 from typing import Optional, Dict, List, Any
 
-from pydantic import BaseModel, ValidationError, Field
+from pydantic import BaseModel, ValidationError
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -84,7 +84,6 @@ SUMMARIZER_TIMEOUT       = float(os.getenv('SUMMARIZER_TIMEOUT',      '45.0'))
 # System design pattern validation
 MAX_DESIGN_PATTERNS      = int(os.getenv('MAX_DESIGN_PATTERNS', '3'))
 
-# Supabase configuration
 SUPABASE_URL               = os.getenv('SUPABASE_URL', '')
 SUPABASE_SERVICE_ROLE_KEY  = os.getenv('SUPABASE_SERVICE_ROLE_KEY', '')
 SUPABASE_FUNCTION_NAME     = os.getenv('SUPABASE_FUNCTION_NAME', 'call-llm')
@@ -205,12 +204,8 @@ class ConfigModel(BaseModel):
     adaptive_config_dir: str = ADAPTIVE_CONFIG_DIR
     adaptive_metrics_dir: str = ADAPTIVE_METRICS_DIR
     adaptive_optimization_interval: int = ADAPTIVE_OPTIMIZATION_INTERVAL
-    supabase_service_role_key: str = Field(
-        default_factory=lambda: os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
-    )
-    supabase_function_name: str = Field(
-        default_factory=lambda: os.environ.get("SUPABASE_FUNCTION_NAME", "call-llm")
-    )
+    supabase_service_role_key: str = SUPABASE_SERVICE_ROLE_KEY
+    supabase_function_name: str = SUPABASE_FUNCTION_NAME
 
     class Config:
         extra = "allow"


### PR DESCRIPTION
## Summary
- reuse supabase constants in `ConfigModel`

## Testing
- `ruff check agent_s3/config.py`
- `pytest -q` *(fails: ImportError due to missing packages)*