### PR TITLE
Require Node.js 18 or newer

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -109,7 +109,7 @@ The Agent-S3 project is a multi-component system that includes:
 - Native fetch API for HTTP client
 
 #### Development Dependencies
-- `@types/node>=22.14.1` - Node.js type definitions
+ - `@types/node>=18.0.0` - Node.js type definitions
 - `@types/react>=18.0.28` - React type definitions
 - `@types/react-dom>=18.0.11` - React DOM type definitions
 - `@types/vscode>=1.99.1` - VSCode API type definitions
@@ -129,7 +129,7 @@ The Agent-S3 project is a multi-component system that includes:
 - `dompurify>=3.0.9` - DOM sanitization
 
 #### Development Dependencies
-- `@types/node>=16.18.11` - Node.js type definitions
+ - `@types/node>=18.0.0` - Node.js type definitions
 - `@types/react>=18.3.21` - React type definitions
 - `@types/react-dom>=18.3.7` - React DOM type definitions
 - `@types/dompurify>=3.0.2` - DOMPurify type definitions
@@ -214,7 +214,7 @@ Additional language support can be added by installing the corresponding tree-si
 ## Troubleshooting
 
 ### Common Issues
-1. **Node.js Version Compatibility**: Ensure Node.js version >= 16.x for React 18 support
+1. **Node.js Version Compatibility**: Ensure Node.js version >= 18.x for React 18 support
 2. **Python Version**: Requires Python >= 3.8 for modern typing features
 3. **Platform-specific Dependencies**: Some packages (like `psycopg2-binary`) may require platform-specific builds
 

--- a/DEPLOYMENT_MANUAL.md
+++ b/DEPLOYMENT_MANUAL.md
@@ -21,7 +21,7 @@ The Agent-S3 system consists of:
 
 ### Required Software
 - **Python 3.10+** (Required for agent_s3 package and Pydantic v2 compatibility)
-- **Node.js 16+** (Required for VS Code extension and webview UI)
+ - **Node.js 18+** (Required for VS Code extension and webview UI)
 - **npm or yarn** (Package management)
 - **Git** (Version control)
 - **Visual Studio Code** (For extension development/testing)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Agent-S3 is a multi-component system with dependencies across Python, Node.js, a
 
 **Prerequisites:**
 - Python 3.10+
-- Node.js 16+
+ - Node.js 18+
 - npm or yarn
 
 **Python Dependencies:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "typescript": "^4.9.5"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "typescript": "^4.9.5"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- document Node.js 18+ requirement
- update Node.js engine settings
- adjust @types/node references for Node 18

## Testing
- `npm test` *(fails: Class extends value undefined is not a constructor or null)*
- `npm run typecheck`
- `pytest -q` *(fails: 11 failed, 39 passed, 1 skipped, 10 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846ab7b250c832d80c529bedae0c082