### PR TITLE
Fix file read handling in context gather

### DIFF
--- a/agent_s3/feature_group_processor.py
+++ b/agent_s3/feature_group_processor.py
@@ -629,8 +629,8 @@ class FeatureGroupProcessor:
             if hasattr(self.coordinator, "file_tool") and affected_files:
                 for file_path in affected_files:
                     try:
-                        content = self.coordinator.file_tool.read(file_path)
-                        if content:
+                        success, content = self.coordinator.file_tool.read_file(file_path)
+                        if success and content:
                             file_contents[file_path] = content
                     except Exception:
                         # Silently continue if file doesn't exist - it might be a new file

--- a/tests/test_code_generator_agentic.py
+++ b/tests/test_code_generator_agentic.py
@@ -59,7 +59,10 @@ class TestCodeGeneratorAgentic:
         ]
 
         # Mock file reading
-        mock_coordinator.file_tool.read_file.return_value = "import datetime\nimport agent_s3.utils\n\ndef existing_func():\n    pass"
+        mock_coordinator.file_tool.read_file.return_value = (
+            True,
+            "import datetime\nimport agent_s3.utils\n\ndef existing_func():\n    pass",
+        )
 
         # Mock os.path.exists and os.listdir
         with patch('pathlib.Path.exists', return_value=True), \

--- a/tests/test_code_generator_complexity.py
+++ b/tests/test_code_generator_complexity.py
@@ -134,7 +134,7 @@ class TestCodeGeneratorComplexity:
             return True
         """
 
-        mock_coordinator.file_tool.read_file.return_value = existing_content
+        mock_coordinator.file_tool.read_file.return_value = (True, existing_content)
 
         with patch('pathlib.Path.exists', return_value=True):
             complexity = code_generator._estimate_file_complexity(implementation_details, file_path="module.py")

--- a/tests/test_coordinator_debugging.py
+++ b/tests/test_coordinator_debugging.py
@@ -35,7 +35,7 @@ def mock_config():
 def mock_file_tool():
     """Create a mock file tool."""
     file_tool = MagicMock()
-    file_tool.read_file.return_value = "Mock file content"
+    file_tool.read_file.return_value = (True, "Mock file content")
     file_tool.write_file.return_value = True
     return file_tool
 

--- a/tests/test_feature_group_processor_context.py
+++ b/tests/test_feature_group_processor_context.py
@@ -1,0 +1,31 @@
+import pytest
+from unittest.mock import MagicMock
+from pathlib import Path
+
+from agent_s3.feature_group_processor import FeatureGroupProcessor
+
+
+def test_gather_context_reads_files_based_on_success(tmp_path):
+    file_ok = tmp_path / "ok.txt"
+    file_ok.write_text("data")
+
+    feature_group = {
+        "group_name": "g1",
+        "features": [
+            {"description": "a", "files_affected": [str(file_ok)]},
+            {"description": "b", "files_affected": ["missing.txt"]},
+        ],
+    }
+
+    coordinator = MagicMock()
+    coordinator.scratchpad = MagicMock()
+    coordinator.context_registry = True
+    coordinator.get_current_context_snapshot.return_value = {}
+    coordinator.file_tool = MagicMock()
+    coordinator.file_tool.read_file.side_effect = [(True, "data"), (False, "error")]
+
+    processor = FeatureGroupProcessor(coordinator)
+    ctx = processor._gather_context_for_feature_group(feature_group)
+
+    assert ctx["file_contents"] == {str(file_ok): "data"}
+

--- a/tests/test_full_debugging.py
+++ b/tests/test_full_debugging.py
@@ -19,7 +19,7 @@ def test_execute_full_debugging_skips_invalid_new_file(tmp_path, monkeypatch):
     )
 
     file_tool = MagicMock()
-    file_tool.read_file.return_value = "print('hi')\n"
+    file_tool.read_file.return_value = (True, "print('hi')\n")
     file_tool.write_file = MagicMock()
 
     coordinator = MagicMock()


### PR DESCRIPTION
## Summary
- gather context using `read_file` and handle success flag
- adapt tests for tuple return from `read_file`
- add unit test covering file read success logic

## Testing
- `ruff check agent_s3/`
- `mypy agent_s3/`
- `pytest tests/test_feature_group_processor_context.py -q`
- ❌ `pytest -q` *(fails: ERROR tests/test_config_pydantic.py ...)*

------
https://chatgpt.com/codex/tasks/task_e_6842ac458578832dbc13958086bc5a08