### PR TITLE
Update docs for progress handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ See `docs/summarization.md` for details.
 - Command Palette integration: Initialize workspace, Make change request, Show help, Show config, Reload LLM config, Explain last LLM interaction, Open Chat Window
 - Status bar item (`$(sparkle) Agent-S3`) to start change requests
 - Dedicated terminal panel for backend interactions
-  - Real-time status updates via HTTP API; progress is written to `progress_log.jsonl`
+  - Real-time status updates via HTTP API; progress is logged to `progress_log.jsonl`
   - Command results are returned directly from `POST /command`; no `/status` endpoint
 - Connection information is stored in `.agent_s3_http_connection.json` at the root
   of your workspace
@@ -257,7 +257,7 @@ Agent-S3 features a real-time UI for chat and progress updates, powered by an HT
 
 - **HTTP Client/Server:** The backend and VS Code extension communicate via HTTP REST API, supporting command processing and status updates.
 - **Streaming Chat UI:** The `ChatView` React component in the extension displays real-time agent responses, partial message rendering, and thinking indicators.
-  - **Backend Integration:** The extension reads `progress_log.jsonl` for progress details and receives command results directly from `POST /command`. Streaming updates will be added after Issue #2.
+  - **Backend Integration:** The extension sends commands to `POST /command` and receives streaming responses. Progress logs are kept in `progress_log.jsonl` for reference.
 - **Robust Error Handling:** Includes reconnection logic, buffering, and error logging for reliable user experience.
 - **Extensible Protocol:** The message protocol supports future UI features like syntax highlighting, progress bars, and operation cancellation.
 

--- a/STORIES.md
+++ b/STORIES.md
@@ -99,7 +99,7 @@ Refer to these resources for a complete understanding of the project.
     *   It shows the terminal (`terminal.show()`).
     *   It sends the developer's request (from input box or chat message) to the CLI, escaping quotes: `python -m agent_s3.cli "<user_request>"` (`terminal.sendText`).
     *   It shows an information notification: `Processing request: <user_request>` (`vscode.window.showInformationMessage`).
-     *   It uses `HttpClient` to send the command and reads `progress_log.jsonl` for progress updates without polling `/status`.
+    *   It uses `HttpClient` to send the command to `POST /command` and streams progress updates directly from the response.
 3.  **Backend CLI Action (`agent_s3/cli.py`):**
     *   The `main` function parses the command-line arguments, receiving the request text.
     *   It loads the configuration (`Config`).
@@ -160,7 +160,7 @@ Refer to these resources for a complete understanding of the project.
             *   Includes database schema metadata in PR descriptions when database changes are involved
         *   Clears the task state and reports completion.
 5.  **VS Code Monitoring (`vscode/extension.ts`):**
-     *   Progress updates are read from `progress_log.jsonl`, eliminating the file watcher and the `/status` polling logic.
+     *   Progress updates stream directly from the backend, so no `/status` polling is required.
     *   Updates the status bar with current phase and status.
     *   When a final state is reached, shows a notification with result summary.
     *   If a PR was created, includes the PR URL in the notification.


### PR DESCRIPTION
## Summary
- clarify that progress logs are written to `progress_log.jsonl`
- document streaming responses in the VS Code extension

## Testing
- `pytest tests/test_config_pydantic.py::test_load_defaults -q`
- `pytest -q` *(fails: AttributeError in integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68441c380f20832daf02b9e08c258aa5