### PR TITLE
Fix design auto failure handling

### DIFF
--- a/agent_s3/coordinator/__init__.py
+++ b/agent_s3/coordinator/__init__.py
@@ -874,7 +874,11 @@ class Coordinator:
             if not success:
                 return {"success": False, "error": message}
 
-            self.start_pre_planning_from_design("design.txt", implement=False)
+            planning_result = self.start_pre_planning_from_design(
+                "design.txt", implement=False
+            )
+            if not planning_result.get("success", False):
+                return planning_result
 
             return {
                 "success": True,

--- a/tests/test_command_processor.py
+++ b/tests/test_command_processor.py
@@ -291,3 +291,15 @@ class TestCommandProcessor:
         assert success
         assert "Design process completed successfully" in result
 
+    def test_execute_design_auto_command_failure(self, command_processor, mock_coordinator):
+        mock_coordinator.execute_design_auto.return_value = {
+            "success": False,
+            "error": "plan failed",
+        }
+
+        result, success = command_processor.execute_design_auto_command("build api")
+
+        mock_coordinator.execute_design_auto.assert_called_once_with("build api")
+        assert not success
+        assert "Design process failed: plan failed" in result
+


### PR DESCRIPTION
## Summary
- return planning failure result in `execute_design_auto`
- test for `/design-auto` error path

## Testing
- `pytest tests/test_command_processor.py::TestCommandProcessor::test_execute_design_auto_command_failure -q`

------
https://chatgpt.com/codex/tasks/task_e_6843f820d468832db6e54aa961e74cdb