### PR TITLE
Fix planning imports and update tests

### DIFF
--- a/agent_s3/coordinator/__init__.py
+++ b/agent_s3/coordinator/__init__.py
@@ -711,8 +711,8 @@ class Coordinator:
 
                     # Handle user modification
                     try:
-                        # Import the regeneration function from planner_json_enforced
-                        from agent_s3.planner_json_enforced import regenerate_consolidated_plan_with_modifications
+                        # Import the regeneration function from planning module
+                        from agent_s3.planning.plan_generation import regenerate_consolidated_plan_with_modifications
 
                         # Regenerate the plan with modifications
                         modified_plan = regenerate_consolidated_plan_with_modifications(

--- a/agent_s3/feature_group_processor.py
+++ b/agent_s3/feature_group_processor.py
@@ -423,7 +423,9 @@ class FeatureGroupProcessor:
         })
 
         try:
-            from .planner_json_enforced import validate_planning_semantic_coherence
+            from .planning.semantic_validation import (
+                validate_planning_semantic_coherence,
+            )
 
             validation_results = validate_planning_semantic_coherence(
                 self.coordinator.router_agent,
@@ -707,7 +709,7 @@ class FeatureGroupProcessor:
     ) -> Tuple[Dict[str, Any], str]:
         """Generate architecture review for a feature group."""
         try:
-            from .planner_json_enforced import generate_architecture_review
+            from .planning.plan_generation import generate_architecture_review
 
             review_data = generate_architecture_review(
                 self.coordinator.router_agent,
@@ -743,10 +745,8 @@ class FeatureGroupProcessor:
         str,
     ]:
         """Generate refined tests and implementations."""
-        from .planner_json_enforced import (
-            generate_refined_test_specifications,
-            generate_test_implementations,
-        )
+        from .planning.plan_generation import generate_refined_test_specifications
+        from .test_generator import generate_test_implementations
 
         try:
             refined_data = generate_refined_test_specifications(
@@ -879,7 +879,7 @@ class FeatureGroupProcessor:
 
         try:
             # Import planner helper for modification regeneration
-            from .planner_json_enforced import (
+            from .planning.plan_generation import (
                 regenerate_consolidated_plan_with_modifications,
             )
 

--- a/agent_s3/planning/__init__.py
+++ b/agent_s3/planning/__init__.py
@@ -13,6 +13,7 @@ from .llm_integration import (
     JSONPlannerError,
 )
 from .plan_generation import (
+    generate_architecture_review,
     generate_refined_test_specifications,
     regenerate_consolidated_plan_with_modifications,
     validate_pre_planning_for_planner,
@@ -33,6 +34,7 @@ __all__ = [
     'parse_and_validate_json',
     'get_openrouter_params',
     'JSONPlannerError',
+    'generate_architecture_review',
     'generate_refined_test_specifications',
     'regenerate_consolidated_plan_with_modifications',
     'validate_pre_planning_for_planner',


### PR DESCRIPTION
## Summary
- implement missing architecture review generation helpers
- adjust feature group processor to use planning modules
- adjust Coordinator to import regenerate helper from planning
- export new function from planning package
- update integration test patches to reference correct modules and simplify setup

## Testing
- `pytest tests/integration/test_run_task_consolidated_plan.py::test_run_task_with_mocked_llm -q` *(fails: AttributeError: No consolidated plan was presented)*
- `pytest -q` *(fails to collect tests due to import errors)*

------
https://chatgpt.com/codex/tasks/task_e_684276d87a58832dbace9e7a5f23625e