### PR TITLE
Add status polling for long commands

### DIFF
--- a/vscode/stubs.d.ts
+++ b/vscode/stubs.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 declare module "vscode" {
   const x: any;
   export = x;


### PR DESCRIPTION
## Summary
- add `/status` endpoint to HTTP server and store last command result
- schedule status polling in VS Code extension when HTTP calls time out
- silence `no-explicit-any` lint errors in stub declarations

## Testing
- `npm run lint` in `vscode`
- `npm run typecheck` in `vscode`
- `pytest -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_684058166ee0832da979c69007d0138f