### PR TITLE
Fix docs and settings for accurate progress handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,13 +125,7 @@ pip check
 ## Core Features
 
 **Python Backend (`agent_s3`):**
-- Real-time communication between backend and VS Code extension via HTTP server with:
-  - Automatic reconnection and heartbeat monitoring
-  - Message type-based routing and handlers
-  - Fallback to CLI commands when HTTP server is unavailable
-  - Authentication and secure message passing
-  - 64&nbsp;KiB message size limit enforced server-side
-    (configurable via HTTP server settings)
+- Commands are sent via an HTTP server. The extension falls back to CLI when the server is unreachable.
 - Advanced context management with:
   - Context registry with multiple providers that can be registered and queried
   - Tool/manager registry for coordinator components (`agent_s3.coordinator.registry`)
@@ -247,12 +241,9 @@ See `docs/summarization.md` for details.
 - Command Palette integration: Initialize workspace, Make change request, Show help, Show config, Reload LLM config, Explain last LLM interaction, Open Chat Window
 - Status bar item (`$(sparkle) Agent-S3`) to start change requests
 - Dedicated terminal panel for backend interactions
-- Real-time status updates via HTTP API; `progress_log.jsonl` stores progress logs
-- The extension polls the `/status` endpoint until a command result is available
-- Server shuts down automatically on exit, removing the connection file
-- Connection file uses `0600` permissions on POSIX systems; default permissions
-  apply on Windows
-- Connection information is stored in `.agent_s3_ws_connection.json` at the root
+- Commands are sent over HTTP using the `/command` endpoint. The extension falls back to CLI when the server is unreachable.
+- Progress details are logged in `progress_log.jsonl` for troubleshooting.
+- Connection information is stored in `.agent_s3_http_connection.json` at the root
   of your workspace
 - Optional Copilot-style chat UI for input; terminal shows actual outputs
 - WebView panels for structured information display:
@@ -264,9 +255,9 @@ See `docs/summarization.md` for details.
 
 Agent-S3 features a real-time UI for chat and progress updates, powered by an HTTP-based architecture. See [docs/streaming_ui_implementation.md](docs/streaming_ui_implementation.md) for implementation details:
 
-- **HTTP Client/Server:** The backend and VS Code extension communicate via HTTP REST API, supporting command processing and status updates.
-- **Streaming Chat UI:** The `ChatView` React component in the extension displays real-time agent responses, partial message rendering, and thinking indicators.
-- **Backend Integration:** The extension currently polls `/status` for command results and reads `progress_log.jsonl` for progress details. Streaming updates will be added after Issue #2.
+- **HTTP Client/Server:** Commands are issued over HTTP via the `/command` endpoint. The extension falls back to CLI when requests fail.
+- **ChatView:** Displays command results returned by the HTTP API. Streaming hooks exist but are not yet active.
+- **Backend Integration:** Progress is logged to `progress_log.jsonl` for reference. Streaming updates will be added after Issue #2.
 - **Robust Error Handling:** Includes reconnection logic, buffering, and error logging for reliable user experience.
 - **Extensible Protocol:** The message protocol supports future UI features like syntax highlighting, progress bars, and operation cancellation.
 

--- a/docs/manual_http_timeout_test.md
+++ b/docs/manual_http_timeout_test.md
@@ -12,5 +12,5 @@ This guide verifies that long-running HTTP commands are processed asynchronously
    - Open the command palette and run **Agent-S3: Make change request**.
    - Provide a complex request that will take additional processing time.
 4. Observe that the `/command` endpoint immediately returns a JSON object containing a `job_id`.
-5. The VS Code extension polls `GET /status/<job_id>` until the backend finishes processing.
-6. Once the job completes, the terminal output updates with the final result and no secondary CLI process is spawned.
+5. The extension waits for the HTTP response while showing progress in the terminal.
+6. When the server returns the result, it appears in the terminal output with no polling required.

--- a/docs/streaming_ui_implementation.md
+++ b/docs/streaming_ui_implementation.md
@@ -35,8 +35,8 @@ This document describes the implementation of HTTP-based communication for Agent
 2. **VS Code Extension**
    - Integrated HTTP client with VS Code extension API
    - Command processing through HTTP endpoints
-   - Progress tracking via the `/status` endpoint and `progress_log.jsonl`
-     (polled until streaming support lands in Issue #2)
+   - Progress details are written to `progress_log.jsonl` for troubleshooting.
+     The extension does not poll a `/status` endpoint.
 
 ## Communication Flow
 
@@ -52,7 +52,7 @@ VS Code Extension -> HTTP GET /health -> {"status": "ok"} -> Connection Status
 
 ### Progress Updates
 ```
-Backend -> `progress_log.jsonl` -> VS Code Extension polls `/status` -> UI Updates
+Backend -> `progress_log.jsonl` -> VS Code reads terminal output -> UI Updates
 ```
 
 ## API Endpoints
@@ -94,7 +94,7 @@ Processes Agent-S3 commands.
 }
 ```
 ### GET /status
-Returns the result of the last command. The extension polls this endpoint until a result is available. The server clears the stored result after it is retrieved.
+Returns the result of an asynchronous command. This endpoint is reserved for future streaming updates and is not currently used by the VS Code extension.
 
 **Response:**
 ```json

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -44,9 +44,8 @@ AGENT_S3_ENCRYPTION_KEY="$(python -c 'from cryptography.fernet import Fernet; pr
 The extension uses HTTP for communication with the backend server.
 Set `AGENT_S3_HTTP_TIMEOUT` (or the `agent-s3.httpTimeoutMs` setting) to adjust
 how long the extension waits for a response before falling back to CLI mode.
-`agent-s3.statusPollIntervalMs` controls how frequently the extension polls the
-backend for command results. `agent-s3.statusPollAttempts` limits the number of
-polling attempts before giving up.
+Progress information is written to `progress_log.jsonl` for troubleshooting; the
+extension does not poll a status endpoint.
 
 When the backend starts it writes a `.agent_s3_http_connection.json` file in the
 workspace root describing the HTTP server address. The extension reads this file

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -131,16 +131,6 @@
           "type": "number",
           "default": 10000,
           "description": "HTTP request timeout in milliseconds (increased for remote connections)"
-        },
-        "agent-s3.statusPollIntervalMs": {
-          "type": "number",
-          "default": 1000,
-          "description": "Interval in milliseconds between status polling requests when waiting for a command result."
-        },
-        "agent-s3.statusPollAttempts": {
-          "type": "number",
-          "default": 30,
-          "description": "Maximum number of status polling attempts before giving up on a command result."
         }
       }
     }


### PR DESCRIPTION
## Summary
- clarify progress logging and drop `/status` polling references
- update manual HTTP timeout test steps
- remove unused polling settings from extension package.json
- document progress log usage in VS Code extension README

## Testing
- `ruff check .`
- `mypy agent_s3` *(failed: Interrupted)*
- `pytest -q` *(errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843eacfa624832db6fa06225864c9f8