### PR TITLE
Fix init failure message and add tests

### DIFF
--- a/agent_s3/command_processor.py
+++ b/agent_s3/command_processor.py
@@ -59,11 +59,19 @@ class CommandProcessor:
                 result_msg = "Workspace initialized successfully."
                 
                 # Get validation details for better user feedback
-                if hasattr(self.coordinator.workspace_initializer, 'validation_failure_reason') and self.coordinator.workspace_initializer.validation_failure_reason:
+                if (
+                    hasattr(self.coordinator.workspace_initializer, "validation_failure_reason")
+                    and self.coordinator.workspace_initializer.validation_failure_reason
+                ):
                     if initialization_success:
-                        result_msg += f" Note: {self.coordinator.workspace_initializer.validation_failure_reason}"
+                        result_msg += (
+                            f" Note: {self.coordinator.workspace_initializer.validation_failure_reason}"
+                        )
                     else:
-                        result_msg = f"Workspace initialization completed with warnings: {self.coordinator.workspace_initializer.validation_failure_reason}. Some features may be limited."
+                        result_msg = (
+                            "Workspace initialization failed: "
+                            f"{self.coordinator.workspace_initializer.validation_failure_reason}"
+                        )
             else:
                 # Handle coordinator fallback with proper return value parsing
                 result = self.coordinator.initialize_workspace()

--- a/agent_s3/coordinator/orchestrator.py
+++ b/agent_s3/coordinator/orchestrator.py
@@ -410,7 +410,7 @@ class WorkflowOrchestrator:
                     )
                     self.coordinator.scratchpad.log(
                         "Orchestrator",
-                        f"Retrieved consolidated context for pre-planning",
+                        "Retrieved consolidated context for pre-planning",
                         level=LogLevel.DEBUG,
                     )
                 else:

--- a/agent_s3/tools/context_management/context_access_layer.py
+++ b/agent_s3/tools/context_management/context_access_layer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from hashlib import sha1
-from typing import Any, Dict, Optional, Set
+from typing import Any, Dict, Set
 
 from .context_manager import ContextManager
 from .context_monitoring import get_context_monitor

--- a/tests/test_command_processor.py
+++ b/tests/test_command_processor.py
@@ -132,6 +132,20 @@ class TestCommandProcessor:
         assert success
         assert "Workspace initialized successfully" in result
 
+    def test_execute_init_command_failure(self, command_processor, mock_coordinator):
+        """Test execute_init_command when initialization fails."""
+        # Setup
+        mock_coordinator.workspace_initializer.initialize_workspace.return_value = False
+        mock_coordinator.workspace_initializer.validation_failure_reason = "bad config"
+
+        # Exercise
+        result, success = command_processor.execute_init_command("")
+
+        # Verify
+        mock_coordinator.workspace_initializer.initialize_workspace.assert_called_once()
+        assert not success
+        assert "Workspace initialization failed: bad config" in result
+
     @patch('pathlib.Path.open')
     @patch('pathlib.Path.exists')
     def test_execute_plan_command(self, mock_exists, mock_open, command_processor, mock_coordinator):


### PR DESCRIPTION
## Summary
- clarify workspace initialization failure message
- adjust orchestrator log string and remove unused import
- test init command failure path

## Testing
- `ruff check agent_s3/`
- `mypy agent_s3/`
- `pytest -q` *(fails: ImportError while importing test modules)*

------
https://chatgpt.com/codex/tasks/task_e_6842395e69a8832db6eb7b85a4173cc1