### PR TITLE
Update docs for immediate POST /command behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ See `docs/summarization.md` for details.
 - Status bar item (`$(sparkle) Agent-S3`) to start change requests
 - Dedicated terminal panel for backend interactions
   - Real-time status updates via HTTP API; progress is logged to `progress_log.jsonl`
-  - Command results are returned directly from `POST /command`; no `/status` endpoint
+  - `POST /command` returns results immediately. The `"async"` option is deprecated, and no `/status` endpoint exists.
 - Connection information is stored in `.agent_s3_http_connection.json` at the root
   of your workspace
 - Optional Copilot-style chat UI for input; terminal shows actual outputs
@@ -257,7 +257,7 @@ Agent-S3 features a real-time UI for chat and progress updates, powered by an HT
 
 - **HTTP Client/Server:** The backend and VS Code extension communicate via HTTP REST API, supporting command processing and status updates.
 - **Streaming Chat UI:** The `ChatView` React component in the extension displays real-time agent responses, partial message rendering, and thinking indicators.
-  - **Backend Integration:** The extension sends commands to `POST /command` and receives streaming responses. Progress logs are kept in `progress_log.jsonl` for reference.
+  - **Backend Integration:** The extension sends commands to `POST /command` and receives streaming responses. Results are returned immediately—the `"async"` option is deprecated. Progress logs are kept in `progress_log.jsonl` for reference.
 - **Robust Error Handling:** Includes reconnection logic, buffering, and error logging for reliable user experience.
 - **Extensible Protocol:** The message protocol supports future UI features like syntax highlighting, progress bars, and operation cancellation.
 

--- a/docs/streaming_ui_implementation.md
+++ b/docs/streaming_ui_implementation.md
@@ -35,6 +35,7 @@ This document describes the implementation of HTTP-based communication for Agent
 2. **VS Code Extension**
    - Integrated HTTP client with VS Code extension API
    - Command processing through HTTP endpoints
+   - `POST /command` returns results immediately; the `"async"` option is deprecated
   - Progress tracking written to `progress_log.jsonl`; no `/status` endpoint
 
 ## Communication Flow
@@ -77,7 +78,7 @@ Returns the same help text as `python -m agent_s3.cli /help`.
 ```
 
 ### POST /command
-Processes Agent-S3 commands.
+Processes Agent-S3 commands. Results are returned immediately; the `"async"` option is deprecated.
 
 **Request:**
 ```json


### PR DESCRIPTION
## Summary
- document that POST /command returns immediate results only
- note that the `"async"` option is deprecated

## Testing
- `python scripts/maintenance.py lint` *(fails: ESLint and safety unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68441f5382a4832d95cfb40198e0bc66