### PR TITLE
Remove deprecated VS Code polling settings

### DIFF
--- a/vscode/README.md
+++ b/vscode/README.md
@@ -44,9 +44,6 @@ AGENT_S3_ENCRYPTION_KEY="$(python -c 'from cryptography.fernet import Fernet; pr
 The extension uses HTTP for communication with the backend server.
 Set `AGENT_S3_HTTP_TIMEOUT` (or the `agent-s3.httpTimeoutMs` setting) to adjust
 how long the extension waits for a response before falling back to CLI mode.
-`agent-s3.statusPollIntervalMs` controls how frequently the extension polls the
-backend for command results. `agent-s3.statusPollAttempts` limits the number of
-polling attempts before giving up.
 
 When the backend starts it writes a `.agent_s3_http_connection.json` file in the
 workspace root describing the HTTP server address. The extension reads this file

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -131,16 +131,6 @@
           "type": "number",
           "default": 10000,
           "description": "HTTP request timeout in milliseconds (increased for remote connections)"
-        },
-        "agent-s3.statusPollIntervalMs": {
-          "type": "number",
-          "default": 1000,
-          "description": "Interval in milliseconds between status polling requests when waiting for a command result."
-        },
-        "agent-s3.statusPollAttempts": {
-          "type": "number",
-          "default": 30,
-          "description": "Maximum number of status polling attempts before giving up on a command result."
         }
       }
     }


### PR DESCRIPTION
## Summary
- remove `statusPollIntervalMs` and `statusPollAttempts` settings
- update README to drop references to removed settings

## Testing
- `pytest tests/unit -q` *(fails: ImportError: attempted relative import with no known parent package)*
- `mypy agent_s3`
- `ruff check agent_s3`


------
https://chatgpt.com/codex/tasks/task_e_6843f63159dc832da056452900d0f303