### PR TITLE
Remove outdated poll settings

### DIFF
--- a/vscode/README.md
+++ b/vscode/README.md
@@ -42,11 +42,11 @@ AGENT_S3_ENCRYPTION_KEY="$(python -c 'from cryptography.fernet import Fernet; pr
 ### Configuration
 
 The extension uses HTTP for communication with the backend server.
-Set `AGENT_S3_HTTP_TIMEOUT` (or the `agent-s3.httpTimeoutMs` setting) to adjust
-how long the extension waits for a response before falling back to CLI mode.
-`agent-s3.statusPollIntervalMs` controls how frequently the extension polls the
-backend for command results. `agent-s3.statusPollAttempts` limits the number of
-polling attempts before giving up.
+Set `AGENT_S3_HTTP_TIMEOUT` (or the `agent-s3.httpTimeoutMs` setting) to control
+how long the extension waits for a response. If the timeout is exceeded or the
+server becomes unavailable, the extension automatically falls back to CLI
+commands. Progress updates continue to be written to `progress_log.jsonl` so you
+can monitor the job.
 
 When the backend starts it writes a `.agent_s3_http_connection.json` file in the
 workspace root describing the HTTP server address. The extension reads this file

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -131,16 +131,6 @@
           "type": "number",
           "default": 10000,
           "description": "HTTP request timeout in milliseconds (increased for remote connections)"
-        },
-        "agent-s3.statusPollIntervalMs": {
-          "type": "number",
-          "default": 1000,
-          "description": "Interval in milliseconds between status polling requests when waiting for a command result."
-        },
-        "agent-s3.statusPollAttempts": {
-          "type": "number",
-          "default": 30,
-          "description": "Maximum number of status polling attempts before giving up on a command result."
         }
       }
     }


### PR DESCRIPTION
## Summary
- remove deprecated `statusPollIntervalMs` and `statusPollAttempts` configuration

## Testing
- `npm run lint` *(fails: Rules with suggestions must set the `meta.hasSuggestions` property)*
- `npm run typecheck`
- `npm test` *(fails to run tests)*
- `pytest` *(fails: 1 failed, 12 passed, 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843f6853a50832dae9ab36679526fb8