### PR TITLE
Update remote backend docs

### DIFF
--- a/vscode/REMOTE_BACKEND_SETUP.md
+++ b/vscode/REMOTE_BACKEND_SETUP.md
@@ -243,8 +243,9 @@ This ensures commands continue working even with connectivity issues.
 
 The remote backend exposes the following endpoints:
 
-- `POST /command` - Execute Agent-S3 commands
 - `GET /health` - Server health check
+- `POST /command` - Execute Agent-S3 commands
+- `GET /status/<job_id>` - Optional endpoint to fetch the result of an asynchronous command
 
 ### Request Format
 
@@ -265,6 +266,11 @@ The remote backend exposes the following endpoints:
     "job_id": "optional-job-id"
 }
 ```
+
+If a `job_id` is returned, the server is processing the request asynchronously.
+You may retrieve the final result with `GET /status/<job_id>`. The VS Code
+extension monitors `progress_log.jsonl` locally rather than polling this
+endpoint.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- update Remote Backend Setup API docs for GET /health, POST /command and GET /status/<job_id>

## Testing
- `ruff check agent_s3`
- `mypy agent_s3`
- `pytest -q` *(fails: KeyboardInterrupt and integration test failures)*

------
https://chatgpt.com/codex/tasks/task_e_684403f97ebc832db2cc1e2ba72d1bc1