### PR TITLE
Add task_description to consolidated plans

### DIFF
--- a/agent_s3/feature_group_processor.py
+++ b/agent_s3/feature_group_processor.py
@@ -686,6 +686,7 @@ class FeatureGroupProcessor:
             "implementation_plan": implementation_plan,
             "tests": tests,
             "discussion": plan_discussion,
+            "task_description": task_description,
             "dependencies": feature_group.get("dependencies", {}),
             "risk_assessment": feature_group.get("risk_assessment", {}),
             # The semantic_validation field will be added later if available
@@ -892,6 +893,8 @@ class FeatureGroupProcessor:
             updated_plan = regenerate_consolidated_plan_with_modifications(
                 self.coordinator.router_agent,
                 plan,
+                plan.get("architecture_review", {}),
+                plan.get("task_description", ""),
                 modifications,
             )
 

--- a/tests/integration/test_run_task_consolidated_plan.py
+++ b/tests/integration/test_run_task_consolidated_plan.py
@@ -50,6 +50,7 @@ SCHEMA = {
     "implementation_plan": dict,
     "tests": dict,
     "discussion": str,
+    "task_description": str,
     "dependencies": dict,
     "risk_assessment": dict,
     "success": bool,

--- a/tests/test_consolidated_workflow.py
+++ b/tests/test_consolidated_workflow.py
@@ -257,6 +257,10 @@ class TestConsolidatedWorkflow(unittest.TestCase):
             plan_data = json.load(f)
             self.assertEqual(plan_data["user_decision"], "modified")
             self.assertEqual(plan_data["modification_text"], "Add two-factor authentication")
+            self.assertEqual(
+                plan_data["consolidated_plan"].get("task_description"),
+                "Implement authentication",
+            )
 
             # Verify modification was added to architecture review
             considerations = plan_data["consolidated_plan"]["architecture_review"]["additional_considerations"]


### PR DESCRIPTION
## Summary
- include `task_description` in consolidated plans
- pass architecture review, task description and modifications to plan regen
- validate new field in schema tests
- verify written plan includes original task description

## Testing
- `pytest -q` *(fails: PytestCollectionWarning and 6 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68429eedeab0832d936280e532baa32c