### PR TITLE
Implement context pruning clarifications and structured LLM context

### DIFF
--- a/agent_s3/planner_json_enforced.py
+++ b/agent_s3/planner_json_enforced.py
@@ -266,9 +266,6 @@ def generate_implementation_plan(
 # Tests
 {json.dumps(tests, indent=2)}
 
-# Additional Context
-{json.dumps(context or {}, indent=2)}
-
 Your task is to create a detailed implementation plan that:
 1. Addresses ALL elements in the system design, maintaining correct element_id references
 2. Explicitly addresses all logical gaps, security concerns, and optimization suggestions from the architecture review
@@ -325,7 +322,9 @@ Focus on creating a comprehensive and detailed plan that a developer can follow 
                     role="planner",
                     system_prompt=system_prompt,
                     user_prompt=user_prompt,
-                    config=params
+                    config=params,
+                    tech_stack=context.get("tech_stack") if context else None,
+                    code_context=context.get("code_context") if context else None,
                 )
 
                 if not response_text:

--- a/agent_s3/pre_planner_json_enforced.py
+++ b/agent_s3/pre_planner_json_enforced.py
@@ -559,12 +559,6 @@ def pre_planning_workflow(
 
     system_prompt = get_json_system_prompt()
     user_prompt = get_json_user_prompt(task_description)
-    if context:
-        try:
-            context_str = json.dumps(context, indent=2)
-        except TypeError:
-            context_str = str(context)
-        user_prompt += "\n\nContext:\n" + context_str
     openrouter_params = get_openrouter_params()
 
     current_prompt = user_prompt
@@ -581,6 +575,8 @@ def pre_planning_workflow(
             system_prompt=system_prompt,
             user_prompt=current_prompt,
             config=openrouter_params,
+            tech_stack=context.get("tech_stack") if context else None,
+            code_context=context.get("code_context") if context else None,
         )
         status, data = process_response(response, task_description)
         if status is True:

--- a/agent_s3/test_generator.py
+++ b/agent_s3/test_generator.py
@@ -282,8 +282,7 @@ def generate_test_implementations(
 # Architecture Review
 {json.dumps(architecture_review, indent=2)}
 
-# Additional Context
-{json.dumps(context or {}, indent=2)}
+# Additional instructions may be provided via the context dictionary.
 
 Your task is to implement complete, runnable test code for each test specification with special attention to:
 
@@ -316,7 +315,9 @@ Each test must include complete runnable code - not stubs or pseudocode.
             role="test_engineer",
             system_prompt=system_prompt,
             user_prompt=user_prompt,
-            config=llm_params
+            config=llm_params,
+            tech_stack=context.get("tech_stack") if context else None,
+            code_context=context.get("code_context") if context else None,
         )
 
         # Parse and validate the response


### PR DESCRIPTION
## Summary
- deduplicate file entries in `ContextManager.update_nested_dict`
- document pruning strategy and context pruning behaviour
- pass structured context to LLM calls instead of serializing JSON
- tweak test generator prompt wording

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'ConfigModel')*

------
https://chatgpt.com/codex/tasks/task_e_684267962838832d98879c1d28778cc7