### PR TITLE
Fix /help output parity

### DIFF
--- a/agent_s3/cli/__init__.py
+++ b/agent_s3/cli/__init__.py
@@ -35,9 +35,9 @@ def configure_logging(verbose: bool = False) -> None:
     logging.getLogger("requests").setLevel(logging.WARNING)
 
 
-def display_help() -> None:
-    """Display help information for the command-line interface."""
-    help_text = """
+def get_help_text() -> str:
+    """Return help information for the command-line interface."""
+    return """
 Agent-S3 Command-Line Interface
 
 Commands:
@@ -86,8 +86,13 @@ Special Commands (can be used in prompt):
   /debug                     - Start debugging utilities
   @<filename>                - Open a file in the editor
   #<tag>                     - Add a tag to the scratchpad
+
 """
-    print(help_text)
+
+
+def display_help() -> None:
+    """Display help information for the command-line interface."""
+    print(get_help_text())
 
 
 def process_command(coordinator: Coordinator, command: str) -> None:

--- a/agent_s3/communication/http_server.py
+++ b/agent_s3/communication/http_server.py
@@ -57,12 +57,8 @@ class Agent3HTTPHandler(BaseHTTPRequestHandler):
             if not self.coordinator:
                 # Fallback simple responses if no coordinator
                 if command == '/help':
-                    return """Available commands:
-/help - Show this help
-/init - Initialize workspace  
-/plan <description> - Generate a plan
-/test - Run tests
-/config - Show configuration"""
+                    from agent_s3.cli import get_help_text
+                    return get_help_text()
                 elif command == '/config':
                     return "Agent-S3 Configuration: Ready"
                 elif command.startswith('/plan'):
@@ -78,12 +74,8 @@ class Agent3HTTPHandler(BaseHTTPRequestHandler):
             
             # Handle help command specially
             if command == "/help":
-                return """Available commands:
-/help - Show this help
-/init - Initialize workspace  
-/plan <description> - Generate a plan
-/test - Run tests
-/config - Show configuration"""
+                from agent_s3.cli import get_help_text
+                return get_help_text()
             
             # Process through coordinator's command processor
             from agent_s3.cli.dispatcher import dispatch

--- a/docs/streaming_ui_implementation.md
+++ b/docs/streaming_ui_implementation.md
@@ -67,12 +67,12 @@ Returns server health status.
 ```
 
 ### GET /help
-Returns available commands.
+Returns the same help text as `python -m agent_s3.cli /help`.
 
 **Response:**
 ```json
 {
-  "result": "Available commands:\n/help - Show this help\n/init - Initialize workspace\n..."
+  "result": "Agent-S3 Command-Line Interface\n\nCommands:\n  agent-s3 <prompt>          - Process a change request (full workflow)\n  ..."
 }
 ```
 


### PR DESCRIPTION
## Summary
- expose help text retrieval via `get_help_text`
- reuse same help text in HTTP handler
- document that `/help` returns the full CLI help

## Testing
- `python scripts/lint_and_fix.py --syntax-only`
- `python scripts/lint_and_fix.py --python-only`
- `python scripts/lint_and_fix.py --tests-only` *(fails: ImportError for several modules)*

------
https://chatgpt.com/codex/tasks/task_e_683ee2f8cd44832d871df00075750f38