### PR TITLE
Enable pre-planning clarification loop

### DIFF
--- a/agent_s3/coordinator/orchestrator.py
+++ b/agent_s3/coordinator/orchestrator.py
@@ -21,7 +21,7 @@ from .registry import CoordinatorRegistry
 from typing import TYPE_CHECKING
 from ..enhanced_scratchpad_manager import LogLevel
 from ..pre_planner_json_enforced import (
-    call_pre_planner_with_enforced_json,
+    pre_planning_workflow,
     regenerate_pre_planning_with_modifications,
 )
 
@@ -430,8 +430,12 @@ class WorkflowOrchestrator:
                 )
                 context = None
 
-            success, pre_plan = call_pre_planner_with_enforced_json(
-                self.coordinator.router_agent, task, context
+            success, pre_plan = pre_planning_workflow(
+                self.coordinator.router_agent,
+                task,
+                context,
+                allow_interactive_clarification=False,
+                clarification_callback=lambda q: self.coordinator.prompt_moderator.ask_for_input(q),
             )
             if not success:
                 self.coordinator.scratchpad.log(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,11 +8,30 @@ from unittest.mock import patch, MagicMock
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir)))
 
 # Provide a dummy Coordinator to avoid heavy imports during testing
+_ORIG_COORDINATOR = sys.modules.get('agent_s3.coordinator')
+_ORIG_ROUTER_AGENT = sys.modules.get('agent_s3.router_agent')
+_ORIG_CONFIG = sys.modules.get('agent_s3.config')
+
 sys.modules['agent_s3.coordinator'] = types.SimpleNamespace(Coordinator=object)
 sys.modules['agent_s3.router_agent'] = types.SimpleNamespace(RouterAgent=object)
 sys.modules['agent_s3.config'] = types.SimpleNamespace(Config=object)
 
 from agent_s3.cli import process_command  # noqa: E402
+
+if _ORIG_COORDINATOR is not None:
+    sys.modules['agent_s3.coordinator'] = _ORIG_COORDINATOR
+else:
+    sys.modules.pop('agent_s3.coordinator', None)
+
+if _ORIG_ROUTER_AGENT is not None:
+    sys.modules['agent_s3.router_agent'] = _ORIG_ROUTER_AGENT
+else:
+    sys.modules.pop('agent_s3.router_agent', None)
+
+if _ORIG_CONFIG is not None:
+    sys.modules['agent_s3.config'] = _ORIG_CONFIG
+else:
+    sys.modules.pop('agent_s3.config', None)
 
 
 class TestCliProcessCommand(unittest.TestCase):
@@ -59,6 +78,7 @@ class TestCliProcessCommand(unittest.TestCase):
         command_processor.execute_continue_command.side_effect = stub_continue
 
         self.mock_coordinator.command_processor = command_processor
+
 
     @patch('builtins.print')
     def test_plan_command(self, mock_print):

--- a/tests/test_feature_group_processor_context.py
+++ b/tests/test_feature_group_processor_context.py
@@ -1,6 +1,4 @@
-import pytest
 from unittest.mock import MagicMock
-from pathlib import Path
 
 from agent_s3.feature_group_processor import FeatureGroupProcessor
 

--- a/tests/test_planning_modification.py
+++ b/tests/test_planning_modification.py
@@ -31,8 +31,8 @@ def test_planning_workflow_regenerates_preplan(monkeypatch):
     new_plan = {"original_request": "task", "feature_groups": [{"group_name": "fg"}]}
 
     monkeypatch.setattr(
-        "agent_s3.coordinator.orchestrator.call_pre_planner_with_enforced_json",
-        lambda router, task, context: (True, pre_plan),
+        "agent_s3.coordinator.orchestrator.pre_planning_workflow",
+        lambda router, task, context=None, max_preplanning_attempts=2, allow_interactive_clarification=False, clarification_callback=None: (True, pre_plan),
     )
 
     regen_called = {}


### PR DESCRIPTION
## Summary
- call `pre_planning_workflow` from orchestrator so clarification questions are handled
- restore real modules in `test_cli` after importing `process_command`
- fix unused imports in `test_feature_group_processor_context`
- update planning modification test for new preplanning call

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q` *(fails: integration tests in context management)*

------
https://chatgpt.com/codex/tasks/task_e_6842d692b824832da9e0213da5178b59