### PR TITLE
Update polling docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,8 +247,8 @@ See `docs/summarization.md` for details.
 - Command Palette integration: Initialize workspace, Make change request, Show help, Show config, Reload LLM config, Explain last LLM interaction, Open Chat Window
 - Status bar item (`$(sparkle) Agent-S3`) to start change requests
 - Dedicated terminal panel for backend interactions
-- Real-time status updates via HTTP API; `progress_log.jsonl` is retained only as a log file
-- The extension's `pollForResult` function repeatedly calls `GET /status` after a command is sent until a result is returned.
+- Real-time status updates via HTTP API; `progress_log.jsonl` stores progress logs
+- The extension polls the `/status` endpoint until a command result is available
 - Server shuts down automatically on exit, removing the connection file
 - Connection file uses `0600` permissions on POSIX systems; default permissions
   apply on Windows
@@ -262,11 +262,11 @@ See `docs/summarization.md` for details.
 
 ## Streaming UI
 
-Agent-S3 features a real-time UI for chat and progress updates, powered by an HTTP-based architecture:
+Agent-S3 features a real-time UI for chat and progress updates, powered by an HTTP-based architecture. See [docs/streaming_ui_implementation.md](docs/streaming_ui_implementation.md) for implementation details:
 
 - **HTTP Client/Server:** The backend and VS Code extension communicate via HTTP REST API, supporting command processing and status updates.
 - **Streaming Chat UI:** The `ChatView` React component in the extension displays real-time agent responses, partial message rendering, and thinking indicators.
-- **Backend Integration:** The backend emits streaming updates for progress, terminal output, and chat, eliminating the need for file polling.
+- **Backend Integration:** The extension currently polls `/status` for command results and reads `progress_log.jsonl` for progress details. Streaming updates will be added after Issue #2.
 - **Robust Error Handling:** Includes reconnection logic, buffering, and error logging for reliable user experience.
 - **Extensible Protocol:** The message protocol supports future UI features like syntax highlighting, progress bars, and operation cancellation.
 

--- a/docs/streaming_ui_implementation.md
+++ b/docs/streaming_ui_implementation.md
@@ -35,7 +35,8 @@ This document describes the implementation of HTTP-based communication for Agent
 2. **VS Code Extension**
    - Integrated HTTP client with VS Code extension API
    - Command processing through HTTP endpoints
-   - Progress tracking via polling or direct CLI execution
+   - Progress tracking via the `/status` endpoint and `progress_log.jsonl`
+     (polled until streaming support lands in Issue #2)
 
 ## Communication Flow
 
@@ -51,7 +52,7 @@ VS Code Extension -> HTTP GET /health -> {"status": "ok"} -> Connection Status
 
 ### Progress Updates
 ```
-Backend -> Progress Log File -> VS Code Extension polls or reads file -> UI Updates
+Backend -> `progress_log.jsonl` -> VS Code Extension polls `/status` -> UI Updates
 ```
 
 ## API Endpoints
@@ -93,7 +94,7 @@ Processes Agent-S3 commands.
 }
 ```
 ### GET /status
-Returns the result of the last command. The server clears the stored result after it is retrieved.
+Returns the result of the last command. The extension polls this endpoint until a result is available. The server clears the stored result after it is retrieved.
 
 **Response:**
 ```json
@@ -161,3 +162,5 @@ Set `allowed_origins` to restrict which Origins may access the API:
 - **Simplified Deployment**: Standard HTTP server deployment practices
 
 This implementation provides a modern, reliable communication layer while maintaining all the functionality of the previous WebSocket-based system with improved simplicity and reliability.
+
+Future enhancements for real-time streaming will be tracked in **Issue #2**.


### PR DESCRIPTION
## Summary
- clarify polling behavior in README and streaming_ui_implementation docs
- note future streaming feature in Issue #2
- crosslink streaming docs from README

## Testing
- `python scripts/lint_and_fix.py --syntax-only`
- `pytest tests/test_progress_tracker_status.py::test_update_progress_with_string_status -q`

------
https://chatgpt.com/codex/tasks/task_e_6840640b86fc832da8df88d20f956b7a