### PR TITLE
Add HTTP auth token check

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ pytest tests/tools/parsing/ --maxfail=3 --disable-warnings -q
   - `pre_planning_mode` selects `off`, `json`, or `enforced_json` workflow. See `docs/pre_planning_workflow.md` for details.
   - HTTP server settings for request/response handling
   - `AGENT_S3_HTTP_TIMEOUT` (optional, defaults to `5000`) timeout in milliseconds before the VS Code extension falls back to CLI mode (see `docs/manual_http_timeout_test.md` for a verification procedure)
+  - `AGENT_S3_AUTH_TOKEN` (optional) require `Authorization: Bearer <token>` on HTTP requests; may also be set in `config.json` under `http.auth_token`
   - `TEST_WS_TOKEN` (optional, defaults to `"replace-me"`)
     authentication token for `simple-test-server.js`
   - `MAX_DESIGN_PATTERNS` (optional, defaults to `3`)

--- a/agent_s3/coordinator/__init__.py
+++ b/agent_s3/coordinator/__init__.py
@@ -307,12 +307,14 @@ class Coordinator:
         http_host = http_config.get('host', 'localhost')
         http_port = http_config.get('port', 8081)  # Default to 8081 for HTTP
         allowed_origins = http_config.get('allowed_origins', ['*'])
+        auth_token = http_config.get('auth_token') or os.getenv('AGENT_S3_AUTH_TOKEN')
 
         self.http_server = EnhancedHTTPServer(
             host=http_host,
             port=http_port,
             coordinator=self,
             allowed_origins=allowed_origins,
+            auth_token=auth_token,
         )
         # Start the server in a separate thread so it doesn't block the coordinator
         self.http_thread = self.http_server.start_in_thread()

--- a/config.json
+++ b/config.json
@@ -13,6 +13,7 @@
   "http": {
     "host": "localhost",
     "port": 8081,
-    "allowed_origins": ["*"]
+    "allowed_origins": ["*"],
+    "auth_token": ""
   }
 }

--- a/config.json.template
+++ b/config.json.template
@@ -13,6 +13,7 @@
   "http": {
     "host": "localhost",
     "port": 8081,
-    "allowed_origins": ["*"]
+    "allowed_origins": ["*"],
+    "auth_token": ""
   }
 }

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -54,6 +54,10 @@ to determine the host and port. If the file is missing or invalid it defaults to
 `localhost:8081`. Automatic fallback to CLI commands occurs when the server is
 unavailable.
 
+If the server is configured with an authentication token, set the
+`agent-s3.authToken` setting or the `AGENT_S3_AUTH_TOKEN` environment variable so
+the extension can include `Authorization: Bearer <token>` with each request.
+
 ## Usage
 
 1. Run "Agent-S3: Initialize workspace" from the command palette (Ctrl+Shift+P) to set up your workspace and authenticate with GitHub


### PR DESCRIPTION
## Summary
- enforce optional Bearer token auth on HTTP server
- read token from env or `config.json`'s `http.auth_token`
- document new token setting in README and VS Code docs

## Testing
- `npm test` *(fails: Haste module naming collision)*
- `pytest -q` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6843f660692c832d879e47837e5a768b