### PR TITLE
Add configurable CORS origins

### DIFF
--- a/agent_s3/coordinator/__init__.py
+++ b/agent_s3/coordinator/__init__.py
@@ -301,15 +301,17 @@ class Coordinator:
         """Initialize communication components like the HTTP server."""
         from agent_s3.communication.http_server import EnhancedHTTPServer
 
-        # Get host and port from HTTP config, with defaults
+        # Get host, port, and allowed origins from HTTP config, with defaults
         http_config = self.config.config.get('http', {})
         http_host = http_config.get('host', 'localhost')
         http_port = http_config.get('port', 8081)  # Default to 8081 for HTTP
+        allowed_origins = http_config.get('allowed_origins', ['*'])
 
         self.http_server = EnhancedHTTPServer(
             host=http_host,
             port=http_port,
-            coordinator=self
+            coordinator=self,
+            allowed_origins=allowed_origins,
         )
         # Start the server in a separate thread so it doesn't block the coordinator
         self.http_thread = self.http_server.start_in_thread()

--- a/config.json
+++ b/config.json
@@ -11,6 +11,7 @@
   },
   "http": {
     "host": "localhost",
-    "port": 8081
+    "port": 8081,
+    "allowed_origins": ["*"]
   }
 }

--- a/docs/streaming_ui_implementation.md
+++ b/docs/streaming_ui_implementation.md
@@ -118,13 +118,15 @@ Processes Agent-S3 commands.
 
 ## Configuration
 
-The system now uses HTTP configuration in `config.json`:
+The system now uses HTTP configuration in `config.json`.
+Set `allowed_origins` to restrict which Origins may access the API:
 
 ```json
 {
   "http": {
     "host": "localhost",
-    "port": 8081
+    "port": 8081,
+    "allowed_origins": ["*"]
   }
 }
 ```


### PR DESCRIPTION
## Summary
- allow configuring allowed CORS origins in the HTTP server
- respect `allowed_origins` from `config.json`
- document the new setting in streaming UI docs

## Testing
- `python scripts/lint_and_fix.py --tests-only` *(fails: ImportError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68405ea08e44832db690acb36efd78aa