### PR TITLE
Add async job support to HTTP server

### DIFF
--- a/docs/manual_http_timeout_test.md
+++ b/docs/manual_http_timeout_test.md
@@ -4,12 +4,13 @@ Description: Manual steps to verify HTTP timeout handling in the VS Code extensi
 -->
 # Manual Test for HTTP Timeout
 
-This guide verifies that long-running HTTP commands do not cause the extension to fall back to the CLI.
+This guide verifies that long-running HTTP commands are processed asynchronously without falling back to the CLI.
 
 1. Launch the Agent-S3 backend so that `.agent_s3_http_connection.json` is created with the HTTP server address.
 2. Set the environment variable `AGENT_S3_HTTP_TIMEOUT=1000` to force a short timeout.
 3. In VS Code, execute a command expected to run longer than one second, for example:
    - Open the command palette and run **Agent-S3: Make change request**.
    - Provide a complex request that will take additional processing time.
-4. Observe that the extension displays a processing message instead of spawning the CLI.
-5. Once the backend finishes, the terminal output should show the result without a secondary CLI process.
+4. Observe that the `/command` endpoint immediately returns a JSON object containing a `job_id`.
+5. The VS Code extension polls `GET /status/<job_id>` until the backend finishes processing.
+6. Once the job completes, the terminal output updates with the final result and no secondary CLI process is spawned.


### PR DESCRIPTION
## Summary
- support async `/command` calls with job ID
- poll for results in VS Code extension
- show final command output once polling completes
- document updated async behavior

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: Rules with suggestions must set the `meta.hasSuggestions` property)*
- `pytest tests/test_shell_quote.py::test_quote_simple`

------
https://chatgpt.com/codex/tasks/task_e_684063a3fdfc832db49b90fdc313522d