### PR TITLE
Fix connection file permissions in HTTP server

### DIFF
--- a/agent_s3/communication/http_server.py
+++ b/agent_s3/communication/http_server.py
@@ -265,8 +265,17 @@ class EnhancedHTTPServer:
             }
 
             connection_file = ".agent_s3_http_connection.json"
-            with open(connection_file, "w") as f:
-                json.dump(connection_info, f)
+            if os.name == "nt":
+                with open(connection_file, "w") as f:
+                    json.dump(connection_info, f)
+            else:
+                fd = os.open(
+                    connection_file,
+                    os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                    0o600,
+                )
+                with os.fdopen(fd, "w") as f:
+                    json.dump(connection_info, f)
 
             # Set restrictive permissions on non-Windows systems
             if os.name != "nt":


### PR DESCRIPTION
## Summary
- ensure `.agent_s3_http_connection.json` is created with `0600` permissions
- guard chmod call on Windows

## Testing
- `ruff check agent_s3/ --quiet`
- `mypy agent_s3/`
- `pytest -q` *(fails: KeyboardInterrupt, multiple tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68440406292c832dba159b8271caf468