### PR TITLE
Remove unused supabase bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,6 @@ This architecture enables a Copilot-like, interactive experience with immediate 
 - Required packages: `sqlalchemy` with optional adapters
   - `psycopg2-binary` for PostgreSQL
   - `pymysql` for MySQL
-  - `supabase-py` for Supabase integration
 - GitHub account and relevant tokens or app credentials
 
 ## Tree-sitter Grammar Setup


### PR DESCRIPTION
## Summary
- remove `supabase-py` from the prerequisites list in the README

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*
- `python -m pytest` *(fails: 5 errors during collection)*