### PR TITLE
Fix issue title generation

### DIFF
--- a/agent_s3/coordinator/orchestrator.py
+++ b/agent_s3/coordinator/orchestrator.py
@@ -918,9 +918,9 @@ class WorkflowOrchestrator:
 
     def _generate_issue_title(self, task_description: str, plan: Dict[str, Any]) -> str:
         """Generate descriptive issue title."""
-        feature_group = plan.get("feature_group", {}).get("name", "")
-        if feature_group:
-            return f"Implement {feature_group}: {task_description[:80]}"
+        group_name = plan.get("group_name", "")
+        if group_name:
+            return f"Implement {group_name}: {task_description[:80]}"
         else:
             return f"Agent-S3 Task: {task_description[:80]}"
 


### PR DESCRIPTION
## Summary
- use `group_name` when generating issue titles

## Testing
- `ruff check agent_s3/coordinator/orchestrator.py`
- `mypy agent_s3/coordinator/orchestrator.py`
- `pytest -q` *(fails: AttributeError and configuration errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843077be7ac832db214cd2383d967c0