### PR TITLE
Inject error handler into managers

### DIFF
--- a/agent_s3/coordinator/__init__.py
+++ b/agent_s3/coordinator/__init__.py
@@ -134,7 +134,8 @@ class Coordinator:
             base_dir=os.path.join(
                 os.path.dirname(self.config.get_log_file_path("development")),
                 "task_snapshots"
-            )
+            ),
+            error_handler=self.error_handler,
         )
         self.current_task_id = None
 
@@ -248,7 +249,10 @@ class Coordinator:
         self.feature_group_processor = FeatureGroupProcessor(coordinator=self)
 
         # Implementation manager handles step-by-step execution of design tasks
-        self.implementation_manager = ImplementationManager(coordinator=self)
+        self.implementation_manager = ImplementationManager(
+            coordinator=self,
+            error_handler=self.error_handler,
+        )
 
         # Design manager for interactive design conversations
         self.design_manager = DesignManager(coordinator=self)

--- a/tests/test_error_handler_injection.py
+++ b/tests/test_error_handler_injection.py
@@ -1,0 +1,31 @@
+from unittest.mock import MagicMock, patch
+
+from agent_s3.implementation_manager import ImplementationManager
+from agent_s3.task_state_manager import TaskStateManager, PlanningState
+
+
+def test_implementation_manager_uses_error_handler(tmp_path):
+    handler = MagicMock()
+    manager = ImplementationManager(coordinator=None, error_handler=handler)
+    manager.progress_file = str(tmp_path / "progress.json")
+
+    with patch("builtins.open", side_effect=IOError("boom")), patch(
+        "os.path.exists", return_value=True
+    ):
+        result = manager._load_progress_tracker()
+
+    assert result is None
+    handler.handle_exception.assert_called_once()
+
+
+def test_task_state_manager_uses_error_handler(tmp_path):
+    handler = MagicMock()
+    manager = TaskStateManager(base_dir=str(tmp_path), error_handler=handler)
+    state = PlanningState("t1", "req", {}, {})
+    state.phase = "planning"
+
+    with patch("builtins.open", side_effect=IOError("boom")):
+        success = manager.save_task_snapshot(state)
+
+    assert not success
+    handler.handle_exception.assert_called_once()


### PR DESCRIPTION
## Summary
- inject `ErrorHandler` into `TaskStateManager` and `ImplementationManager`
- use `ErrorHandler.handle_exception` for error logging
- pass coordinator error handler to submodules
- test that managers log errors through the handler

## Testing
- `ruff check agent_s3/ tests/test_error_handler_injection.py`
- `mypy agent_s3/`
- `pytest -q tests/test_error_handler_injection.py`

------
https://chatgpt.com/codex/tasks/task_e_684448d68be4832d8b239eda978046ac