### PR TITLE
Remove statusPoll docs

### DIFF
--- a/vscode/README.md
+++ b/vscode/README.md
@@ -42,11 +42,11 @@ AGENT_S3_ENCRYPTION_KEY="$(python -c 'from cryptography.fernet import Fernet; pr
 ### Configuration
 
 The extension uses HTTP for communication with the backend server.
-Set `AGENT_S3_HTTP_TIMEOUT` (or the `agent-s3.httpTimeoutMs` setting) to adjust
-how long the extension waits for a response before falling back to CLI mode.
-`agent-s3.statusPollIntervalMs` controls how frequently the extension polls the
-backend for command results. `agent-s3.statusPollAttempts` limits the number of
-polling attempts before giving up.
+Set `AGENT_S3_HTTP_TIMEOUT` (or the `agent-s3.httpTimeoutMs` setting) to control
+how long the extension waits for a response. If the timeout is exceeded or the
+server becomes unavailable, the extension automatically falls back to CLI
+commands. Progress updates continue to be written to `progress_log.jsonl` so you
+can monitor the job.
 
 When the backend starts it writes a `.agent_s3_http_connection.json` file in the
 workspace root describing the HTTP server address. The extension reads this file


### PR DESCRIPTION
## Summary
- update VS Code extension docs to focus on CLI fallback and progress logs
- remove status polling references

## Testing
- `npm run lint` *(fails: Rules with suggestions must set the meta.hasSuggestions property)*
- `npm run typecheck`
- `npm test` *(fails to run tests)*
- `pytest` *(fails: several tests and errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843f6853a50832dae9ab36679526fb8