### PR TITLE
Remove unused status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ See `docs/summarization.md` for details.
 - Status bar item (`$(sparkle) Agent-S3`) to start change requests
 - Dedicated terminal panel for backend interactions
   - Real-time status updates via HTTP API; progress is written to `progress_log.jsonl`
-  - Command results are returned directly from `POST /command`; no `/status` polling
+  - Command results are returned directly from `POST /command`; no `/status` endpoint
 - Connection information is stored in `.agent_s3_http_connection.json` at the root
   of your workspace
 - Optional Copilot-style chat UI for input; terminal shows actual outputs

--- a/agent_s3/communication/http_server.py
+++ b/agent_s3/communication/http_server.py
@@ -52,14 +52,6 @@ class Agent3HTTPHandler(BaseHTTPRequestHandler):
         elif parsed.path == "/help":
             result = self.execute_command("/help")
             self.send_json(result)
-        elif parsed.path.startswith("/status/"):
-            job_id = parsed.path.split("/", 2)[-1]
-            with self.job_lock:
-                result = self.jobs.pop(job_id, None)
-            if result is not None:
-                self.send_json({"ready": True, **result})
-            else:
-                self.send_json({"ready": False})
         else:
             self.send_error(404)
 
@@ -279,7 +271,7 @@ class EnhancedHTTPServer:
 
             logger.info(f"HTTP server started on http://{self.host}:{self.port}")
             logger.info(
-                "Available endpoints: GET /health, GET /help, POST /command, GET /status/<job_id>"
+                "Available endpoints: GET /health, GET /help, POST /command"
             )
 
             self.server.serve_forever()

--- a/docs/manual_http_timeout_test.md
+++ b/docs/manual_http_timeout_test.md
@@ -13,4 +13,4 @@ This guide verifies that the extension gracefully falls back to the CLI when an 
    - Provide a complex request that will take additional processing time.
 4. Run the request. The extension sends an HTTP `POST /command` request.
 5. Because the timeout is short, the HTTP request fails and the extension automatically falls back to the CLI.
-6. The command output appears in the terminal once the CLI run completes; no polling of `/status` occurs.
+6. The command output appears in the terminal once the CLI run completes; the server does not expose a `/status` endpoint.

--- a/docs/streaming_ui_implementation.md
+++ b/docs/streaming_ui_implementation.md
@@ -35,7 +35,7 @@ This document describes the implementation of HTTP-based communication for Agent
 2. **VS Code Extension**
    - Integrated HTTP client with VS Code extension API
    - Command processing through HTTP endpoints
-   - Progress tracking written to `progress_log.jsonl`; no `/status` polling
+  - Progress tracking written to `progress_log.jsonl`; no `/status` endpoint
 
 ## Communication Flow
 
@@ -92,19 +92,6 @@ Processes Agent-S3 commands.
   "result": "Command output here"
 }
 ```
-### GET /status
-Returns the result of the last asynchronous command. This endpoint is retained for compatibility, but the VS Code extension now reads `progress_log.jsonl` instead of polling `/status`.
-
-**Response:**
-```json
-{
-  "result": "Command output here",
-  "output": "",
-  "success": true
-}
-```
-
-
 ## File Structure
 
 ### Backend Files

--- a/vscode/REMOTE_BACKEND_SETUP.md
+++ b/vscode/REMOTE_BACKEND_SETUP.md
@@ -261,8 +261,7 @@ The remote backend exposes the following endpoints:
 {
     "success": true,
     "result": "Command output here",
-    "output": "Detailed output",
-    "job_id": "optional-job-id"
+    "output": "Detailed output"
 }
 ```
 

--- a/vscode/src/http/httpClient.ts
+++ b/vscode/src/http/httpClient.ts
@@ -5,7 +5,6 @@ export interface HttpResponse {
     result: string;
     output?: string;
     success: boolean;
-    job_id?: string;
 }
 
 export class HttpClient {
@@ -47,26 +46,6 @@ export class HttpClient {
         }
     }
 
-    public async getStatus(jobId: string): Promise<HttpResponse> {
-        const config = await this.connectionManager.getConnectionConfig();
-        const headers: Record<string, string> = {};
-
-        if (config.auth_token) {
-            headers['Authorization'] = `Bearer ${config.auth_token}`;
-        }
-
-        const response = await fetch(`${config.base_url}/status/${jobId}`, {
-            method: 'GET',
-            headers,
-            signal: AbortSignal.timeout(5000)
-        });
-
-        if (!response.ok) {
-            throw new Error(`HTTP ${response.status}: Health check failed`);
-        }
-
-        return await response.json() as HttpResponse;
-    }
 
     public async testConnection(): Promise<boolean> {
         return await this.connectionManager.testConnection();


### PR DESCRIPTION
## Summary
- drop deprecated `/status/<job_id>` handler
- remove matching VS Code API call
- document that the backend no longer exposes a `/status` endpoint

## Testing
- `ruff check agent_s3/`
- `mypy agent_s3/` *(failed: Interrupted)*
- `npm run lint` *(failed: ESLint error)*
- `npm run typecheck`
- `npm test` *(failed: Test suite failed to run)*
- `pytest -q` *(failed: 3 failed, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684403f7594c832d861a271db968f949