### PR TITLE
docs: document GET /status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ See `docs/summarization.md` for details.
 - Status bar item (`$(sparkle) Agent-S3`) to start change requests
 - Dedicated terminal panel for backend interactions
 - Real-time status updates via HTTP API; `progress_log.jsonl` is retained only as a log file
+- The extension's `pollForResult` function repeatedly calls `GET /status` after a command is sent until a result is returned.
 - Server shuts down automatically on exit, removing the connection file
 - Connection file uses `0600` permissions on POSIX systems; default permissions
   apply on Windows

--- a/docs/streaming_ui_implementation.md
+++ b/docs/streaming_ui_implementation.md
@@ -92,6 +92,18 @@ Processes Agent-S3 commands.
   "result": "Command output here"
 }
 ```
+### GET /status
+Returns the result of the last command. The server clears the stored result after it is retrieved.
+
+**Response:**
+```json
+{
+  "result": "Command output here",
+  "output": "",
+  "success": true
+}
+```
+
 
 ## File Structure
 


### PR DESCRIPTION
## Summary
- document GET /status in streaming API docs
- mention pollForResult in README

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*
- `pytest -q` *(fails: 5 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68405e87b944832dbd2fb4bcc65827ad