### PR TITLE
Fix orchestrator feature group key mismatch

### DIFF
--- a/agent_s3/coordinator/orchestrator.py
+++ b/agent_s3/coordinator/orchestrator.py
@@ -497,8 +497,17 @@ class WorkflowOrchestrator:
             return []
 
         plans: List[Dict[str, Any]] = []
-        for data in fg_result.get("feature_group_results", {}).values():
-            consolidated_plan = data.get("consolidated_plan")
+        group_results = fg_result.get("feature_group_results")
+        if group_results is None:
+            processed = fg_result.get("processed_groups", [])
+            group_results = {
+                grp.get("group_name", f"group_{i}"): {"consolidated_plan": grp}
+                for i, grp in enumerate(processed)
+                if isinstance(grp, dict)
+            }
+
+        for data in group_results.values():
+            consolidated_plan = data.get("consolidated_plan") if isinstance(data, dict) else None
             if not consolidated_plan:
                 continue
             decision, modification = (


### PR DESCRIPTION
## Summary
- handle legacy `processed_groups` results in the planning workflow

## Testing
- `pytest tests/test_consolidated_workflow.py tests/test_planning_modification.py` *(fails: call_llm_by_role MagicMock errors)*

------
https://chatgpt.com/codex/tasks/task_e_6842a2db5ad0832dbb7c72c0c12f89c3