### PR TITLE
Add feature_group_results from planning

### DIFF
--- a/agent_s3/feature_group_processor.py
+++ b/agent_s3/feature_group_processor.py
@@ -494,19 +494,26 @@ class FeatureGroupProcessor:
             )
 
             processed_groups = []
+            feature_group_results: Dict[str, Dict[str, Any]] = {}
             all_groups_valid = True
 
-            for feature_group in feature_groups:
-                group_result = self._process_single_feature_group(feature_group, task_description)
+            for idx, feature_group in enumerate(feature_groups):
+                group_result = self._process_single_feature_group(
+                    feature_group, task_description
+                )
                 processed_groups.append(group_result)
-                
+
+                group_name = feature_group.get("group_name", f"group_{idx}")
+                feature_group_results[group_name] = {"consolidated_plan": group_result}
+
                 # Check if this group failed
                 if not group_result.get("success", True):
                     all_groups_valid = False
 
             return {
                 "success": all_groups_valid,
-                "processed_groups": processed_groups
+                "processed_groups": processed_groups,
+                "feature_group_results": feature_group_results,
             }
 
         except Exception as e:

--- a/agent_s3/planning_helper.py
+++ b/agent_s3/planning_helper.py
@@ -67,8 +67,18 @@ def generate_plan_via_workflow(
             "plan": None,
         }
 
-    groups = fg_result.get("processed_groups", [])
-    if not groups:
+    group_results = fg_result.get("feature_group_results")
+    if group_results is None:
+        processed = fg_result.get("processed_groups", [])
+        if processed:
+            group_results = {
+                grp.get("group_name", f"group_{i}"): {"consolidated_plan": grp}
+                for i, grp in enumerate(processed)
+                if isinstance(grp, dict)
+            }
+
+    if not group_results:
         return {"success": False, "error": "No processed plans returned", "plan": None}
 
-    return {"success": True, "plan": groups[0]}
+    first_plan = next(iter(group_results.values()), {}).get("consolidated_plan")
+    return {"success": True, "plan": first_plan}


### PR DESCRIPTION
## Summary
- return `feature_group_results` from `FeatureGroupProcessor.process_pre_planning_output`
- adapt `planning_helper.generate_plan_via_workflow` to use the new key

## Testing
- `pytest -q` *(fails: ImportError due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6842ab246468832daf3396de0f2fc65d