### PR TITLE
Handle numeric status in progress tracker

### DIFF
--- a/agent_s3/progress_tracker.py
+++ b/agent_s3/progress_tracker.py
@@ -77,6 +77,11 @@ class ProgressTracker:
                 status = Status[status_val.upper()]
             except KeyError:
                 status = Status.IN_PROGRESS
+        elif isinstance(status_val, int):
+            try:
+                status = Status(status_val)
+            except ValueError:
+                status = Status.IN_PROGRESS
         elif isinstance(status_val, Status):
             status = status_val
         else:

--- a/tests/test_progress_tracker_status.py
+++ b/tests/test_progress_tracker_status.py
@@ -1,0 +1,47 @@
+from agent_s3.progress_tracker import ProgressTracker, Status
+
+class DummyConfig:
+    def __init__(self, log_file: str):
+        self.config = {"log_files": {"progress": log_file}}
+
+def make_tracker(tmp_path):
+    cfg = DummyConfig(str(tmp_path / "progress.jsonl"))
+    tracker = ProgressTracker(cfg)
+    return tracker
+
+def test_update_progress_with_string_status(tmp_path):
+    tracker = make_tracker(tmp_path)
+    captured = {}
+
+    def fake_log_entry(entry):
+        captured['entry'] = entry
+        return True
+
+    tracker.log_entry = fake_log_entry
+    assert tracker.update_progress({"phase": "phase", "status": "completed"})
+    assert captured['entry'].status == Status.COMPLETED.value
+
+def test_update_progress_with_int_status(tmp_path):
+    tracker = make_tracker(tmp_path)
+    captured = {}
+
+    def fake_log_entry(entry):
+        captured['entry'] = entry
+        return True
+
+    tracker.log_entry = fake_log_entry
+    assert tracker.update_progress({"phase": "phase", "status": Status.FAILED.value})
+    assert captured['entry'].status == Status.FAILED.value
+
+
+def test_update_progress_with_invalid_status(tmp_path):
+    tracker = make_tracker(tmp_path)
+    captured = {}
+
+    def fake_log_entry(entry):
+        captured['entry'] = entry
+        return True
+
+    tracker.log_entry = fake_log_entry
+    assert tracker.update_progress({"phase": "phase", "status": 999})
+    assert captured['entry'].status == Status.IN_PROGRESS.value


### PR DESCRIPTION
## Summary
- interpret integer `status` values in `update_progress`
- test progress tracker with numeric and string statuses

## Testing
- `pytest tests/test_progress_tracker_status.py -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68401f240f48832d8b4b1068c094b43c