### PR TITLE
Sanitize config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "task_state_directory": "./task_snapshots",
   "sandbox_environment": false,
   "host_os_type": "linux",
-  "OPENROUTER_API_KEY": "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",
+  "OPENROUTER_API_KEY": "your-openrouter-api-key-here",
   "context_management": {
     "optimization_interval": 60,
     "compression_threshold": 1000,


### PR DESCRIPTION
## Summary
- replace the OpenRouter API key in `config.json` with a placeholder
- verify `config.json` is listed in `.gitignore`

## Testing
- `npm test` *(fails: Class extends value undefined is not a constructor)*
- `pytest -q` *(fails: ImportError/ModuleNotFoundError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_6842664f9bd4832db522169d443af01f