### PR TITLE
Refactor test spec prompt usage

### DIFF
--- a/agent_s3/planning/plan_generation.py
+++ b/agent_s3/planning/plan_generation.py
@@ -56,9 +56,7 @@ def generate_refined_test_specifications(
     )
 
     # Get system prompt for test specification refinement
-    from ..planner_json_enforced import get_test_specification_refinement_system_prompt
-
-    system_prompt = get_test_specification_refinement_system_prompt()
+    system_prompt = get_stage_system_prompt("refined_tests")
 
     # Get LLM configuration with reasonable defaults
     config = _get_test_specification_config()


### PR DESCRIPTION
## Summary
- remove obsolete prompt import in plan generation
- use `get_stage_system_prompt("refined_tests")` for refined test generation

## Testing
- `pytest -q`
- `ruff check .`
- `mypy`

------
https://chatgpt.com/codex/tasks/task_e_68429e825fac832db7c94aa3958da734